### PR TITLE
fix: bg_fetch セキュリティ・安定性修正

### DIFF
--- a/src/background/handlers/bg-fetch.ts
+++ b/src/background/handlers/bg-fetch.ts
@@ -12,9 +12,21 @@ const MAX_RESPONSE_SIZE = 5 * 1024 * 1024; // 5MB
 const MAX_REDIRECTS = 10;
 const CACHE_TTL = 5 * 60 * 1000; // 5 minutes
 const MAX_CACHE_ENTRIES = 100;
-
 const BLOCKED_PROTOCOLS = ["chrome:", "chrome-extension:", "file:", "data:", "javascript:"];
-const BLOCKED_HOSTS = ["localhost", "127.0.0.1", "::1", "0.0.0.0", "[::1]"];
+const BLOCKED_HOSTS = new Set([
+  "localhost",
+  "0.0.0.0",
+  "[::1]",
+  "metadata.google.internal",
+]);
+const ALLOWED_METHODS = new Set(["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"]);
+const BLOCKED_HEADERS = new Set([
+  "host",
+  "origin",
+  "cookie",
+  "set-cookie",
+  "proxy-authorization",
+]);
 
 // --- Semaphore ---
 
@@ -46,29 +58,87 @@ const fetchSemaphore = new Semaphore(10);
 
 // --- Cache ---
 
-const cache = new Map<string, { data: BgFetchResponse["data"]; expires: number }>();
+interface CacheEntry {
+  data: BgFetchResponse["data"];
+  expires: number;
+  insertedAt: number;
+}
 
