### PR TITLE
feat: bg_fetch ツール追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@mantine/hooks": "^9.0.0",
     "@mantine/modals": "^9.0.0",
     "@mantine/notifications": "^9.0.0",
+    "@mozilla/readability": "^0.6.0",
     "ai": "^6.0.143",
     "ai-sdk-ollama": "^3.8.2",
     "decode-named-character-reference": "^1.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@mantine/notifications':
         specifier: ^9.0.0
         version: 9.0.0(@mantine/core@9.0.0(@mantine/hooks@9.0.0(react@19.2.4))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@mantine/hooks@9.0.0(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@mozilla/readability':
+        specifier: ^0.6.0
+        version: 0.6.0
       ai:
         specifier: ^6.0.143
         version: 6.0.145(zod@4.3.6)
@@ -323,6 +326,10 @@ packages:
     peerDependenciesMeta:
       '@cfworker/json-schema':
         optional: true
+
+  '@mozilla/readability@0.6.0':
+    resolution: {integrity: sha512-juG5VWh4qAivzTAeMzvY9xs9HY5rAcr2E4I7tiSSCokRFi7XIZCAu92ZkSTsIj1OPceCifL3cpfteP3pDT9/QQ==}
+    engines: {node: '>=14.0.0'}
 
   '@napi-rs/wasm-runtime@1.1.3':
     resolution: {integrity: sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==}
@@ -2523,6 +2530,8 @@ snapshots:
       zod-to-json-schema: 3.25.2(zod@4.3.6)
     transitivePeerDependencies:
       - supports-color
+
+  '@mozilla/readability@0.6.0': {}
 
   '@napi-rs/wasm-runtime@1.1.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
     dependencies:

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -28,7 +28,8 @@
     "alarms",
     "notifications",
     "debugger",
-    "downloads"
+    "downloads",
+    "offscreen"
   ],
   "host_permissions": ["<all_urls>"],
   "commands": {

--- a/public/offscreen.html
+++ b/public/offscreen.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<html>
+  <head><meta charset="utf-8" /></head>
+  <body><script src="offscreen.js"></script></body>
+</html>

--- a/src/background/handlers/bg-fetch.ts
+++ b/src/background/handlers/bg-fetch.ts
@@ -1,0 +1,346 @@
+import type {
+  BgFetchMessage,
+  BgFetchResponse,
+  ReadabilityMessage,
+  ReadabilityResponse,
+} from "@/shared/message-types";
+
+// --- Constants ---
+
+const MAX_URL_LENGTH = 2000;
+const MAX_RESPONSE_SIZE = 5 * 1024 * 1024; // 5MB
+const MAX_REDIRECTS = 10;
+const CACHE_TTL = 5 * 60 * 1000; // 5 minutes
+const MAX_CACHE_ENTRIES = 100;
+
+const BLOCKED_PROTOCOLS = ["chrome:", "chrome-extension:", "file:", "data:", "javascript:"];
+const BLOCKED_HOSTS = ["localhost", "127.0.0.1", "::1", "0.0.0.0", "[::1]"];
+
+// --- Semaphore ---
+
+class Semaphore {
+  private queue: Array<() => void> = [];
+  private active = 0;
+
+  constructor(private readonly max: number) {}
+
+  acquire(): Promise<void> {
+    if (this.active < this.max) {
+      this.active++;
+      return Promise.resolve();
+    }
+    return new Promise((resolve) => this.queue.push(resolve));
+  }
+
+  release(): void {
+    this.active--;
+    const next = this.queue.shift();
+    if (next) {
+      this.active++;
+      next();
+    }
+  }
+}
+
+const fetchSemaphore = new Semaphore(10);
+
+// --- Cache ---
+
+const cache = new Map<string, { data: BgFetchResponse["data"]; expires: number }>();
+
+function getFromCache(url: string): BgFetchResponse["data"] | null {
+  const entry = cache.get(url);
+  if (!entry) return null;
+  if (Date.now() > entry.expires) {
+    cache.delete(url);
+    return null;
+  }
+  return entry.data;
+}
+
+function setCache(url: string, data: BgFetchResponse["data"]): void {
+  if (cache.size >= MAX_CACHE_ENTRIES) {
+    const now = Date.now();
+    for (const [k, v] of cache) {
+      if (now > v.expires) cache.delete(k);
+    }
+  }
+  cache.set(url, { data, expires: Date.now() + CACHE_TTL });
+}
+
+// --- URL Validation ---
+
+function validateUrl(url: string): { valid: boolean; error?: string } {
+  if (url.length > MAX_URL_LENGTH) {
+    return { valid: false, error: `URL exceeds maximum length of ${MAX_URL_LENGTH}` };
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return { valid: false, error: "Invalid URL" };
+  }
+
+  for (const proto of BLOCKED_PROTOCOLS) {
+    if (parsed.protocol === proto || parsed.protocol === `${proto}//`) {
+      return { valid: false, error: `Blocked protocol: ${parsed.protocol}` };
+    }
+  }
+
+  if (BLOCKED_HOSTS.includes(parsed.hostname)) {
+    return { valid: false, error: `Blocked host: ${parsed.hostname}` };
+  }
+
+  if (parsed.username || parsed.password) {
+    return { valid: false, error: "URLs with credentials are not allowed" };
+  }
+
+  return { valid: true };
+}
+
+function upgradeToHttps(url: string): string {
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol === "http:") {
+      parsed.protocol = "https:";
+      return parsed.toString();
+    }
+  } catch {
+    // return as-is
+  }
+  return url;
+}
+
+// --- Redirect ---
+
+function isPermittedRedirect(originalUrl: string, redirectUrl: string): boolean {
+  try {
+    const original = new URL(originalUrl);
+    const redirect = new URL(redirectUrl);
+
+    if (redirect.protocol !== original.protocol) return false;
+    if (redirect.port !== original.port) return false;
+    if (redirect.username || redirect.password) return false;
+
+    const stripWww = (h: string) => h.replace(/^www\./, "");
+    return stripWww(original.hostname) === stripWww(redirect.hostname);
+  } catch {
+    return false;
+  }
+}
+
+interface RedirectInfo {
+  redirected: true;
+  redirectUrl: string;
+  status: number;
+}
+
+async function fetchWithRedirects(
+  url: string,
+  init: RequestInit,
+  timeout: number,
+  depth = 0,
+): Promise<Response | RedirectInfo> {
+  if (depth > MAX_REDIRECTS) {
+    throw new Error(`Too many redirects (exceeded ${MAX_REDIRECTS})`);
+  }
+
+  const response = await fetch(url, {
+    ...init,
+    redirect: "manual",
+    signal: AbortSignal.timeout(timeout),
+  });
+
+  if ([301, 302, 307, 308].includes(response.status)) {
+    const location = response.headers.get("location");
+    if (!location) throw new Error("Redirect missing Location header");
+
+    const redirectUrl = new URL(location, url).toString();
+
+    if (isPermittedRedirect(url, redirectUrl)) {
+      return fetchWithRedirects(redirectUrl, init, timeout, depth + 1);
+    }
+
+    return { redirected: true, redirectUrl, status: response.status };
+  }
+
+  return response;
+}
+
+// --- Readability via offscreen ---
+
+async function extractWithReadability(
+  html: string,
+  url: string,
+): Promise<{ title: string; content: string; links: Array<{ text: string; href: string }> }> {
+  const hasDoc = await chrome.offscreen.hasDocument();
+  if (!hasDoc) {
+    await chrome.offscreen.createDocument({
+      url: "offscreen.html",
+      reasons: [chrome.offscreen.Reason.DOM_PARSER],
+      justification: "Parse HTML and extract main content with Readability",
+    });
+  }
+
+  const result = await chrome.runtime.sendMessage<ReadabilityMessage, ReadabilityResponse>({
+    type: "BG_READABILITY",
+    html,
+    url,
+  });
+
+  if (!result?.success) {
+    throw new Error(result?.error ?? "Readability extraction failed");
+  }
+
+  return {
+    title: result.title ?? "",
+    content: result.content ?? "",
+    links: result.links ?? [],
+  };
+}
+
+// --- Response conversion ---
+
+function extractHeaders(response: Response): Record<string, string> {
+  const headers: Record<string, string> = {};
+  response.headers.forEach((value, key) => {
+    headers[key] = value;
+  });
+  return headers;
+}
+
+async function convertResponse(
+  response: Response,
+  responseType: BgFetchMessage["responseType"],
+  url: string,
+): Promise<BgFetchResponse["data"]> {
+  const base = {
+    url,
+    ok: response.ok,
+    status: response.status,
+    statusText: response.statusText,
+    headers: extractHeaders(response),
+  };
+
+  // Check size via Content-Length hint
+  const contentLength = response.headers.get("content-length");
+  if (contentLength && parseInt(contentLength, 10) > MAX_RESPONSE_SIZE) {
+    throw new Error(`Response too large: ${contentLength} bytes (max ${MAX_RESPONSE_SIZE})`);
+  }
+
+  const buffer = await response.arrayBuffer();
+  if (buffer.byteLength > MAX_RESPONSE_SIZE) {
+    throw new Error(`Response too large: ${buffer.byteLength} bytes (max ${MAX_RESPONSE_SIZE})`);
+  }
+
+  switch (responseType) {
+    case "json": {
+      const text = new TextDecoder().decode(buffer);
+      try {
+        return { ...base, body: JSON.parse(text) };
+      } catch {
+        throw new Error("Invalid JSON response");
+      }
+    }
+
+    case "base64": {
+      const bytes = new Uint8Array(buffer);
+      let binary = "";
+      const chunk = 0x8000;
+      for (let i = 0; i < bytes.length; i += chunk) {
+        binary += String.fromCharCode(...bytes.subarray(i, i + chunk));
+      }
+      return { ...base, body: btoa(binary) };
+    }
+
+    case "readability": {
+      const html = new TextDecoder().decode(buffer);
+      const extracted = await extractWithReadability(html, url);
+      return { ...base, body: extracted };
+    }
+
+    case "text":
+    default: {
+      return { ...base, body: new TextDecoder().decode(buffer) };
+    }
+  }
+}
+
+// --- Main handler ---
+
+async function handleBgFetch(msg: BgFetchMessage): Promise<BgFetchResponse> {
+  const validation = validateUrl(msg.url);
+  if (!validation.valid) {
+    return { success: false, error: validation.error };
+  }
+
+  const url = upgradeToHttps(msg.url);
+
+  // Cache check (GET only)
+  if (msg.method === "GET") {
+    const cached = getFromCache(url);
+    if (cached) return { success: true, data: cached };
+  }
+
+  await fetchSemaphore.acquire();
+  try {
+    const init: RequestInit = {
+      method: msg.method,
+      headers: msg.headers,
+      body: msg.body,
+    };
+
+    const result = await fetchWithRedirects(url, init, msg.timeout);
+
+    // Cross-host redirect
+    if ("redirected" in result && !(result instanceof Response)) {
+      return {
+        success: true,
+        data: {
+          url,
+          ok: false,
+          status: result.status,
+          statusText: "Redirect",
+          headers: {},
+          body: "",
+          redirected: true,
+          redirectUrl: result.redirectUrl,
+        },
+      };
+    }
+
+    const data = await convertResponse(result as Response, msg.responseType, url);
+
+    // Cache GET responses
+    if (msg.method === "GET") {
+      setCache(url, data);
+    }
+
+    return { success: true, data };
+  } catch (e: unknown) {
+    const message = e instanceof Error ? e.message : String(e);
+    return { success: false, error: message };
+  } finally {
+    fetchSemaphore.release();
+  }
+}
+
+// --- Message handler registration ---
+
+chrome.runtime.onMessage.addListener(
+  (msg: BgFetchMessage, _sender, sendResponse: (response: BgFetchResponse) => void) => {
+    if (msg.type === "BG_FETCH") {
+      handleBgFetch(msg)
+        .then(sendResponse)
+        .catch((err) =>
+          sendResponse({
+            success: false,
+            error: err instanceof Error ? err.message : String(err),
+          }),
+        );
+      return true; // async
+    }
+    return false;
+  },
+);

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -5,6 +5,7 @@ import { acquireLock, releaseLocksForWindow } from "./handlers/session-lock";
 import { addOpenPanel, removeOpenPanel } from "./handlers/panel-tracker";
 import { initWire, sendPing } from "./handlers/wire";
 import "./handlers/native-input";
