### PR TITLE
fix: 要素ピッカーのハイライトがスクロール時にズレる問題を修正

### DIFF
--- a/src/adapters/chrome/chrome-browser-executor.ts
+++ b/src/adapters/chrome/chrome-browser-executor.ts
@@ -478,8 +478,8 @@ function injectPicker(message: string): Promise<{
         currentEl = el;
         const rect = el.getBoundingClientRect();
         highlight.style.display = "block";
-        highlight.style.top = `${rect.top + window.scrollY}px`;
-        highlight.style.left = `${rect.left + window.scrollX}px`;
+        highlight.style.top = `${rect.top}px`;
+        highlight.style.left = `${rect.left}px`;
         highlight.style.width = `${rect.width}px`;
         highlight.style.height = `${rect.height}px`;
       };


### PR DESCRIPTION
## Summary
- overlayが`position:fixed`なのに、ハイライト位置に`window.scrollY/scrollX`を加算していたためスクロール時にズレていた
- `getBoundingClientRect()`のviewport座標をそのまま使うように修正

## Test plan
- [x] スクロールしたページで要素ピッカーのハイライトが正しい位置に表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)