-function getFromCache(url: string): BgFetchResponse["data"] | null {
-  const entry = cache.get(url);
+const cache = new Map<string, CacheEntry>();
+
+function buildCacheKey(url: string, responseType: string): string {
+  return `${responseType}:${url}`;
+}
+
+function getFromCache(key: string): BgFetchResponse["data"] | null {
+  const entry = cache.get(key);
   if (!entry) return null;
   if (Date.now() > entry.expires) {
-    cache.delete(url);
+    cache.delete(key);
     return null;
   }
   return entry.data;
 }
 
-function setCache(url: string, data: BgFetchResponse["data"]): void {
-  if (cache.size >= MAX_CACHE_ENTRIES) {
-    const now = Date.now();
-    for (const [k, v] of cache) {
-      if (now > v.expires) cache.delete(k);
-    }
+function setCache(key: string, data: BgFetchResponse["data"]): void {
+  // Purge expired entries
+  const now = Date.now();
+  for (const [k, v] of cache) {
+    if (now > v.expires) cache.delete(k);
   }
-  cache.set(url, { data, expires: Date.now() + CACHE_TTL });
+
+  // Evict oldest if still at capacity
+  if (cache.size >= MAX_CACHE_ENTRIES) {
+    let oldestKey: string | null = null;
+    let oldestTime = Infinity;
+    for (const [k, v] of cache) {
+      if (v.insertedAt < oldestTime) {
+        oldestTime = v.insertedAt;
+        oldestKey = k;
+      }
+    }
+    if (oldestKey) cache.delete(oldestKey);
+  }
+
+  cache.set(key, { data, expires: now + CACHE_TTL, insertedAt: now });
 }
 
 // --- URL Validation ---
+
+function isPrivateIp(hostname: string): boolean {
+  // IPv6 loopback
+  if (hostname === "::1" || hostname === "[::1]") return true;
+
+  // Strip IPv6 brackets
+  const h = hostname.replace(/^\[|\]$/g, "");
+
+  // IPv4-mapped IPv6 (::ffff:x.x.x.x)
+  const v4Mapped = /^::ffff:(\d+\.\d+\.\d+\.\d+)$/i.exec(h);
+  const ipStr = v4Mapped ? v4Mapped[1]! : h;
+
+  // Parse IPv4 octets
+  const parts = ipStr.split(".");
+  if (parts.length !== 4) return false;
+  const octets = parts.map(Number);
+  if (octets.some((o) => isNaN(o) || o < 0 || o > 255)) return false;
+
+  const [a, b] = octets as [number, number, number, number];
+
+  // Loopback: 127.0.0.0/8
+  if (a === 127) return true;
+  // 0.0.0.0/8
+  if (a === 0) return true;
+  // Private: 10.0.0.0/8
+  if (a === 10) return true;
+  // Private: 172.16.0.0/12
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  // Private: 192.168.0.0/16
+  if (a === 192 && b === 168) return true;
+  // Link-local: 169.254.0.0/16 (includes AWS/GCP metadata 169.254.169.254)
+  if (a === 169 && b === 254) return true;
+
+  return false;
+}
 
 function validateUrl(url: string): { valid: boolean; error?: string } {
   if (url.length > MAX_URL_LENGTH) {
@@ -82,16 +152,27 @@ function validateUrl(url: string): { valid: boolean; error?: string } {
     return { valid: false, error: "Invalid URL" };
   }
 
-  for (const proto of BLOCKED_PROTOCOLS) {
-    if (parsed.protocol === proto || parsed.protocol === `${proto}//`) {
-      return { valid: false, error: `Blocked protocol: ${parsed.protocol}` };
-    }
+  // Protocol check
+  if (BLOCKED_PROTOCOLS.includes(parsed.protocol)) {
+    return { valid: false, error: `Blocked protocol: ${parsed.protocol}` };
   }
 
-  if (BLOCKED_HOSTS.includes(parsed.hostname)) {
+  // Only allow http/https
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return { valid: false, error: `Unsupported protocol: ${parsed.protocol}` };
+  }
+
+  // Host check
+  if (BLOCKED_HOSTS.has(parsed.hostname)) {
     return { valid: false, error: `Blocked host: ${parsed.hostname}` };
   }
 
+  // Private/internal IP check
+  if (isPrivateIp(parsed.hostname)) {
+    return { valid: false, error: `Blocked: private/internal IP address` };
+  }
+
+  // Credentials check
   if (parsed.username || parsed.password) {
     return { valid: false, error: "URLs with credentials are not allowed" };
   }
@@ -112,6 +193,30 @@ function upgradeToHttps(url: string): string {
   return url;
 }
 
+// --- Input Validation ---
+
+function sanitizeMethod(method: string): string {
+  const upper = method.toUpperCase();
+  if (!ALLOWED_METHODS.has(upper)) {
+    throw new Error(`Blocked HTTP method: ${method}`);
+  }
+  return upper;
+}
+
+function sanitizeHeaders(
+  headers: Record<string, string> | undefined,
+): Record<string, string> | undefined {
+  if (!headers) return undefined;
+
+  const sanitized: Record<string, string> = {};
+  for (const [key, value] of Object.entries(headers)) {
+    if (typeof key !== "string" || typeof value !== "string") continue;
+    if (BLOCKED_HEADERS.has(key.toLowerCase())) continue;
+    sanitized[key] = value;
+  }
+  return sanitized;
+}
+
 // --- Redirect ---
 
 function isPermittedRedirect(originalUrl: string, redirectUrl: string): boolean {
@@ -119,9 +224,18 @@ function isPermittedRedirect(originalUrl: string, redirectUrl: string): boolean 
     const original = new URL(originalUrl);
     const redirect = new URL(redirectUrl);
 
-    if (redirect.protocol !== original.protocol) return false;
-    if (redirect.port !== original.port) return false;
+    // Allow same protocol or http→https upgrade
+    if (redirect.protocol !== original.protocol) {
+      if (!(original.protocol === "http:" && redirect.protocol === "https:")) {
+        return false;
+      }
+    }
+
     if (redirect.username || redirect.password) return false;
+
+    // Compare effective ports (handle default port omission)
+    const effectivePort = (u: URL) => u.port || (u.protocol === "https:" ? "443" : "80");
+    if (effectivePort(original) !== effectivePort(redirect)) return false;
 
     const stripWww = (h: string) => h.replace(/^www\./, "");
     return stripWww(original.hostname) === stripWww(redirect.hostname);
@@ -158,6 +272,12 @@ async function fetchWithRedirects(
 
     const redirectUrl = new URL(location, url).toString();
 
+    // Validate redirect target against security rules
+    const validation = validateUrl(redirectUrl);
+    if (!validation.valid) {
+      throw new Error(`Redirect blocked: ${validation.error} (${redirectUrl})`);
+    }
+
     if (isPermittedRedirect(url, redirectUrl)) {
       return fetchWithRedirects(redirectUrl, init, timeout, depth + 1);
     }
@@ -170,34 +290,67 @@ async function fetchWithRedirects(
 
 // --- Readability via offscreen ---
 
+// Singleton promise to prevent concurrent createDocument calls
+let offscreenPromise: Promise<void> | null = null;
+
+async function ensureOffscreenDocument(): Promise<void> {
+  if (offscreenPromise) return offscreenPromise;
+
+  offscreenPromise = (async () => {
+    try {
+      const hasDoc = await chrome.offscreen.hasDocument();
+      if (!hasDoc) {
+        await chrome.offscreen.createDocument({
+          url: "offscreen.html",
+          reasons: [chrome.offscreen.Reason.DOM_PARSER],
+          justification: "Parse HTML and extract main content with Readability",
+        });
+      }
+    } catch {
+      offscreenPromise = null;
+      throw new Error("Failed to create offscreen document");
+    }
+  })();
+
+  return offscreenPromise;
+}
+
+async function closeOffscreenDocument(): Promise<void> {
+  offscreenPromise = null;
+  try {
+    await chrome.offscreen.closeDocument();
+  } catch {
+    // Already closed or never created
+  }
+}
+
 async function extractWithReadability(
   html: string,
   url: string,
 ): Promise<{ title: string; content: string; links: Array<{ text: string; href: string }> }> {
-  const hasDoc = await chrome.offscreen.hasDocument();
-  if (!hasDoc) {
-    await chrome.offscreen.createDocument({
-      url: "offscreen.html",
-      reasons: [chrome.offscreen.Reason.DOM_PARSER],
-      justification: "Parse HTML and extract main content with Readability",
+  await ensureOffscreenDocument();
+
+  try {
+    const result = await chrome.runtime.sendMessage<ReadabilityMessage, ReadabilityResponse>({
+      type: "BG_READABILITY",
+      html,
+      url,
     });
+
+    if (!result?.success) {
+      throw new Error(result?.error ?? "Readability extraction failed");
+    }
+
+    return {
+      title: result.title ?? "",
+      content: result.content ?? "",
+      links: result.links ?? [],
+    };
+  } finally {
+    // Close offscreen document after use to avoid message routing conflicts
+    // (CRITICAL-1: offscreen's onMessage listener interferes with other sendMessage calls)
+    await closeOffscreenDocument();
   }
-
-  const result = await chrome.runtime.sendMessage<ReadabilityMessage, ReadabilityResponse>({
-    type: "BG_READABILITY",
-    html,
-    url,
-  });
-
-  if (!result?.success) {
-    throw new Error(result?.error ?? "Readability extraction failed");
-  }
-
-  return {
-    title: result.title ?? "",
-    content: result.content ?? "",
-    links: result.links ?? [],
-  };
 }
 
 // --- Response conversion ---
@@ -270,25 +423,36 @@ async function convertResponse(
 // --- Main handler ---
 
 async function handleBgFetch(msg: BgFetchMessage): Promise<BgFetchResponse> {
+  // Validate method
+  let method: string;
+  try {
+    method = sanitizeMethod(msg.method);
+  } catch (e: unknown) {
+    return { success: false, error: e instanceof Error ? e.message : String(e) };
+  }
+
+  // Validate URL
   const validation = validateUrl(msg.url);
   if (!validation.valid) {
     return { success: false, error: validation.error };
   }
 
   const url = upgradeToHttps(msg.url);
+  const headers = sanitizeHeaders(msg.headers);
 
-  // Cache check (GET only)
-  if (msg.method === "GET") {
-    const cached = getFromCache(url);
+  // Cache check (GET only, keyed by url + responseType)
+  const cacheKey = buildCacheKey(url, msg.responseType);
+  if (method === "GET") {
+    const cached = getFromCache(cacheKey);
     if (cached) return { success: true, data: cached };
   }
 
   await fetchSemaphore.acquire();
   try {
     const init: RequestInit = {
-      method: msg.method,
-      headers: msg.headers,
-      body: msg.body,
+      method,
+      headers,
+      body: method === "GET" || method === "HEAD" ? undefined : msg.body,
     };
 
     const result = await fetchWithRedirects(url, init, msg.timeout);
@@ -313,8 +477,8 @@ async function handleBgFetch(msg: BgFetchMessage): Promise<BgFetchResponse> {
     const data = await convertResponse(result as Response, msg.responseType, url);
 
     // Cache GET responses
-    if (msg.method === "GET") {
-      setCache(url, data);
+    if (method === "GET") {
+      setCache(cacheKey, data);
     }
 
     return { success: true, data };
@@ -329,9 +493,13 @@ async function handleBgFetch(msg: BgFetchMessage): Promise<BgFetchResponse> {
 // --- Message handler registration ---
 
 chrome.runtime.onMessage.addListener(
-  (msg: BgFetchMessage, _sender, sendResponse: (response: BgFetchResponse) => void) => {
+  (
+    msg: { type?: string },
+    _sender: chrome.runtime.MessageSender,
+    sendResponse: (response: BgFetchResponse) => void,
+  ) => {
     if (msg.type === "BG_FETCH") {
-      handleBgFetch(msg)
+      handleBgFetch(msg as BgFetchMessage)
         .then(sendResponse)
         .catch((err) =>
           sendResponse({
@@ -341,6 +509,5 @@ chrome.runtime.onMessage.addListener(
         );
       return true; // async
     }
-    return false;
   },
 );

--- a/src/features/tools/bg-fetch.ts
+++ b/src/features/tools/bg-fetch.ts
@@ -48,15 +48,6 @@ export const bgFetchToolDef: ToolDefinition = {
   },
 };
 
-interface BgFetchArgs {
-  urls: string[];
-  method?: string;
-  headers?: Record<string, string>;
-  body?: string;
-  response_type?: "text" | "json" | "base64" | "readability";
-  timeout?: number;
-}
-
 interface BgFetchResultItem {
   url: string;
   ok: boolean;
@@ -69,28 +60,63 @@ interface BgFetchResultItem {
   error?: string;
 }
 
+function truncateBody(body: string | object): string | object {
+  if (typeof body === "string") {
+    return body.length > MAX_BODY_CHARS
+      ? body.substring(0, MAX_BODY_CHARS) + "\n... (truncated)"
+      : body;
+  }
+
+  // Handle readability body { title, content, links }
+  if (typeof body === "object" && body !== null && "content" in body) {
+    const rb = body as { title: string; content: string; links: unknown[] };
+    if (rb.content.length > MAX_BODY_CHARS) {
+      return { ...rb, content: rb.content.substring(0, MAX_BODY_CHARS) + "\n... (truncated)" };
+    }
+  }
+
+  return body;
+}
+
 export async function executeBgFetch(
   args: Record<string, unknown>,
 ): Promise<Result<BgFetchResultItem | BgFetchResultItem[], ToolError>> {
-  const { urls, method, headers, body, response_type, timeout } = args as unknown as BgFetchArgs;
-
+  // Runtime input validation
+  const urls = args.urls;
   if (!urls || !Array.isArray(urls) || urls.length === 0) {
     return err({ code: "tool_script_error", message: "urls must be a non-empty array" });
   }
   if (urls.length > MAX_URLS) {
     return err({ code: "tool_script_error", message: `Maximum ${MAX_URLS} URLs per request` });
   }
+  if (urls.some((u) => typeof u !== "string")) {
+    return err({ code: "tool_script_error", message: "All urls must be strings" });
+  }
+
+  const method = typeof args.method === "string" ? args.method : "GET";
+  const headers =
+    args.headers && typeof args.headers === "object" && !Array.isArray(args.headers)
+      ? (args.headers as Record<string, string>)
+      : undefined;
+  const body = typeof args.body === "string" ? args.body : undefined;
+  const responseType =
+    typeof args.response_type === "string" &&
+    ["text", "json", "base64", "readability"].includes(args.response_type)
+      ? (args.response_type as BgFetchMessage["responseType"])
+      : "text";
+  const timeout =
+    typeof args.timeout === "number" ? Math.min(Math.max(args.timeout, 1000), 60000) : 30000;
 
   const fetchOne = async (url: string): Promise<BgFetchResultItem> => {
     try {
       const message: BgFetchMessage = {
         type: "BG_FETCH",
         url,
-        method: method ?? "GET",
+        method,
         headers,
         body,
-        responseType: response_type ?? "text",
-        timeout: Math.min(timeout ?? 30000, 60000),
+        responseType,
+        timeout,
       };
 
       const result = await chrome.runtime.sendMessage<BgFetchMessage, BgFetchResponse>(message);
@@ -103,16 +129,11 @@ export async function executeBgFetch(
           statusText: "",
           headers: {},
           body: "",
-          error: result?.error ?? "bgFetch failed",
+          error: result?.error ?? "bgFetch: no response from background handler",
         };
       }
 
-      const data = result.data;
-      if (typeof data.body === "string" && data.body.length > MAX_BODY_CHARS) {
-        data.body = data.body.substring(0, MAX_BODY_CHARS) + "\n... (truncated)";
-      }
-
-      return { ...data, url };
+      return { ...result.data, url, body: truncateBody(result.data.body) };
     } catch (e: unknown) {
       return {
         url,

--- a/src/offscreen/index.ts
+++ b/src/offscreen/index.ts
@@ -1,6 +1,8 @@
 import { Readability } from "@mozilla/readability";
 import type { ReadabilityMessage, ReadabilityResponse } from "@/shared/message-types";
 
+const MAX_CONTENT_LENGTH = 100_000; // 100K chars
+
 chrome.runtime.onMessage.addListener(
   (msg: ReadabilityMessage, _sender, sendResponse: (r: ReadabilityResponse) => void) => {
     if (msg.type !== "BG_READABILITY") return false;
@@ -21,10 +23,15 @@ chrome.runtime.onMessage.addListener(
       const article = reader.parse();
 
       const title = article?.title || doc.title || "";
-      const content =
+      let content =
         article && article.textContent && article.textContent.length > 100
           ? article.textContent.trim()
           : extractFallback(doc);
+
+      // Truncate to prevent token explosion
+      if (content.length > MAX_CONTENT_LENGTH) {
+        content = content.substring(0, MAX_CONTENT_LENGTH) + "\n... (truncated)";
+      }
 
       sendResponse({ success: true, title, content, links });
     } catch (e) {
@@ -67,5 +74,9 @@ function extractFallback(doc: Document): string {
       return el.textContent.trim();
     }
   }
-  return doc.body?.textContent?.trim() ?? "";
+  // Truncate body fallback too
+  const bodyText = doc.body?.textContent?.trim() ?? "";
+  return bodyText.length > MAX_CONTENT_LENGTH
+    ? bodyText.substring(0, MAX_CONTENT_LENGTH) + "\n... (truncated)"
+    : bodyText;
 }


### PR DESCRIPTION
## Summary
Oracleレビューで指摘された CRITICAL 2件 + MAJOR 6件 + MINOR 4件を全て修正。

### CRITICAL（バグ修正）
- offscreen document のメッセージルーティング競合を解消（"bgFetch failed" エラーの根本原因）
- offscreen document 作成の競合を singleton promise で防止

### MAJOR（セキュリティ強化）
- SSRF対策: プライベートIP全域、リンクローカル、クラウドmetadata IPをブロック
- リダイレクト先にも URL バリデーションを適用
- キャッシュキーに responseType を含める
- HTTP メソッドのホワイトリスト制限
- 危険ヘッダー (Host, Origin, Cookie等) の自動除去

### MINOR（品質改善）
- Readability 出力の文字数制限（100K）
- object 型 body にも truncation 適用
- ランタイム入力検証の強化

## Test plan
- [ ] readability → text の連続呼び出しで "bgFetch failed" が発生しないこと
- [ ] `http://127.0.0.1`, `http://169.254.169.254` がブロックされること
- [ ] リダイレクト先がプライベートIPの場合にブロックされること
- [ ] ビルドが通ること ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)