+import "./handlers/bg-fetch";
 
 const log = createLogger("background");
 const browserExecutor = new ChromeBrowserExecutor();

--- a/src/features/tools/bg-fetch.ts
+++ b/src/features/tools/bg-fetch.ts
@@ -1,0 +1,140 @@
+import type { ToolDefinition } from "@/ports/ai-provider";
+import type { Result, ToolError } from "@/shared/errors";
+import { ok, err } from "@/shared/errors";
+import type { BgFetchMessage, BgFetchResponse } from "@/shared/message-types";
+
+const MAX_URLS = 20;
+const MAX_BODY_CHARS = 50_000;
+
+export const bgFetchToolDef: ToolDefinition = {
+  name: "bg_fetch",
+  description:
+    "外部URLのコンテンツを取得する。CORSを回避してあらゆるURLにアクセス可能。" +
+    "複数URLを並列取得できる。Webページはresponse_type='readability'で本文のみ抽出すると効率的。" +
+    "readabilityモードでは本文テキストに加え、ページ内リンク一覧も返すのでドキュメント探索に活用できる。",
+  parameters: {
+    type: "object",
+    properties: {
+      urls: {
+        type: "array",
+        items: { type: "string" },
+        description: "取得するURLのリスト",
+      },
+      method: {
+        type: "string",
+        description: "HTTPメソッド（default: GET）",
+      },
+      headers: {
+        type: "object",
+        description: "リクエストヘッダー",
+      },
+      body: {
+        type: "string",
+        description: "リクエストボディ",
+      },
+      response_type: {
+        type: "string",
+        enum: ["text", "json", "base64", "readability"],
+        description:
+          "レスポンス形式。text=生テキスト, json=JSONパース, base64=バイナリ, " +
+          "readability=HTMLから本文+リンク一覧を抽出（Webページに推奨）",
+      },
+      timeout: {
+        type: "number",
+        description: "タイムアウトms（default: 30000, max: 60000）",
+      },
+    },
+    required: ["urls"],
+  },
+};
+
+interface BgFetchArgs {
+  urls: string[];
+  method?: string;
+  headers?: Record<string, string>;
+  body?: string;
+  response_type?: "text" | "json" | "base64" | "readability";
+  timeout?: number;
+}
+
+interface BgFetchResultItem {
+  url: string;
+  ok: boolean;
+  status: number;
+  statusText: string;
+  headers: Record<string, string>;
+  body: string | object;
+  redirected?: boolean;
+  redirectUrl?: string;
+  error?: string;
+}
+
+export async function executeBgFetch(
+  args: Record<string, unknown>,
+): Promise<Result<BgFetchResultItem | BgFetchResultItem[], ToolError>> {
+  const { urls, method, headers, body, response_type, timeout } = args as unknown as BgFetchArgs;
+
+  if (!urls || !Array.isArray(urls) || urls.length === 0) {
+    return err({ code: "tool_script_error", message: "urls must be a non-empty array" });
+  }
+  if (urls.length > MAX_URLS) {
+    return err({ code: "tool_script_error", message: `Maximum ${MAX_URLS} URLs per request` });
+  }
+
+  const fetchOne = async (url: string): Promise<BgFetchResultItem> => {
+    try {
+      const message: BgFetchMessage = {
+        type: "BG_FETCH",
+        url,
+        method: method ?? "GET",
+        headers,
+        body,
+        responseType: response_type ?? "text",
+        timeout: Math.min(timeout ?? 30000, 60000),
+      };
+
+      const result = await chrome.runtime.sendMessage<BgFetchMessage, BgFetchResponse>(message);
+
+      if (!result?.success || !result.data) {
+        return {
+          url,
+          ok: false,
+          status: 0,
+          statusText: "",
+          headers: {},
+          body: "",
+          error: result?.error ?? "bgFetch failed",
+        };
+      }
+
+      const data = result.data;
+      if (typeof data.body === "string" && data.body.length > MAX_BODY_CHARS) {
+        data.body = data.body.substring(0, MAX_BODY_CHARS) + "\n... (truncated)";
+      }
+
+      return { ...data, url };
+    } catch (e: unknown) {
+      return {
+        url,
+        ok: false,
+        status: 0,
+        statusText: "",
+        headers: {},
+        body: "",
+        error: e instanceof Error ? e.message : String(e),
+      };
+    }
+  };
+
+  const results = await Promise.all(urls.map(fetchOne));
+
+  if (results.length === 1) {
+    const item = results[0]!;
+    if (!item.ok && item.error) {
+      return err({ code: "tool_script_error", message: `${item.url}: ${item.error}` });
+    }
+    return ok(item);
+  }
+
+  return ok(results);
+}

