### PR TITLE
refactor: チャットUIのツール表示を整理・リッチ化

### DIFF
--- a/src/features/chat/ChatBubble.tsx
+++ b/src/features/chat/ChatBubble.tsx
@@ -1,5 +1,8 @@
+import { useState } from "react";
 import {
   ActionIcon,
+  Badge,
+  Box,
   Collapse,
   CopyButton,
   Group,
@@ -9,8 +12,17 @@ import {
 } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
 import { motion } from "framer-motion";
-import { Bot, Brain, Check, ChevronDown, ChevronRight, Copy, User } from "lucide-react";
-import type { ChatMessage } from "@/ports/session-types";
+import {
+  Bot,
+  Brain,
+  Check,
+  ChevronDown,
+  ChevronRight,
+  Copy,
+  Wrench,
+  User,
+} from "lucide-react";
+import type { ChatMessage, ToolCallInfo } from "@/ports/session-types";
 import { useStore } from "@/store/index";
 import { messageStyles, type StyledRole } from "./theme";
 import { MarkdownContent } from "./MarkdownContent";
@@ -41,6 +53,67 @@ function ReasoningBlock({ text, isThinking }: { text: string; isThinking?: boole
         </Text>
       </Collapse>
     </Paper>
+  );
+}
+
+function ToolCallGroup({ toolCalls }: { toolCalls: ToolCallInfo[] }) {
+  const hasRunning = toolCalls.some((tc) => tc.isRunning);
+  const allSuccess = toolCalls.every((tc) => tc.success === true);
+  const hasError = toolCalls.some((tc) => tc.success === false);
+  const [expanded, setExpanded] = useState(hasRunning || toolCalls.length <= 2);
+
+  // If only 1-2 tools, show inline without grouping
+  if (toolCalls.length <= 2) {
+    return (
+      <>
+        {toolCalls.map((tc) => (
+          <ToolCallBlock key={tc.id} tc={tc} />
+        ))}
+      </>
+    );
+  }
+
+  return (
+    <Box mt={8}>
+      <UnstyledButton
+        onClick={() => setExpanded((prev) => !prev)}
+        py={4}
+        px={6}
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 6,
+          borderRadius: 4,
+        }}
+        className="hover-highlight"
+      >
+        <Wrench size={12} color="var(--mantine-color-dimmed)" />
+        <Text size="xs" c="dimmed" fw={500}>
+          ツール実行
+        </Text>
+        <Badge
+          size="xs"
+          variant="light"
+          color={hasRunning ? "indigo" : hasError ? "red" : allSuccess ? "green" : "gray"}
+        >
+          {toolCalls.length}
+        </Badge>
+        <ChevronDown
+          size={12}
+          color="var(--mantine-color-dimmed)"
+          style={{
+            transform: expanded ? "rotate(180deg)" : "rotate(0deg)",
+            transition: "transform 0.15s ease",
+          }}
+        />
+      </UnstyledButton>
+
+      <Collapse expanded={expanded}>
+        {toolCalls.map((tc) => (
+          <ToolCallBlock key={tc.id} tc={tc} />
+        ))}
+      </Collapse>
+    </Box>
   );
 }
 
@@ -105,9 +178,9 @@ export function ChatBubble({ msg, isLast }: { msg: ChatMessage; isLast?: boolean
           </Paper>
         )}
 
-        {msg.toolCalls?.map((tc) => (
-          <ToolCallBlock key={tc.id} tc={tc} />
-        ))}
+        {msg.toolCalls && msg.toolCalls.length > 0 && (
+          <ToolCallGroup toolCalls={msg.toolCalls} />
+        )}
       </Paper>
     </motion.div>
   );

--- a/src/features/chat/ToolCallBlock.tsx
+++ b/src/features/chat/ToolCallBlock.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { Box, Collapse, Code, Paper, Text, UnstyledButton } from "@mantine/core";
-import { ChevronDown, ChevronUp, FileCode, Image as ImageIcon, Terminal } from "lucide-react";
+import { ChevronDown, ChevronUp, FileCode, Globe, Image as ImageIcon, Terminal } from "lucide-react";
 import type { ToolCallInfo } from "@/ports/session-types";
 import { defaultConsoleLogService } from "./services/console-log";
 import { defaultToolRendererRegistry } from "./tool-renderers";
