### PR TITLE
feat: 画像ライトボックス表示の追加

### DIFF
--- a/src/features/chat/ChatBubble.tsx
+++ b/src/features/chat/ChatBubble.tsx
@@ -3,7 +3,6 @@ import {
   Collapse,
   CopyButton,
   Group,
-  Image,
   Paper,
   Text,
   UnstyledButton,
@@ -16,6 +15,7 @@ import { useStore } from "@/store/index";
 import { messageStyles, type StyledRole } from "./theme";
 import { MarkdownContent } from "./MarkdownContent";
 import { ToolCallBlock } from "./ToolCallBlock";
+import { ImageLightbox } from "./tool-renderers/components";
 
 const roleConfig = {
   user: { icon: User, label: "You" },
@@ -100,13 +100,9 @@ export function ChatBubble({ msg, isLast }: { msg: ChatMessage; isLast?: boolean
         <MarkdownContent content={msg.content} />
 
         {msg.image && (
-          <Image
-            src={msg.image}
-            radius="sm"
-            mt={4}
-            maw={300}
-            style={{ border: "1px solid var(--mantine-color-default-border)" }}
-          />
+          <Paper mt={4} radius="sm" withBorder style={{ maxWidth: 300, overflow: "hidden" }}>
+            <ImageLightbox src={msg.image} alt="Screenshot" />
+          </Paper>
         )}
 
         {msg.toolCalls?.map((tc) => (

--- a/src/features/chat/ToolCallBlock.tsx
+++ b/src/features/chat/ToolCallBlock.tsx
@@ -1,10 +1,10 @@
 import { useState } from "react";
-import { Box, Collapse, Code, Image, Paper, Text, UnstyledButton } from "@mantine/core";
+import { Box, Collapse, Code, Paper, Text, UnstyledButton } from "@mantine/core";
 import { ChevronDown, ChevronUp, FileCode, Image as ImageIcon, Terminal } from "lucide-react";
 import type { ToolCallInfo } from "@/ports/session-types";
 import { defaultConsoleLogService } from "./services/console-log";
 import { defaultToolRendererRegistry } from "./tool-renderers";
-import { ToolMessageContainer } from "./tool-renderers/components";
+import { ImageLightbox, ToolMessageContainer } from "./tool-renderers/components";
 import type { ToolRendererContext } from "./tool-renderers/types";
 
 export function formatArgs(args: Record<string, unknown> | unknown): string | null {
@@ -151,7 +151,7 @@ function GenericToolResult({ toolCall }: { toolCall: ToolCallInfo }) {
   return (
     <Box mt={4} pt={4} style={{ borderTop: "1px solid var(--mantine-color-default-border)" }}>
       {imageUrl ? (
-        <Image src={imageUrl} radius="sm" maw="100%" alt="Screenshot" />
+        <ImageLightbox src={imageUrl} alt="Screenshot" />
       ) : canShowStructuredJson ? (
         <Paper withBorder p="sm" radius="md" style={{ maxWidth: "100%", overflowX: "auto" }}>
           <Text size="xs" fw={700} mb={6}>

--- a/src/features/chat/tool-renderers/components.tsx
+++ b/src/features/chat/tool-renderers/components.tsx
@@ -6,6 +6,7 @@ import {
   Group,
   Image,
   Loader,
+  Modal,
   Paper,
   Text,
   UnstyledButton,
@@ -22,6 +23,7 @@ import {
   FileCode,
   Image as ImageIcon,
   Terminal,
+  X,
   Zap,
   XCircle,
 } from "lucide-react";
@@ -261,6 +263,59 @@ function JsonValue({ value }: { value: unknown }) {
   );
 }
 
+export function ImageLightbox({ src, alt }: { src: string; alt?: string }) {
+  const [opened, setOpened] = useState(false);
+
+  return (
+    <>
+      <UnstyledButton onClick={() => setOpened(true)} style={{ cursor: "zoom-in", display: "block" }}>
+        <Image src={src} alt={alt ?? "Image"} style={{ maxWidth: "100%", height: "auto" }} />
+      </UnstyledButton>
+      {opened && (
+        <Modal
+          opened
+          onClose={() => setOpened(false)}
+          fullScreen
+          withCloseButton={false}
+          styles={{
+            body: {
+              padding: 0,
+              height: "100%",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              background: "rgba(0, 0, 0, 0.9)",
+            },
+            content: { background: "transparent", boxShadow: "none" },
+          }}
+        >
+          <ActionIcon
+            variant="filled"
+            color="dark"
+            size="lg"
+            radius="xl"
+            onClick={() => setOpened(false)}
+            aria-label="閉じる"
+            style={{ position: "fixed", top: 16, right: 16, zIndex: 1 }}
+          >
+            <X size={24} />
+          </ActionIcon>
+          <UnstyledButton
+            onClick={() => setOpened(false)}
+            style={{ cursor: "zoom-out", maxWidth: "95vw", maxHeight: "95vh" }}
+          >
+            <img
+              src={src}
+              alt={alt ?? "Image"}
+              style={{ maxWidth: "95vw", maxHeight: "95vh", objectFit: "contain" }}
+            />
+          </UnstyledButton>
+        </Modal>
+      )}
+    </>
+  );
+}
+
 function syncConsoleLogsFromOutput(
   consoleLogService: ToolRendererContext["consoleLogService"],
   toolCallId: string,
@@ -494,7 +549,7 @@ function ExtractImageRendererView({ toolCall }: ToolRendererContext) {
         mt="xs"
         style={{ overflow: "hidden", maxWidth: "100%", position: "relative" }}
       >
-        <Image src={imageUrl} alt="Extracted image" style={{ maxWidth: "100%", height: "auto" }} />
+        <ImageLightbox src={imageUrl} alt="Extracted image" />
 
         <ActionIcon
           variant="filled"
@@ -504,7 +559,8 @@ function ExtractImageRendererView({ toolCall }: ToolRendererContext) {
           title="画像をダウンロード"
           aria-label="画像をダウンロード"
           loading={isDownloading}
-          onClick={async () => {
+          onClick={async (e) => {
+            e.stopPropagation();
             const mediaTypeMatch = imageUrl.match(/^data:image\/([^;]+);/);
             const mediaType = mediaTypeMatch?.[1]?.toLowerCase();
             const extension = mediaType === "jpeg" ? "jpg" : mediaType || "png";


### PR DESCRIPTION
## Summary
- 画像クリックでフルスクリーンモーダル表示する `ImageLightbox` コンポーネントを追加
- `extract_image` ツール結果、`screenshot` 汎用ツール結果、チャット添付スクリーンショットの3箇所に適用
- ダウンロードボタンとのイベントバブリング防止（`stopPropagation`）

## Test plan
- [ ] `extract_image` ツール実行後、画像クリックでフルスクリーン表示されること
- [ ] `screenshot` ツール実行後、画像クリックでフルスクリーン表示されること
- [ ] チャットに添付されたスクリーンショットクリックでフルスクリーン表示されること
- [ ] モーダル内の画像クリック・Xボタン・Escキーで閉じること
- [ ] `extract_image` のダウンロードボタンがモーダルを開かずにダウンロードすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)