--- a/src/features/tools/index.ts
+++ b/src/features/tools/index.ts
@@ -37,6 +37,7 @@ import {
   type DeleteSkillDraftArgs,
   type DeleteSkillDraftResult,
 } from "./skill";
+import { bgFetchToolDef, executeBgFetch } from "./bg-fetch";
 import { artifactsTool } from "./definitions/artifacts-tool";
 import { handleArtifactsTool } from "./handlers/artifacts-handler";
 
@@ -58,6 +59,7 @@ export {
   executeUpdateSkillDraft,
   executeDeleteSkillDraft,
 };
+export { bgFetchToolDef, executeBgFetch };
 export { artifactsTool, handleArtifactsTool };
 export type {
   SkillAction,
@@ -102,6 +104,7 @@ export const ALL_TOOL_DEFS: ToolDefinition[] = [
   updateSkillDraftToolDef,
   deleteSkillDraftToolDef,
   artifactsTool,
+  bgFetchToolDef,
 ];
 
 export const AGENT_TOOL_DEFS: ToolDefinition[] = ALL_TOOL_DEFS.filter(
@@ -160,6 +163,8 @@ export function createToolExecutorWithSkills(
           selector: args.selector,
           maxWidth: typeof args.maxWidth === "number" ? args.maxWidth : undefined,
         });
+      case "bg_fetch":
+        return executeBgFetch(args);
       case "skill": {
         const tab = await browser.getActiveTab();
         return executeSkill(storage, skillRegistry, tab.url, args as SkillAction);

--- a/src/offscreen/index.ts
+++ b/src/offscreen/index.ts
@@ -1,0 +1,71 @@
+import { Readability } from "@mozilla/readability";
+import type { ReadabilityMessage, ReadabilityResponse } from "@/shared/message-types";
+
+chrome.runtime.onMessage.addListener(
+  (msg: ReadabilityMessage, _sender, sendResponse: (r: ReadabilityResponse) => void) => {
+    if (msg.type !== "BG_READABILITY") return false;
+
+    try {
+      const doc = new DOMParser().parseFromString(msg.html, "text/html");
+
+      // Set base URL for relative path resolution
+      const base = doc.createElement("base");
+      base.href = msg.url;
+      doc.head.prepend(base);
+
+      // Extract links before Readability modifies the DOM
+      const contentRoot = doc.querySelector("main, article, [role='main']") ?? doc.body;
+      const links = extractLinks(contentRoot, msg.url);
+
+      const reader = new Readability(doc.cloneNode(true) as Document);
+      const article = reader.parse();
+
+      const title = article?.title || doc.title || "";
+      const content =
+        article && article.textContent && article.textContent.length > 100
+          ? article.textContent.trim()
+          : extractFallback(doc);
+
+      sendResponse({ success: true, title, content, links });
+    } catch (e) {
+      sendResponse({
+        success: false,
+        error: e instanceof Error ? e.message : String(e),
+      });
+    }
+
+    return true;
+  },
+);
+
+function extractLinks(root: Element, baseUrl: string): Array<{ text: string; href: string }> {
+  const seen = new Set<string>();
+  const links: Array<{ text: string; href: string }> = [];
+
+  for (const a of root.querySelectorAll("a[href]")) {
+    const text = a.textContent?.trim() ?? "";
+    if (!text) continue;
+
+    try {
+      const href = new URL(a.getAttribute("href")!, baseUrl).href;
+      if (seen.has(href) || !href.startsWith("http")) continue;
+      seen.add(href);
+      links.push({ text, href });
+    } catch {
+      // Invalid URL — skip
+    }
+  }
+
+  return links;
+}
+
+function extractFallback(doc: Document): string {
+  const selectors = ["main", "article", '[role="main"]', ".main-content", ".content"];
+  for (const sel of selectors) {
+    const el = doc.querySelector(sel);
+    if (el && el.textContent && el.textContent.trim().length > 200) {
+      return el.textContent.trim();
+    }
+  }
+  return doc.body?.textContent?.trim() ?? "";
+}

--- a/src/shared/message-types.ts
+++ b/src/shared/message-types.ts
@@ -38,3 +38,46 @@ export interface NativeInputResponse {
   success: boolean;
   error?: string;
 }
+
+// --- bg_fetch ---
+
+export interface BgFetchMessage {
+  type: "BG_FETCH";
+  url: string;
+  method: string;
+  headers?: Record<string, string>;
+  body?: string;
+  responseType: "text" | "json" | "base64" | "readability";
+  timeout: number;
+}
+
+export interface BgFetchResponse {
+  success: boolean;
+  data?: {
+    url: string;
+    ok: boolean;
+    status: number;
+    statusText: string;
+    headers: Record<string, string>;
+    body: string | object;
+    redirected?: boolean;
+    redirectUrl?: string;
+  };
+  error?: string;
+}
+
+// --- Readability (background → offscreen) ---
+
+export interface ReadabilityMessage {
+  type: "BG_READABILITY";
+  html: string;
+  url: string;
+}
+
+export interface ReadabilityResponse {
+  success: boolean;
+  title?: string;
+  content?: string;
+  links?: Array<{ text: string; href: string }>;
+  error?: string;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,6 +21,9 @@ function chromeExtensionPlugin() {
         copyFileSync(`public/icons/${f}`, `${dist}/icons/${f}`);
       }
 
+      // offscreen.html をコピー
+      copyFileSync("public/offscreen.html", `${dist}/offscreen.html`);
+
       // 2. sidepanel HTML を正しい位置に移動
       const srcHtml = `${dist}/src/sidepanel/index.html`;
       if (existsSync(srcHtml)) {
@@ -58,6 +61,11 @@ export function getManualChunk(id: string): string | undefined {
   const normalizedId = normalizePath(id);
 
   if (normalizedId.includes("/node_modules/")) return "vendor";
+
+  // Offscreen document — isolated like background
+  if (normalizedId.includes("/src/offscreen/")) {
+    return "offscreen";
+  }
 
   // Background service-worker modules — isolated so they never pull in the
   // heavy sidepanel/artifacts dependency tree.
@@ -134,6 +142,7 @@ export default defineConfig({
         sidepanel: resolve(__dirname, "src/sidepanel/index.html"),
         "artifact-popup": resolve(__dirname, "src/artifact-popup/index.html"),
         background: resolve(__dirname, "src/background/index.ts"),
+        offscreen: resolve(__dirname, "src/offscreen/index.ts"),
       },
       output: {
         entryFileNames: "[name].js",


### PR DESCRIPTION
## Summary
- 独立AI toolとして `bg_fetch` を実装（#7）
- 複数URLの並列取得（`urls: string[]`、セマフォ最大10並列）
- `response_type: "readability"` でHTMLから本文+リンク一覧を抽出（offscreen document + @mozilla/readability）
- セキュリティ: URLバリデーション、http→https昇格、リダイレクト制御、5MBサイズ制限、30秒タイムアウト
- GETリクエストのキャッシュ（5分TTL、最大100エントリ）

## New files
- `src/background/handlers/bg-fetch.ts` — Background fetchハンドラー
- `src/features/tools/bg-fetch.ts` — Tool定義 + 実行関数
- `src/offscreen/index.ts` — Readability本文抽出 + リンク抽出
- `public/offscreen.html` — Offscreen document

## Changed files
- `src/shared/message-types.ts` — BgFetch/Readability メッセージ型
- `src/features/tools/index.ts` — tool登録
- `src/background/index.ts` — ハンドラーimport
- `public/manifest.json` — `offscreen` permission
- `vite.config.ts` — offscreenエントリポイント + ビルド設定

## Test plan
- [ ] `bg_fetch({ urls: ["https://httpbin.org/get"] })` でテキスト取得
- [ ] `response_type: "json"` でJSONパース
- [ ] `response_type: "readability"` で本文+リンク抽出
- [ ] 複数URL並列取得
- [ ] ブロック対象URL (`chrome://`, `localhost` 等) がエラー
- [ ] ビルドが通ること ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)