### PR TITLE
feat: スキルパスマッチングで ** (globstar) をサポート

### DIFF
--- a/src/features/tools/skill.ts
+++ b/src/features/tools/skill.ts
@@ -195,7 +195,8 @@ validation 結果を返し、Settings の下書き一覧で内容を確認した
           paths: {
             type: "array",
             items: { type: "string" },
-            description: "マッチ対象のパスパターン（省略可）",
+            description:
+              "マッチ対象のパスパターン（省略可）。* は単一セグメント、** は複数セグメントにマッチ。例: /articles/* は /articles/slug にマッチ、/articles/** は /articles/slug/edit にもマッチ。ワイルドカードなしは前方一致。",
           },
           signals: {
             type: "array",
@@ -272,7 +273,8 @@ draftId で指定した承認待ちの下書きに対して、部分的な変更
               paths: {
                 type: "array",
                 items: { type: "string" },
-                description: "マッチ対象のパスパターン",
+                description:
+                  "マッチ対象のパスパターン。* は単一セグメント、** は複数セグメントにマッチ。",
               },
               signals: {
                 type: "array",

--- a/src/shared/__tests__/skill-registry-matchpath.test.ts
+++ b/src/shared/__tests__/skill-registry-matchpath.test.ts
@@ -83,6 +83,44 @@ describe("matchPath", () => {
     });
   });
 
+  describe("ダブルワイルドカード（**）", () => {
+    it("/articles/** は /articles/slug にマッチ", () => {
+      expect(matchPath("/articles/slug", "/articles/**")).toBe(true);
+    });
+
+    it("/articles/** は /articles/slug/edit にマッチ", () => {
+      expect(matchPath("/articles/slug/edit", "/articles/**")).toBe(true);
+    });
+
+    it("/articles/** は /articles/a/b/c にマッチ", () => {
+      expect(matchPath("/articles/a/b/c", "/articles/**")).toBe(true);
+    });
+
+    it("/articles/** は /books/slug にマッチしない", () => {
+      expect(matchPath("/books/slug", "/articles/**")).toBe(false);
+    });
+
+    it("/**/settings は /user/settings にマッチ", () => {
+      expect(matchPath("/user/settings", "/**/settings")).toBe(true);
+    });
+
+    it("/**/settings は /a/b/settings にマッチ", () => {
+      expect(matchPath("/a/b/settings", "/**/settings")).toBe(true);
+    });
+
+    it("/api/**/detail は /api/v1/users/detail にマッチ", () => {
+      expect(matchPath("/api/v1/users/detail", "/api/**/detail")).toBe(true);
+    });
+
+    it("** と * の混在: /a/*/b/** は /a/x/b/c/d にマッチ", () => {
+      expect(matchPath("/a/x/b/c/d", "/a/*/b/**")).toBe(true);
+    });
+
+    it("** と * の混在: /a/*/b/** は /a/x/y/b/c にマッチしない", () => {
+      expect(matchPath("/a/x/y/b/c", "/a/*/b/**")).toBe(false);
+    });
+  });
+
   describe("エッジケース", () => {
     it("空パターンはマッチしない", () => {
       expect(matchPath("/anything", "")).toBe(false);

--- a/src/shared/skill-registry.ts
+++ b/src/shared/skill-registry.ts
@@ -1,9 +1,9 @@
 import type { Skill, SkillMatch, DOMSnapshot, DOMIndicators } from "./skill-types";
 
 // パスパターンのワイルドカードマッチング。
-// * は / 以外の任意の文字列にマッチ（末尾・中間・拡張子いずれも対応）。
-// * を含まないパターンは startsWith によるプレフィックスマッチ。
-// ** はサポートしない（* と同じ扱い）。
+// *  は / 以外の任意の文字列にマッチ（単一セグメント）。
+// ** は / を含む任意の文字列にマッチ（複数セグメント）。
+// ワイルドカードを含まないパターンは startsWith によるプレフィックスマッチ。
 const regexCache = new Map<string, RegExp>();
 
 export function matchPath(pathname: string, pattern: string): boolean {
@@ -16,7 +16,12 @@ export function matchPath(pathname: string, pattern: string): boolean {
   let regex = regexCache.get(pattern);
   if (!regex) {
     const escaped = pattern.replace(/[.+?^${}()|\\[\]]/g, "\\$&");
-    const regexStr = escaped.replace(/\*/g, "[^/]*");
+    // ** → 任意パス（.*)、* → 単一セグメント（[^/]*）
+    // 先に ** を置換してから * を置換する
+    const regexStr = escaped
+      .replace(/\*\*/g, "<<GLOBSTAR>>")
+      .replace(/\*/g, "[^/]*")
+      .replace(/<<GLOBSTAR>>/g, ".*");
     regex = new RegExp(`^${regexStr}$`);
     regexCache.set(pattern, regex);
   }


### PR DESCRIPTION
## Summary
- `matchPath` で `**` を `.*`（複数セグメント）に変換するロジックを追加。`*` は従来通り単一セグメント `[^/]*`
- `create_skill_draft` / `update_skill_draft` ツールの `paths` description に `*` / `**` の仕様を明記
- `**` 用のテストケース9件を追加（全31→全40テスト通過）

## Test plan
- [x] 既存の `matchPath` テスト31件が全て通過
- [x] 新規 `**` テスト9件が通過（単体・混在・不一致）
- [x] `skill.test.ts` 108件通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)