@@ -198,14 +198,18 @@ function getToolDescription(toolCall: ToolCallInfo): string | null {
 
 function getToolIcon(toolName: string) {
   if (toolName === "artifacts") {
-    return <FileCode size={18} color="var(--mantine-color-indigo-5)" />;
+    return <FileCode size={14} color="var(--mantine-color-indigo-5)" />;
   }
 
   if (toolName === "extract_image") {
-    return <ImageIcon size={18} color="var(--mantine-color-green-5)" />;
+    return <ImageIcon size={14} color="var(--mantine-color-green-5)" />;
   }
 
-  return <Terminal size={18} color="var(--mantine-color-indigo-5)" />;
+  if (toolName === "bg_fetch") {
+    return <Globe size={14} color="var(--mantine-color-cyan-5)" />;
+  }
+
+  return <Terminal size={14} color="var(--mantine-color-indigo-5)" />;
 }
 
 export function ToolCallBlock({ tc }: { tc: ToolCallInfo }) {

--- a/src/features/chat/tool-renderers/bg-fetch-renderer.tsx
+++ b/src/features/chat/tool-renderers/bg-fetch-renderer.tsx
@@ -1,0 +1,313 @@
+import { useState } from "react";
+import {
+  Badge,
+  Box,
+  Collapse,
+  Group,
+  Loader,
+  Paper,
+  Text,
+  UnstyledButton,
+} from "@mantine/core";
+import {
+  CheckCircle,
+  ChevronDown,
+  ExternalLink,
+  XCircle,
+} from "lucide-react";
+import type { ToolRenderer, ToolRendererContext } from "./types";
+
+interface FetchResultItem {
+  url: string;
+  ok: boolean;
+  status: number;
+  statusText: string;
+  headers: Record<string, string>;
+  body: string | object;
+  redirected?: boolean;
+  redirectUrl?: string;
+  error?: string;
+}
+
+function getFavicon(url: string): string {
+  try {
+    return `https://www.google.com/s2/favicons?domain=${new URL(url).hostname}&sz=16`;
+  } catch {
+    return "";
+  }
+}
+
+function getHostname(url: string): string {
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return url;
+  }
+}
+
+function getStatusColor(status: number): string {
+  if (status >= 200 && status < 300) return "green";
+  if (status >= 300 && status < 400) return "blue";
+  if (status >= 400 && status < 500) return "orange";
+  return "red";
+}
+
+function getBodyPreview(body: string | object): string {
+  if (typeof body === "object" && body !== null) {
+    if ("title" in body && typeof (body as { title?: string }).title === "string") {
+      return (body as { title: string }).title;
+    }
+    if ("content" in body && typeof (body as { content?: string }).content === "string") {
+      return (body as { content: string }).content.substring(0, 100);
+    }
+    return JSON.stringify(body).substring(0, 100);
+  }
+  return body.substring(0, 100);
+}
+
+function FetchResultCard({ item }: { item: FetchResultItem }) {
+  const [expanded, setExpanded] = useState(false);
+  const hostname = getHostname(item.url);
+  const favicon = getFavicon(item.url);
+  const preview = item.ok ? getBodyPreview(item.body) : item.error || item.statusText;
+
+  return (
+    <Paper
+      radius="sm"
+      withBorder
+      style={{
+        borderColor: item.ok
+          ? "var(--mantine-color-green-3)"
+          : "var(--mantine-color-red-3)",
+        overflow: "hidden",
+      }}
+    >
+      <UnstyledButton
+        onClick={() => setExpanded((prev) => !prev)}
+        w="100%"
+        px="sm"
+        py={8}
+        style={{ display: "flex", alignItems: "center", gap: 8 }}
+      >
+        <img
+          src={favicon}
+          alt=""
+          width={14}
+          height={14}
+          style={{ borderRadius: 2, flexShrink: 0 }}
+          onError={(e) => {
+            (e.target as HTMLImageElement).style.display = "none";
+          }}
+        />
+        <Text size="xs" fw={600} truncate style={{ flex: 1 }}>
+          {hostname}
+        </Text>
+        {item.status > 0 && (
+          <Badge size="xs" variant="light" color={getStatusColor(item.status)}>
+            {item.status}
+          </Badge>
+        )}
+        {item.ok ? (
+          <CheckCircle size={12} color="var(--mantine-color-green-5)" />
+        ) : (
+          <XCircle size={12} color="var(--mantine-color-red-5)" />
+        )}
+        <ChevronDown
+          size={12}
+          style={{
+            transform: expanded ? "rotate(180deg)" : "rotate(0deg)",
+            transition: "transform 0.15s ease",
+            opacity: 0.4,
+          }}
+        />
+      </UnstyledButton>
+
+      {!expanded && preview && (
+        <Text size="xs" c="dimmed" px="sm" pb={6} truncate>
+          {preview}
+        </Text>
+      )}
+
+      <Collapse expanded={expanded}>
+        <Box
+          px="sm"
+          pb="sm"
+          style={{
+            borderTop: "1px solid var(--mantine-color-default-border)",
+          }}
+        >
+          <Text
+            size="xs"
+            c="dimmed"
+            mt={6}
+            style={{
+              fontFamily: "monospace",
+              wordBreak: "break-all",
+            }}
+          >
+            {item.url}
+          </Text>
+
+          {item.redirected && item.redirectUrl && (
+            <Group gap={4} mt={4}>
+              <ExternalLink size={10} />
+              <Text size="xs" c="dimmed" style={{ fontFamily: "monospace" }}>
+                → {item.redirectUrl}
+              </Text>
+            </Group>
+          )}
+
+          {item.ok && (
+            <Paper
+              mt={8}
+              p="xs"
+              radius="sm"
+              style={{
+                background: "var(--mantine-color-default-hover)",
+                maxHeight: 200,
+                overflow: "auto",
+              }}
+            >
+              <Text
+                size="xs"
+                style={{
+                  whiteSpace: "pre-wrap",
+                  wordBreak: "break-word",
+                  fontFamily: "monospace",
+                }}
+              >
+                {typeof item.body === "string"
+                  ? item.body.substring(0, 2000)
+                  : JSON.stringify(item.body, null, 2).substring(0, 2000)}
+              </Text>
+            </Paper>
+          )}
+
+          {!item.ok && item.error && (
+            <Text size="xs" c="red" mt={4}>
+              {item.error}
+            </Text>
+          )}
+        </Box>
+      </Collapse>
+    </Paper>
+  );
+}
+
+function parseResult(result?: string): FetchResultItem[] {
+  if (!result) return [];
+  try {
+    const parsed = JSON.parse(result);
+    if (Array.isArray(parsed)) return parsed;
+    if (typeof parsed === "object" && parsed !== null && "url" in parsed) return [parsed];
+    return [];
+  } catch {
+    return [];
+  }
+}
+
+function getUrls(args: Record<string, unknown>): string[] {
+  if (Array.isArray(args.urls)) return args.urls.filter((u) => typeof u === "string");
+  return [];
+}
+
+function BgFetchExecuting({ toolCall }: ToolRendererContext) {
+  const urls = getUrls(toolCall.args);
+  const responseType = typeof toolCall.args.response_type === "string"
+    ? toolCall.args.response_type
+    : "text";
+
+  return (
+    <Box>
+      <Group gap={6} mb={8}>
+        <Badge size="xs" variant="light" color="indigo">
+          {responseType}
+        </Badge>
+        <Text size="xs" c="dimmed">
+          {urls.length} URL{urls.length > 1 ? "s" : ""} を取得中
+        </Text>
+      </Group>
+      <Box style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+        {urls.map((url) => (
+          <Group key={url} gap={6} px={4} py={2}>
+            <Loader size={10} type="dots" />
+            <img
+              src={getFavicon(url)}
+              alt=""
+              width={12}
+              height={12}
+              style={{ borderRadius: 2 }}
+              onError={(e) => {
+                (e.target as HTMLImageElement).style.display = "none";
+              }}
+            />
+            <Text size="xs" c="dimmed" truncate style={{ fontFamily: "monospace" }}>
+              {getHostname(url)}
+            </Text>
+          </Group>
+        ))}
+      </Box>
+    </Box>
+  );
+}
+
+function BgFetchSuccess({ toolCall }: ToolRendererContext) {
+  const items = parseResult(toolCall.result);
+  const responseType = typeof toolCall.args.response_type === "string"
+    ? toolCall.args.response_type
+    : "text";
+  const successCount = items.filter((i) => i.ok).length;
+
+  return (
+    <Box>
+      <Group gap={6} mb={8}>
+        <Badge size="xs" variant="light" color="indigo">
+          {responseType}
+        </Badge>
+        <Text size="xs" c="dimmed">
+          {successCount}/{items.length} 成功
+        </Text>
+      </Group>
+      <Box style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+        {items.map((item) => (
+          <FetchResultCard key={item.url} item={item} />
+        ))}
+      </Box>
+    </Box>
+  );
+}
+
+function BgFetchError({ toolCall }: ToolRendererContext) {
+  return (
+    <Box p="xs" style={{ background: "var(--mantine-color-red-light)", borderRadius: 4 }}>
+      <Group gap={6}>
+        <XCircle size={14} color="var(--mantine-color-red-5)" />
+        <Text size="xs" c="red">
+          {toolCall.result || "Fetch failed"}
+        </Text>
+      </Group>
+    </Box>
+  );
+}
+
+export const bgFetchToolRenderer: ToolRenderer = {
+  renderExecuting: (context) => <BgFetchExecuting {...context} />,
+  renderSuccess: (context) => <BgFetchSuccess {...context} />,
+  renderError: (context) => <BgFetchError {...context} />,
+  renderSummary: ({ toolCall }) => {
+    const urls = getUrls(toolCall.args);
+    const responseType = typeof toolCall.args.response_type === "string"
+      ? toolCall.args.response_type
+      : "text";
+    return (
+      <Group gap={6}>
+        <Badge size="xs" variant="light" color="indigo">
+          {responseType}
+        </Badge>
+        <Text size="xs" c="dimmed">
+          {urls.length} URL{urls.length > 1 ? "s" : ""}
+        </Text>
+      </Group>
+    );
+  },
+};

--- a/src/features/chat/tool-renderers/components.tsx
+++ b/src/features/chat/tool-renderers/components.tsx
@@ -14,7 +14,6 @@ import {
 import {
   CheckCircle,
   ChevronDown,
-  ChevronUp,
   Check,
   Code2,
   Copy,
@@ -75,7 +74,10 @@ export function ToolMessageContainer({
   defaultExpanded,
   children,
 }: ToolMessageContainerProps) {
-  const [expanded, setExpanded] = useState(toolCall.isRunning || defaultExpanded === true);
+  const isComplete = !toolCall.isRunning && toolCall.success !== undefined;
+  const [expanded, setExpanded] = useState(
+    toolCall.isRunning || (defaultExpanded === true && !isComplete),
+  );
 
   useEffect(() => {
     if (toolCall.isRunning) {
@@ -83,48 +85,70 @@ export function ToolMessageContainer({
     }
   }, [toolCall.isRunning]);
 
+  const borderLeftColor = toolCall.isRunning
+    ? "var(--mantine-color-indigo-5)"
+    : toolCall.success === true
+      ? "var(--mantine-color-green-5)"
+      : toolCall.success === false
+        ? "var(--mantine-color-red-5)"
+        : "var(--mantine-color-default-border)";
+
   return (
-    <Paper
-      mt="sm"
-      radius="md"
-      withBorder
+    <Box
+      mt={6}
+      className={toolCall.isRunning ? "tool-running" : undefined}
       style={{
-        borderColor: toolCall.isRunning
-          ? "var(--mantine-color-indigo-3)"
-          : "var(--mantine-color-default-border)",
-        boxShadow: toolCall.isRunning ? "0 0 0 1px var(--mantine-color-indigo-light)" : undefined,
+        borderLeft: `3px solid ${borderLeftColor}`,
+        borderRadius: 4,
+        background: toolCall.isRunning
+          ? "var(--mantine-color-indigo-light)"
+          : expanded
+            ? "var(--mantine-color-default-hover)"
+            : "transparent",
+        transition: "background 0.15s ease",
       }}
     >
       <UnstyledButton
         onClick={() => !toolCall.isRunning && setExpanded((prev) => !prev)}
         w="100%"
-        px="md"
-        py="sm"
-        style={{ display: "flex", alignItems: "center", gap: 10 }}
+        px="sm"
+        py={6}
+        style={{ display: "flex", alignItems: "center", gap: 8 }}
         aria-label={`ツール: ${toolCall.name}`}
         aria-expanded={expanded}
       >
-        {icon ?? <Terminal size={18} color="var(--mantine-color-indigo-5)" />}
-        <Text size="sm" fw={600} c="indigo">
+        {icon ?? <Terminal size={14} color="var(--mantine-color-indigo-5)" />}
+        <Text size="xs" fw={600} c={toolCall.isRunning ? "indigo" : "dimmed"}>
           {toolCall.name}
         </Text>
         {summary ? (
           <Box style={{ flex: 1 }}>{summary}</Box>
         ) : description ? (
-          <Text size="sm" c="dimmed" truncate style={{ flex: 1 }}>
+          <Text size="xs" c="dimmed" truncate style={{ flex: 1 }}>
             {description}
           </Text>
-        ) : null}
+        ) : (
+          <Box style={{ flex: 1 }} />
+        )}
         <StatusIcon toolCall={toolCall} />
-        {!toolCall.isRunning && (expanded ? <ChevronUp size={16} /> : <ChevronDown size={16} />)}
+        {!toolCall.isRunning && (
+          <ChevronDown
+            size={12}
+            style={{
+              transform: expanded ? "rotate(180deg)" : "rotate(0deg)",
+              transition: "transform 0.15s ease",
+              opacity: 0.5,
+            }}
+          />
+        )}
       </UnstyledButton>
 
       {expanded && (
-        <Box px="md" pb="md">
+        <Box px="sm" pb="sm">
           {children}
         </Box>
       )}
-    </Paper>
+    </Box>
   );
 }
 

--- a/src/features/chat/tool-renderers/index.ts
+++ b/src/features/chat/tool-renderers/index.ts
@@ -1,4 +1,5 @@
 import { defaultConsoleLogService } from "../services/console-log";
+import { bgFetchToolRenderer } from "./bg-fetch-renderer";
 import { artifactsToolRenderer, extractImageToolRenderer, replToolRenderer } from "./components";
 import { ToolRendererRegistry } from "./registry";
 
@@ -8,6 +9,7 @@ export function createDefaultToolRendererRegistry(consoleLogService = defaultCon
   registry.register("repl", replToolRenderer);
   registry.register("extract_image", extractImageToolRenderer);
   registry.register("artifacts", artifactsToolRenderer);
+  registry.register("bg_fetch", bgFetchToolRenderer);
   return registry;
 }
 

--- a/src/sidepanel/styles.css
+++ b/src/sidepanel/styles.css
@@ -254,6 +254,27 @@ body,
   }
 }
 
+/* Tool running pulse animation */
+.tool-running {
+  animation: toolPulse 1.5s ease-in-out infinite;
+}
+
+@keyframes toolPulse {
+  0%,
+  100% {
+    background: var(--mantine-color-indigo-light);
+  }
+  50% {
+    background: color-mix(in srgb, var(--mantine-color-indigo-light) 60%, transparent);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tool-running {
+    animation: none;
+  }
+}
+
 /* Markdown content styles */
 .markdown-content pre {
   scrollbar-width: thin;


### PR DESCRIPTION
## Summary
- ToolMessageContainerを完了済みデフォルト折りたたみ化、左ボーダーでステータス表示、コンパクト化
- bg_fetch専用レンダラー追加（ファビコン付きURL一覧、ステータスコードバッジ、プレビュー）
- 3つ以上のツールコールをグルーピング表示で視認性向上
- 実行中ツールのパルスアニメーション追加

## Test plan
- [ ] チャットでツールを使う会話を行い、完了済みツールが折りたたまれていることを確認
- [ ] bg_fetchツール実行時にファビコン・ステータスバッジが表示されることを確認
- [ ] 3つ以上のツールコールがグルーピングされることを確認
- [ ] 実行中ツールにパルスアニメーションが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)