### PR TITLE
fix: SPA ナビゲーションループ防止 + bg_fetch SPA検出

### DIFF
--- a/public/offscreen.html
+++ b/public/offscreen.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
 <html>
   <head><meta charset="utf-8" /></head>
-  <body><script src="offscreen.js"></script></body>
+  <body><script type="module" src="offscreen.js"></script></body>
 </html>

--- a/src/features/tools/bg-fetch.ts
+++ b/src/features/tools/bg-fetch.ts
@@ -60,6 +60,16 @@ interface BgFetchResultItem {
   redirected?: boolean;
   redirectUrl?: string;
   error?: string;
+  spaWarning?: string;
+}
+
+/** readability 結果の content が極端に短い場合、SPA/CSR の可能性が高い */
+const SPA_CONTENT_THRESHOLD = 200;
+
+function isSpaLikelyReadability(body: unknown): boolean {
+  if (typeof body !== "object" || body === null || !("content" in body)) return false;
+  const rb = body as { content: string };
+  return typeof rb.content === "string" && rb.content.trim().length < SPA_CONTENT_THRESHOLD;
 }
 
 function truncateBody(body: string | object): string | object {
@@ -135,7 +145,18 @@ export async function executeBgFetch(
         };
       }
 
-      return { ...result.data, url, body: truncateBody(result.data.body) };
+      const item: BgFetchResultItem = { ...result.data, url, body: truncateBody(result.data.body) };
+
+      // readability モードで本文がほぼ空 → SPA/CSR の可能性が高い
+      if (responseType === "readability" && isSpaLikelyReadability(result.data.body)) {
+        item.spaWarning =
+          "⚠️ This page returned very little content via bg_fetch. " +
+          "It is likely a SPA/CSR site where content is rendered by JavaScript. " +
+          "Do NOT use bg_fetch for other pages on this same domain. " +
+          "Instead, use navigate() to load the page, then read_page or browserjs() to extract content.";
+      }
+
+      return item;
     } catch (e: unknown) {
       return {
         url,

--- a/src/features/tools/navigate.ts
+++ b/src/features/tools/navigate.ts
@@ -51,6 +51,8 @@ Actions:
 3. List all tabs: { "listTabs": true }
 4. Switch to tab: { "switchToTab": 12345 }
 
+IMPORTANT: Do NOT navigate to a URL you have already visited in this session. Use read_page to re-read content if needed. Collect all necessary pages first, then proceed to analysis — do not loop between pages.
+
 When switching tabs, use the tab ID from listTabs.
 Tab IDs are temporary and may change when the browser restarts.`,
   parameters: {

--- a/src/orchestration/agent-loop.ts
+++ b/src/orchestration/agent-loop.ts
@@ -57,6 +57,7 @@ export interface ChatActions {
   syncHistory(messages: AIMessage[]): void;
   getMessages(): ChatMessage[];
   addNavigationMessage?(nav: { url: string; title: string; favicon?: string }): void;
+  setToolNavigating?(v: boolean): void;
 }
 
 export interface AutoSaver {
@@ -94,6 +95,53 @@ export type { ToolExecutor } from "@/ports/tool-executor";
 const MAX_TURNS = 25;
 const MAX_TOOL_RESULT_CHARS = 30_000;
 const CONTEXT_TOKEN_LIMIT = 100_000;
+
+/** 末尾スラッシュを除去してURLを正規化する */
+function normalizeUrl(url: string): string {
+  return url.replace(/\/$/, "");
+}
+
+/** 訪問済みURLの再訪問警告メッセージを生成する（再訪問でなければ null） */
+function trackVisitedUrl(
+  visitedUrls: Map<string, number>,
+  url: string,
+): string | null {
+  const normalized = normalizeUrl(url);
+  const count = (visitedUrls.get(normalized) ?? 0) + 1;
+  visitedUrls.set(normalized, count);
+  if (count >= 2) {
+    return `\n\n⚠️ WARNING: This URL has already been visited ${count} time(s) in this session. Do NOT navigate to it again. Use the information you already collected from previous visits. If you have enough information, proceed to analysis/response instead of collecting more pages.`;
+  }
+  return null;
+}
+
+/** bg_fetch 結果から SPA ドメインを検出・追跡し、警告メッセージを返す */
+function trackSpaDomainsFromBgFetch(
+  spaDetectedDomains: Set<string>,
+  toolValue: unknown,
+): string {
+  let warning = "";
+  try {
+    const items = Array.isArray(toolValue) ? toolValue : [toolValue];
+    for (const item of items) {
+      const it = item as { url?: string; spaWarning?: string };
+      if (!it.url) continue;
+      // spaWarning があればドメインを登録
+      if (it.spaWarning) {
+        spaDetectedDomains.add(new URL(it.url).hostname);
+      } else {
+        // spaWarning がなくても既知 SPA ドメインなら警告
+        const host = new URL(it.url).hostname;
+        if (spaDetectedDomains.has(host)) {
+          warning += `\n\n⚠️ WARNING: The domain "${host}" was previously detected as a SPA/CSR site. bg_fetch cannot retrieve JS-rendered content from this domain. Use navigate() + read_page/browserjs() instead.`;
+        }
+      }
+    }
+  } catch {
+    // Ignore
+  }
+  return warning;
+}
 
 function trimMessagesForContext(messages: AIMessage[]): void {
   for (const msg of messages) {
@@ -155,6 +203,14 @@ export async function runAgentLoop(params: AgentLoopParams): Promise<void> {
     // Ignore error, continue with empty URL
   }
 
+  // 訪問済みURL追跡: 同一URLへの繰り返しナビゲーションを検出・警告する
+  const visitedUrls = new Map<string, number>(); // URL → 訪問回数
+  // SPA と判定されたドメインの追跡: bg_fetch で SPA 警告が出たドメインを記録
+  const spaDetectedDomains = new Set<string>();
+  // setToolNavigating(false) の遅延タイマー。連続 navigate 時に前のタイマーをキャンセルし、
+  // 後の navigate のフラグが意図せずクリアされるのを防ぐ。
+  let navFlagTimer: ReturnType<typeof setTimeout> | null = null;
+
   let messages: AIMessage[] = buildMessagesForAPI(
     session,
     chatStore.getMessages(),
@@ -201,6 +257,15 @@ export async function runAgentLoop(params: AgentLoopParams): Promise<void> {
           chatStore.updateToolCallArgs(id, args);
         }
 
+        const isNavTool = name === "navigate" || name === "repl";
+        if (isNavTool) {
+          if (navFlagTimer !== null) {
+            clearTimeout(navFlagTimer);
+            navFlagTimer = null;
+          }
+          chatStore.setToolNavigating?.(true);
+        }
+
         let toolResult: Result<unknown, AppError>;
         try {
           toolResult = await toolExecutor(name, args, deps.browserExecutor, undefined, {
@@ -230,6 +295,18 @@ export async function runAgentLoop(params: AgentLoopParams): Promise<void> {
               message: e instanceof Error ? e.message : String(e),
             },
           };
+        } finally {
+          if (isNavTool) {
+            // SPA の初期ルーティング完了を待ってからフラグをクリアする。
+            // DOMContentLoaded 直後に SPA がクライアントサイドリダイレクトを行い、
+            // onTabUpdated が遅延発火するケースでの抑制漏れを防ぐ。
+            // 連続 navigate 時は新しい setToolNavigating(true) で前のタイマーを
+            // キャンセル済みなので、後の navigate のフラグが意図せずクリアされない。
+            navFlagTimer = setTimeout(() => {
+              navFlagTimer = null;
+              chatStore.setToolNavigating?.(false);
+            }, 500);
+          }
         }
         pendingToolCalls.push({ id, name, args, providerOptions });
         let resultStr = toolResult.ok
@@ -270,22 +347,42 @@ export async function runAgentLoop(params: AgentLoopParams): Promise<void> {
         if (resultStr.includes("data:image/")) {
           resultStr = "[screenshot captured]";
         }
-        chatStore.updateToolCallResult(id, toolResult);
-        pendingToolResults.push({
-          toolCallId: id,
-          toolName: name,
-          result: resultStr,
-          isError: !toolResult.ok,
-        });
 
-        // Check for navigation during tool execution and update skills if needed
+        // --- ツール別ポスト処理: 訪問追跡・SPA検出・スキル再構築 ---
+
+        let loopWarningEmitted = false;
+
+        if (name === "navigate" && toolResult.ok) {
+          const navResult = toolResult.value as { finalUrl?: string };
+          if (navResult.finalUrl) {
+            const warning = trackVisitedUrl(visitedUrls, navResult.finalUrl);
+            if (warning) {
+              resultStr += warning;
+              loopWarningEmitted = true;
+            }
+          }
+        }
+
+        if (name === "bg_fetch" && toolResult.ok) {
+          resultStr += trackSpaDomainsFromBgFetch(spaDetectedDomains, toolResult.value);
+        }
+
+        // navigate/repl 後のURL変化検出: スキル再構築 + repl 訪問追跡
         if (name === "navigate" || name === "repl") {
           try {
             const tab = await deps.browserExecutor.getActiveTab();
             const newUrl = tab.url || "";
+            // repl 経由のナビゲーションは currentUrl と同じでも追跡する。
+            // navigate ツール直接呼び出しは上で追跡済みなのでここでは repl のみ。
+            if (name === "repl" && newUrl) {
+              const warning = trackVisitedUrl(visitedUrls, newUrl);
+              if (warning) {
+                resultStr += warning;
+                loopWarningEmitted = true;
+              }
+            }
             if (newUrl && newUrl !== currentUrl) {
               currentUrl = newUrl;
-              // Rebuild messages with new skills
               messages = buildMessagesForAPI(
                 session,
                 chatStore.getMessages(),
@@ -297,6 +394,21 @@ export async function runAgentLoop(params: AgentLoopParams): Promise<void> {
             // Ignore error
           }
         }
+
+        // ループ警告が出た場合、ユーザーにもシステムメッセージで通知
+        if (loopWarningEmitted) {
+          chatStore.addSystemMessage(
+            "⚠️ 同じページへの繰り返しアクセスを検出しました。AIに収集を終えて分析に移るよう指示しています。",
+          );
+        }
+
+        chatStore.updateToolCallResult(id, toolResult);
+        pendingToolResults.push({
+          toolCallId: id,
+          toolName: name,
+          result: resultStr,
+          isError: !toolResult.ok,
+        });
 
         if (name === "repl" && toolResult.ok) {
           const prevNames = new Set(useStore.getState().artifacts.map((a) => a.name));

--- a/src/shared/models.generated.ts
+++ b/src/shared/models.generated.ts
@@ -14,629 +14,634 @@ export interface ProviderModels {
 }
 
 export const GENERATED_MODELS: Record<string, ProviderModels> = {
-  anthropic: {
-    defaultModel: "claude-sonnet-4-6",
-    models: [
+  "anthropic": {
+    "defaultModel": "claude-sonnet-4-6",
+    "models": [
       {
-        id: "claude-3-5-haiku-20241022",
-        name: "Claude Haiku 3.5",
-        reasoning: false,
+        "id": "claude-3-5-haiku-20241022",
+        "name": "Claude Haiku 3.5",
+        "reasoning": false
       },
       {
-        id: "claude-3-5-haiku-latest",
-        name: "Claude Haiku 3.5 (latest)",
-        reasoning: false,
+        "id": "claude-3-5-haiku-latest",
+        "name": "Claude Haiku 3.5 (latest)",
+        "reasoning": false
       },
       {
-        id: "claude-3-5-sonnet-20240620",
-        name: "Claude Sonnet 3.5",
-        reasoning: false,
+        "id": "claude-3-5-sonnet-20240620",
+        "name": "Claude Sonnet 3.5",
+        "reasoning": false
       },
       {
-        id: "claude-3-5-sonnet-20241022",
-        name: "Claude Sonnet 3.5 v2",
-        reasoning: false,
+        "id": "claude-3-5-sonnet-20241022",
+        "name": "Claude Sonnet 3.5 v2",
+        "reasoning": false
       },
       {
-        id: "claude-3-haiku-20240307",
-        name: "Claude Haiku 3",
-        reasoning: false,
+        "id": "claude-3-haiku-20240307",
+        "name": "Claude Haiku 3",
+        "reasoning": false
       },
       {
-        id: "claude-3-opus-20240229",
-        name: "Claude Opus 3",
-        reasoning: false,
+        "id": "claude-3-opus-20240229",
+        "name": "Claude Opus 3",
+        "reasoning": false
       },
       {
-        id: "claude-3-sonnet-20240229",
-        name: "Claude Sonnet 3",
-        reasoning: false,
+        "id": "claude-3-sonnet-20240229",
+        "name": "Claude Sonnet 3",
+        "reasoning": false
       },
       {
-        id: "claude-3-7-sonnet-20250219",
-        name: "Claude Sonnet 3.7",
-        reasoning: true,
+        "id": "claude-3-7-sonnet-20250219",
+        "name": "Claude Sonnet 3.7",
+        "reasoning": true
       },
       {
-        id: "claude-haiku-4-5",
-        name: "Claude Haiku 4.5 (latest)",
-        reasoning: true,
+        "id": "claude-haiku-4-5",
+        "name": "Claude Haiku 4.5 (latest)",
+        "reasoning": true
       },
       {
-        id: "claude-haiku-4-5-20251001",
-        name: "Claude Haiku 4.5",
-        reasoning: true,
+        "id": "claude-haiku-4-5-20251001",
+        "name": "Claude Haiku 4.5",
+        "reasoning": true
       },
       {
-        id: "claude-opus-4-0",
-        name: "Claude Opus 4 (latest)",
-        reasoning: true,
+        "id": "claude-opus-4-0",
+        "name": "Claude Opus 4 (latest)",
+        "reasoning": true
       },
       {
-        id: "claude-opus-4-1",
-        name: "Claude Opus 4.1 (latest)",
-        reasoning: true,
+        "id": "claude-opus-4-1",
+        "name": "Claude Opus 4.1 (latest)",
+        "reasoning": true
       },
       {
-        id: "claude-opus-4-1-20250805",
-        name: "Claude Opus 4.1",
-        reasoning: true,
+        "id": "claude-opus-4-1-20250805",
+        "name": "Claude Opus 4.1",
+        "reasoning": true
       },
       {
-        id: "claude-opus-4-20250514",
-        name: "Claude Opus 4",
-        reasoning: true,
+        "id": "claude-opus-4-20250514",
+        "name": "Claude Opus 4",
+        "reasoning": true
       },
       {
-        id: "claude-opus-4-5",
-        name: "Claude Opus 4.5 (latest)",
-        reasoning: true,
+        "id": "claude-opus-4-5",
+        "name": "Claude Opus 4.5 (latest)",
+        "reasoning": true
       },
       {
-        id: "claude-opus-4-5-20251101",
-        name: "Claude Opus 4.5",
-        reasoning: true,
+        "id": "claude-opus-4-5-20251101",
+        "name": "Claude Opus 4.5",
+        "reasoning": true
       },
       {
-        id: "claude-opus-4-6",
-        name: "Claude Opus 4.6",
-        reasoning: true,
+        "id": "claude-opus-4-6",
+        "name": "Claude Opus 4.6",
+        "reasoning": true
       },
       {
-        id: "claude-sonnet-4-0",
-        name: "Claude Sonnet 4 (latest)",
-        reasoning: true,
+        "id": "claude-opus-4-7",
+        "name": "Claude Opus 4.7",
+        "reasoning": true
       },
       {
-        id: "claude-sonnet-4-20250514",
-        name: "Claude Sonnet 4",
-        reasoning: true,
+        "id": "claude-sonnet-4-0",
+        "name": "Claude Sonnet 4 (latest)",
+        "reasoning": true
       },
       {
-        id: "claude-sonnet-4-5",
-        name: "Claude Sonnet 4.5 (latest)",
-        reasoning: true,
+        "id": "claude-sonnet-4-20250514",
+        "name": "Claude Sonnet 4",
+        "reasoning": true
       },
       {
-        id: "claude-sonnet-4-5-20250929",
-        name: "Claude Sonnet 4.5",
-        reasoning: true,
+        "id": "claude-sonnet-4-5",
+        "name": "Claude Sonnet 4.5 (latest)",
+        "reasoning": true
       },
       {
-        id: "claude-sonnet-4-6",
-        name: "Claude Sonnet 4.6",
-        reasoning: true,
+        "id": "claude-sonnet-4-5-20250929",
+        "name": "Claude Sonnet 4.5",
+        "reasoning": true
       },
-    ],
+      {
+        "id": "claude-sonnet-4-6",
+        "name": "Claude Sonnet 4.6",
+        "reasoning": true
+      }
+    ]
   },
-  openai: {
-    defaultModel: "gpt-5.4",
-    models: [
+  "openai": {
+    "defaultModel": "gpt-5.4",
+    "models": [
       {
-        id: "gpt-4",
-        name: "GPT-4",
-        reasoning: false,
+        "id": "gpt-4",
+        "name": "GPT-4",
+        "reasoning": false
       },
       {
-        id: "gpt-4-turbo",
-        name: "GPT-4 Turbo",
-        reasoning: false,
+        "id": "gpt-4-turbo",
+        "name": "GPT-4 Turbo",
+        "reasoning": false
       },
       {
-        id: "gpt-4.1",
-        name: "GPT-4.1",
-        reasoning: false,
+        "id": "gpt-4.1",
+        "name": "GPT-4.1",
+        "reasoning": false
       },
       {
-        id: "gpt-4.1-mini",
-        name: "GPT-4.1 mini",
-        reasoning: false,
+        "id": "gpt-4.1-mini",
+        "name": "GPT-4.1 mini",
+        "reasoning": false
       },
       {
-        id: "gpt-4.1-nano",
-        name: "GPT-4.1 nano",
-        reasoning: false,
+        "id": "gpt-4.1-nano",
+        "name": "GPT-4.1 nano",
+        "reasoning": false
       },
       {
-        id: "gpt-4o",
-        name: "GPT-4o",
-        reasoning: false,
+        "id": "gpt-4o",
+        "name": "GPT-4o",
+        "reasoning": false
       },
       {
-        id: "gpt-4o-2024-05-13",
-        name: "GPT-4o (2024-05-13)",
-        reasoning: false,
+        "id": "gpt-4o-2024-05-13",
+        "name": "GPT-4o (2024-05-13)",
+        "reasoning": false
       },
       {
-        id: "gpt-4o-2024-08-06",
-        name: "GPT-4o (2024-08-06)",
-        reasoning: false,
+        "id": "gpt-4o-2024-08-06",
+        "name": "GPT-4o (2024-08-06)",
+        "reasoning": false
       },
       {
-        id: "gpt-4o-2024-11-20",
-        name: "GPT-4o (2024-11-20)",
-        reasoning: false,
+        "id": "gpt-4o-2024-11-20",
+        "name": "GPT-4o (2024-11-20)",
+        "reasoning": false
       },
       {
-        id: "gpt-4o-mini",
-        name: "GPT-4o mini",
-        reasoning: false,
+        "id": "gpt-4o-mini",
+        "name": "GPT-4o mini",
+        "reasoning": false
       },
       {
-        id: "gpt-5.3-chat-latest",
-        name: "GPT-5.3 Chat (latest)",
-        reasoning: false,
+        "id": "gpt-5.3-chat-latest",
+        "name": "GPT-5.3 Chat (latest)",
+        "reasoning": false
       },
       {
-        id: "gpt-5",
-        name: "GPT-5",
-        reasoning: true,
+        "id": "gpt-5",
+        "name": "GPT-5",
+        "reasoning": true
       },
       {
-        id: "gpt-5-mini",
-        name: "GPT-5 Mini",
-        reasoning: true,
+        "id": "gpt-5-mini",
+        "name": "GPT-5 Mini",
+        "reasoning": true
       },
       {
-        id: "gpt-5-nano",
-        name: "GPT-5 Nano",
-        reasoning: true,
+        "id": "gpt-5-nano",
+        "name": "GPT-5 Nano",
+        "reasoning": true
       },
       {
-        id: "gpt-5-pro",
-        name: "GPT-5 Pro",
-        reasoning: true,
+        "id": "gpt-5-pro",
+        "name": "GPT-5 Pro",
+        "reasoning": true
       },
       {
-        id: "gpt-5.1",
-        name: "GPT-5.1",
-        reasoning: true,
+        "id": "gpt-5.1",
+        "name": "GPT-5.1",
+        "reasoning": true
       },
       {
-        id: "gpt-5.1-chat-latest",
-        name: "GPT-5.1 Chat",
-        reasoning: true,
+        "id": "gpt-5.1-chat-latest",
+        "name": "GPT-5.1 Chat",
+        "reasoning": true
       },
       {
-        id: "gpt-5.2",
-        name: "GPT-5.2",
-        reasoning: true,
+        "id": "gpt-5.2",
+        "name": "GPT-5.2",
+        "reasoning": true
       },
       {
-        id: "gpt-5.2-chat-latest",
-        name: "GPT-5.2 Chat",
-        reasoning: true,
+        "id": "gpt-5.2-chat-latest",
+        "name": "GPT-5.2 Chat",
+        "reasoning": true
       },
       {
-        id: "gpt-5.2-pro",
-        name: "GPT-5.2 Pro",
-        reasoning: true,
+        "id": "gpt-5.2-pro",
+        "name": "GPT-5.2 Pro",
+        "reasoning": true
       },
       {
-        id: "gpt-5.4",
-        name: "GPT-5.4",
-        reasoning: true,
+        "id": "gpt-5.4",
+        "name": "GPT-5.4",
+        "reasoning": true
       },
       {
-        id: "gpt-5.4-mini",
-        name: "GPT-5.4 mini",
-        reasoning: true,
+        "id": "gpt-5.4-mini",
+        "name": "GPT-5.4 mini",
+        "reasoning": true
       },
       {
-        id: "gpt-5.4-nano",
-        name: "GPT-5.4 nano",
-        reasoning: true,
+        "id": "gpt-5.4-nano",
+        "name": "GPT-5.4 nano",
+        "reasoning": true
       },
       {
-        id: "gpt-5.4-pro",
-        name: "GPT-5.4 Pro",
-        reasoning: true,
+        "id": "gpt-5.4-pro",
+        "name": "GPT-5.4 Pro",
+        "reasoning": true
       },
       {
-        id: "o1",
-        name: "o1",
-        reasoning: true,
+        "id": "o1",
+        "name": "o1",
+        "reasoning": true
       },
       {
-        id: "o1-pro",
-        name: "o1-pro",
-        reasoning: true,
+        "id": "o1-pro",
+        "name": "o1-pro",
+        "reasoning": true
       },
       {
-        id: "o3",
-        name: "o3",
-        reasoning: true,
+        "id": "o3",
+        "name": "o3",
+        "reasoning": true
       },
       {
-        id: "o3-deep-research",
-        name: "o3-deep-research",
-        reasoning: true,
+        "id": "o3-deep-research",
+        "name": "o3-deep-research",
+        "reasoning": true
       },
       {
-        id: "o3-mini",
-        name: "o3-mini",
-        reasoning: true,
+        "id": "o3-mini",
+        "name": "o3-mini",
+        "reasoning": true
       },
       {
-        id: "o3-pro",
-        name: "o3-pro",
-        reasoning: true,
+        "id": "o3-pro",
+        "name": "o3-pro",
+        "reasoning": true
       },
       {
-        id: "o4-mini",
-        name: "o4-mini",
-        reasoning: true,
+        "id": "o4-mini",
+        "name": "o4-mini",
+        "reasoning": true
       },
       {
-        id: "o4-mini-deep-research",
-        name: "o4-mini-deep-research",
-        reasoning: true,
-      },
-    ],
+        "id": "o4-mini-deep-research",
+        "name": "o4-mini-deep-research",
+        "reasoning": true
+      }
+    ]
   },
-  google: {
-    defaultModel: "gemini-2.5-flash",
-    models: [
+  "google": {
+    "defaultModel": "gemini-2.5-flash",
+    "models": [
       {
-        id: "gemini-1.5-flash",
-        name: "Gemini 1.5 Flash",
-        reasoning: false,
+        "id": "gemini-1.5-flash",
+        "name": "Gemini 1.5 Flash",
+        "reasoning": false
       },
       {
-        id: "gemini-1.5-flash-8b",
-        name: "Gemini 1.5 Flash-8B",
-        reasoning: false,
+        "id": "gemini-1.5-flash-8b",
+        "name": "Gemini 1.5 Flash-8B",
+        "reasoning": false
       },
       {
-        id: "gemini-1.5-pro",
-        name: "Gemini 1.5 Pro",
-        reasoning: false,
+        "id": "gemini-1.5-pro",
+        "name": "Gemini 1.5 Pro",
+        "reasoning": false
       },
       {
-        id: "gemini-2.0-flash",
-        name: "Gemini 2.0 Flash",
-        reasoning: false,
+        "id": "gemini-2.0-flash",
+        "name": "Gemini 2.0 Flash",
+        "reasoning": false
       },
       {
-        id: "gemini-2.0-flash-lite",
-        name: "Gemini 2.0 Flash Lite",
-        reasoning: false,
+        "id": "gemini-2.0-flash-lite",
+        "name": "Gemini 2.0 Flash Lite",
+        "reasoning": false
       },
       {
-        id: "gemini-2.5-flash",
-        name: "Gemini 2.5 Flash",
-        reasoning: true,
+        "id": "gemini-2.5-flash",
+        "name": "Gemini 2.5 Flash",
+        "reasoning": true
       },
       {
-        id: "gemini-2.5-flash-lite",
-        name: "Gemini 2.5 Flash Lite",
-        reasoning: true,
+        "id": "gemini-2.5-flash-lite",
+        "name": "Gemini 2.5 Flash Lite",
+        "reasoning": true
       },
       {
-        id: "gemini-2.5-pro",
-        name: "Gemini 2.5 Pro",
-        reasoning: true,
+        "id": "gemini-2.5-pro",
+        "name": "Gemini 2.5 Pro",
+        "reasoning": true
       },
       {
-        id: "gemini-3-flash-preview",
-        name: "Gemini 3 Flash Preview",
-        reasoning: true,
+        "id": "gemini-3-flash-preview",
+        "name": "Gemini 3 Flash Preview",
+        "reasoning": true
       },
       {
-        id: "gemini-3-pro-preview",
-        name: "Gemini 3 Pro Preview",
-        reasoning: true,
+        "id": "gemini-3-pro-preview",
+        "name": "Gemini 3 Pro Preview",
+        "reasoning": true
       },
       {
-        id: "gemini-3.1-flash-lite-preview",
-        name: "Gemini 3.1 Flash Lite Preview",
-        reasoning: true,
+        "id": "gemini-3.1-flash-lite-preview",
+        "name": "Gemini 3.1 Flash Lite Preview",
+        "reasoning": true
       },
       {
-        id: "gemini-3.1-pro-preview",
-        name: "Gemini 3.1 Pro Preview",
-        reasoning: true,
+        "id": "gemini-3.1-pro-preview",
+        "name": "Gemini 3.1 Pro Preview",
+        "reasoning": true
       },
       {
-        id: "gemini-3.1-pro-preview-customtools",
-        name: "Gemini 3.1 Pro Preview Custom Tools",
-        reasoning: true,
+        "id": "gemini-3.1-pro-preview-customtools",
+        "name": "Gemini 3.1 Pro Preview Custom Tools",
+        "reasoning": true
       },
       {
-        id: "gemini-flash-latest",
-        name: "Gemini Flash Latest",
-        reasoning: true,
+        "id": "gemini-flash-latest",
+        "name": "Gemini Flash Latest",
+        "reasoning": true
       },
       {
-        id: "gemini-flash-lite-latest",
-        name: "Gemini Flash-Lite Latest",
-        reasoning: true,
+        "id": "gemini-flash-lite-latest",
+        "name": "Gemini Flash-Lite Latest",
+        "reasoning": true
       },
       {
-        id: "gemini-live-2.5-flash",
-        name: "Gemini Live 2.5 Flash",
-        reasoning: true,
+        "id": "gemini-live-2.5-flash",
+        "name": "Gemini Live 2.5 Flash",
+        "reasoning": true
       },
       {
-        id: "gemini-live-2.5-flash-preview-native-audio",
-        name: "Gemini Live 2.5 Flash Preview Native Audio",
-        reasoning: true,
-      },
-    ],
+        "id": "gemini-live-2.5-flash-preview-native-audio",
+        "name": "Gemini Live 2.5 Flash Preview Native Audio",
+        "reasoning": true
+      }
+    ]
   },
-  copilot: {
-    defaultModel: "gpt-4.1",
-    models: [
+  "copilot": {
+    "defaultModel": "gpt-4.1",
+    "models": [
       {
-        id: "gemini-2.5-pro",
-        name: "Gemini 2.5 Pro",
-        reasoning: false,
+        "id": "gemini-2.5-pro",
+        "name": "Gemini 2.5 Pro",
+        "reasoning": false
       },
       {
-        id: "gpt-4.1",
-        name: "GPT-4.1",
-        reasoning: false,
+        "id": "gpt-4.1",
+        "name": "GPT-4.1",
+        "reasoning": false
       },
       {
-        id: "gpt-4o",
-        name: "GPT-4o",
-        reasoning: false,
+        "id": "gpt-4o",
+        "name": "GPT-4o",
+        "reasoning": false
       },
       {
-        id: "claude-haiku-4.5",
-        name: "Claude Haiku 4.5",
-        reasoning: true,
+        "id": "claude-haiku-4.5",
+        "name": "Claude Haiku 4.5",
+        "reasoning": true
       },
       {
-        id: "claude-opus-4.5",
-        name: "Claude Opus 4.5",
-        reasoning: true,
+        "id": "claude-opus-4.5",
+        "name": "Claude Opus 4.5",
+        "reasoning": true
       },
       {
-        id: "claude-opus-4.6",
-        name: "Claude Opus 4.6",
-        reasoning: true,
+        "id": "claude-opus-4.6",
+        "name": "Claude Opus 4.6",
+        "reasoning": true
       },
       {
-        id: "claude-sonnet-4",
-        name: "Claude Sonnet 4",
-        reasoning: true,
+        "id": "claude-sonnet-4",
+        "name": "Claude Sonnet 4",
+        "reasoning": true
       },
       {
-        id: "claude-sonnet-4.5",
-        name: "Claude Sonnet 4.5",
-        reasoning: true,
+        "id": "claude-sonnet-4.5",
+        "name": "Claude Sonnet 4.5",
+        "reasoning": true
       },
       {
-        id: "claude-sonnet-4.6",
-        name: "Claude Sonnet 4.6",
-        reasoning: true,
+        "id": "claude-sonnet-4.6",
+        "name": "Claude Sonnet 4.6",
+        "reasoning": true
       },
       {
-        id: "gemini-3-flash-preview",
-        name: "Gemini 3 Flash",
-        reasoning: true,
+        "id": "gemini-3-flash-preview",
+        "name": "Gemini 3 Flash",
+        "reasoning": true
       },
       {
-        id: "gemini-3-pro-preview",
-        name: "Gemini 3 Pro Preview",
-        reasoning: true,
+        "id": "gemini-3-pro-preview",
+        "name": "Gemini 3 Pro Preview",
+        "reasoning": true
       },
       {
-        id: "gemini-3.1-pro-preview",
-        name: "Gemini 3.1 Pro Preview",
-        reasoning: true,
+        "id": "gemini-3.1-pro-preview",
+        "name": "Gemini 3.1 Pro Preview",
+        "reasoning": true
       },
       {
-        id: "gpt-5",
-        name: "GPT-5",
-        reasoning: true,
+        "id": "gpt-5",
+        "name": "GPT-5",
+        "reasoning": true
       },
       {
-        id: "gpt-5-mini",
-        name: "GPT-5-mini",
-        reasoning: true,
+        "id": "gpt-5-mini",
+        "name": "GPT-5-mini",
+        "reasoning": true
       },
       {
-        id: "gpt-5.1",
-        name: "GPT-5.1",
-        reasoning: true,
+        "id": "gpt-5.1",
+        "name": "GPT-5.1",
+        "reasoning": true
       },
       {
-        id: "gpt-5.2",
-        name: "GPT-5.2",
-        reasoning: true,
+        "id": "gpt-5.2",
+        "name": "GPT-5.2",
+        "reasoning": true
       },
       {
-        id: "gpt-5.4",
-        name: "GPT-5.4",
-        reasoning: true,
+        "id": "gpt-5.4",
+        "name": "GPT-5.4",
+        "reasoning": true
       },
       {
-        id: "gpt-5.4-mini",
-        name: "GPT-5.4 Mini",
-        reasoning: true,
+        "id": "gpt-5.4-mini",
+        "name": "GPT-5.4 Mini",
+        "reasoning": true
       },
       {
-        id: "grok-code-fast-1",
-        name: "Grok Code Fast 1",
-        reasoning: true,
-      },
-    ],
+        "id": "grok-code-fast-1",
+        "name": "Grok Code Fast 1",
+        "reasoning": true
+      }
+    ]
   },
   "kimi-coding": {
-    defaultModel: "k2p5",
-    models: [
+    "defaultModel": "k2p5",
+    "models": [
       {
-        id: "k2p5",
-        name: "Kimi K2.5",
-        reasoning: true,
+        "id": "k2p5",
+        "name": "Kimi K2.5",
+        "reasoning": true
       },
       {
-        id: "kimi-k2-thinking",
-        name: "Kimi K2 Thinking",
-        reasoning: true,
-      },
-    ],
+        "id": "kimi-k2-thinking",
+        "name": "Kimi K2 Thinking",
+        "reasoning": true
+      }
+    ]
   },
-  zai: {
-    defaultModel: "glm-5.1",
-    models: [
+  "zai": {
+    "defaultModel": "glm-5.1",
+    "models": [
       {
-        id: "glm-4.5",
-        name: "GLM-4.5",
-        reasoning: true,
+        "id": "glm-4.5",
+        "name": "GLM-4.5",
+        "reasoning": true
       },
       {
-        id: "glm-4.5-air",
-        name: "GLM-4.5-Air",
-        reasoning: true,
+        "id": "glm-4.5-air",
+        "name": "GLM-4.5-Air",
+        "reasoning": true
       },
       {
-        id: "glm-4.5-flash",
-        name: "GLM-4.5-Flash",
-        reasoning: true,
+        "id": "glm-4.5-flash",
+        "name": "GLM-4.5-Flash",
+        "reasoning": true
       },
       {
-        id: "glm-4.5v",
-        name: "GLM-4.5V",
-        reasoning: true,
+        "id": "glm-4.5v",
+        "name": "GLM-4.5V",
+        "reasoning": true
       },
       {
-        id: "glm-4.6",
-        name: "GLM-4.6",
-        reasoning: true,
+        "id": "glm-4.6",
+        "name": "GLM-4.6",
+        "reasoning": true
       },
       {
-        id: "glm-4.6v",
-        name: "GLM-4.6V",
-        reasoning: true,
+        "id": "glm-4.6v",
+        "name": "GLM-4.6V",
+        "reasoning": true
       },
       {
-        id: "glm-4.7",
-        name: "GLM-4.7",
-        reasoning: true,
+        "id": "glm-4.7",
+        "name": "GLM-4.7",
+        "reasoning": true
       },
       {
-        id: "glm-4.7-flash",
-        name: "GLM-4.7-Flash",
-        reasoning: true,
+        "id": "glm-4.7-flash",
+        "name": "GLM-4.7-Flash",
+        "reasoning": true
       },
       {
-        id: "glm-4.7-flashx",
-        name: "GLM-4.7-FlashX",
-        reasoning: true,
+        "id": "glm-4.7-flashx",
+        "name": "GLM-4.7-FlashX",
+        "reasoning": true
       },
       {
-        id: "glm-5",
-        name: "GLM-5",
-        reasoning: true,
+        "id": "glm-5",
+        "name": "GLM-5",
+        "reasoning": true
       },
       {
-        id: "glm-5-turbo",
-        name: "GLM-5-Turbo",
-        reasoning: true,
+        "id": "glm-5-turbo",
+        "name": "GLM-5-Turbo",
+        "reasoning": true
       },
       {
-        id: "glm-5.1",
-        name: "GLM-5.1",
-        reasoning: true,
+        "id": "glm-5.1",
+        "name": "GLM-5.1",
+        "reasoning": true
       },
       {
-        id: "glm-5v-turbo",
-        name: "glm-5v-turbo",
-        reasoning: true,
-      },
-    ],
+        "id": "glm-5v-turbo",
+        "name": "glm-5v-turbo",
+        "reasoning": true
+      }
+    ]
   },
   "zai-coding": {
-    defaultModel: "glm-5.1",
-    models: [
+    "defaultModel": "glm-5.1",
+    "models": [
       {
-        id: "glm-4.5",
-        name: "GLM-4.5",
-        reasoning: true,
+        "id": "glm-4.5",
+        "name": "GLM-4.5",
+        "reasoning": true
       },
       {
-        id: "glm-4.5-air",
-        name: "GLM-4.5-Air",
-        reasoning: true,
+        "id": "glm-4.5-air",
+        "name": "GLM-4.5-Air",
+        "reasoning": true
       },
       {
-        id: "glm-4.5-flash",
-        name: "GLM-4.5-Flash",
-        reasoning: true,
+        "id": "glm-4.5-flash",
+        "name": "GLM-4.5-Flash",
+        "reasoning": true
       },
       {
-        id: "glm-4.5v",
-        name: "GLM-4.5V",
-        reasoning: true,
+        "id": "glm-4.5v",
+        "name": "GLM-4.5V",
+        "reasoning": true
       },
       {
-        id: "glm-4.6",
-        name: "GLM-4.6",
-        reasoning: true,
+        "id": "glm-4.6",
+        "name": "GLM-4.6",
+        "reasoning": true
       },
       {
-        id: "glm-4.6v",
-        name: "GLM-4.6V",
-        reasoning: true,
+        "id": "glm-4.6v",
+        "name": "GLM-4.6V",
+        "reasoning": true
       },
       {
-        id: "glm-4.7",
-        name: "GLM-4.7",
-        reasoning: true,
+        "id": "glm-4.7",
+        "name": "GLM-4.7",
+        "reasoning": true
       },
       {
-        id: "glm-4.7-flash",
-        name: "GLM-4.7-Flash",
-        reasoning: true,
+        "id": "glm-4.7-flash",
+        "name": "GLM-4.7-Flash",
+        "reasoning": true
       },
       {
-        id: "glm-4.7-flashx",
-        name: "GLM-4.7-FlashX",
-        reasoning: true,
+        "id": "glm-4.7-flashx",
+        "name": "GLM-4.7-FlashX",
+        "reasoning": true
       },
       {
-        id: "glm-5",
-        name: "GLM-5",
-        reasoning: true,
+        "id": "glm-5",
+        "name": "GLM-5",
+        "reasoning": true
       },
       {
-        id: "glm-5-turbo",
-        name: "GLM-5-Turbo",
-        reasoning: true,
+        "id": "glm-5-turbo",
+        "name": "GLM-5-Turbo",
+        "reasoning": true
       },
       {
-        id: "glm-5.1",
-        name: "GLM-5.1",
-        reasoning: true,
+        "id": "glm-5.1",
+        "name": "GLM-5.1",
+        "reasoning": true
       },
       {
-        id: "glm-5v-turbo",
-        name: "glm-5v-turbo",
-        reasoning: true,
-      },
-    ],
-  },
+        "id": "glm-5v-turbo",
+        "name": "glm-5v-turbo",
+        "reasoning": true
+      }
+    ]
+  }
 } as const;

--- a/src/sidepanel/App.tsx
+++ b/src/sidepanel/App.tsx
@@ -203,9 +203,14 @@ export function App({ windowId }: { windowId: number }) {
 
     const unsubUpdate = browserExecutor.onTabUpdated(async (_tabId, url) => {
       await refreshTab();
-      if (useStore.getState().isStreaming && url && !isExcludedUrl(url)) {
-        const tab = useStore.getState().currentTab;
-        useStore.getState().addNavigationMessage({
+      // ストリーミング中のナビゲーションメッセージ:
+      // - AI が navigate/repl ツールで遷移した場合 (isToolNavigating=true) → 抑制
+      //   AI はツール結果から遷移先を既に把握しており、再通知するとループの原因になる
+      // - ユーザーが手動で遷移した場合 (isToolNavigating=false) → 通知する
+      const state = useStore.getState();
+      if (state.isStreaming && !state.isToolNavigating && url && !isExcludedUrl(url)) {
+        const tab = state.currentTab;
+        state.addNavigationMessage({
           url,
           title: tab.title || getHostname(url),
         });

--- a/src/sidepanel/hooks/use-agent.ts
+++ b/src/sidepanel/hooks/use-agent.ts
@@ -190,6 +190,7 @@ export function useAgent() {
           addErrorMessage: (e) => useStore.getState().addErrorMessage(e),
           syncHistory: (msgs) => useStore.getState().syncHistory(msgs),
           getMessages: () => useStore.getState().messages,
+          setToolNavigating: (v) => useStore.getState().setToolNavigating(v),
         },
         settings: {
           provider: settings.provider,

--- a/src/sidepanel/ui-store.ts
+++ b/src/sidepanel/ui-store.ts
@@ -5,6 +5,7 @@ import type { AppStore, TabInfo } from "@/store/types";
 export interface UISlice {
   settingsOpen: boolean;
   artifactPanelOpen: boolean;
+  isToolNavigating: boolean;
   currentTab: TabInfo;
   tab: TabInfo;
   pendingScreenshot: string | null;
@@ -15,6 +16,7 @@ export interface UISlice {
   toggleSettings(): void;
   setArtifactPanelOpen(v: boolean): void;
   toggleArtifactPanel(): void;
+  setToolNavigating(v: boolean): void;
   setTab(tab: TabInfo): void;
   setPendingScreenshot(s: string | null): void;
   setTheme(t: ColorScheme): void;
@@ -26,6 +28,7 @@ const DEFAULT_TAB: TabInfo = { id: null, url: "", title: "" };
 export const createUISlice: StateCreator<AppStore, [], [], UISlice> = (set, get) => ({
   settingsOpen: false,
   artifactPanelOpen: false,
+  isToolNavigating: false,
   currentTab: DEFAULT_TAB,
   tab: DEFAULT_TAB,
   pendingScreenshot: null,
@@ -36,6 +39,7 @@ export const createUISlice: StateCreator<AppStore, [], [], UISlice> = (set, get)
   toggleSettings: () => set({ settingsOpen: !get().settingsOpen }),
   setArtifactPanelOpen: (v) => set({ artifactPanelOpen: v }),
   toggleArtifactPanel: () => set({ artifactPanelOpen: !get().artifactPanelOpen }),
+  setToolNavigating: (v) => set({ isToolNavigating: v }),
   setTab: (tab) => set({ currentTab: tab, tab }),
   setPendingScreenshot: (s) => set({ pendingScreenshot: s }),
   setTheme: (t) => set({ theme: t }),


### PR DESCRIPTION
## Summary

- AIがSPAサイトで同じページを往復し続ける無限ループ問題を修正
- `bg_fetch` でSPA/CSRサイトを検出し、同一ドメインへの再利用を抑制
- `offscreen.html` の `type="module"` 欠落を修正（既存バグ）

## 変更内容

### ナビゲーションループ防止
- **`App.tsx`**: ストリーミング中の`onTabUpdated`でAI起因の遷移（`isToolNavigating=true`）のみ`[ページ遷移]`メッセージを抑制。ユーザー手動遷移は従来通り通知
- **`ui-store.ts`**: `isToolNavigating` フラグを UISlice に追加
- **`agent-loop.ts`**: `ChatActions` インターフェース経由で `setToolNavigating` を操作。navigate/repl 実行前に true、完了後に500ms遅延で false（SPA初期ルーティング対応）。連続navigate時のタイマー競合防止付き
- **`agent-loop.ts`**: `trackVisitedUrl()` で訪問済みURLを追跡。再訪問時はAIへ警告 + UIにシステムメッセージ通知
- **`navigate.ts`**: ツール説明に再訪問禁止の注意書きを追加

### bg_fetch SPA検出
- **`bg-fetch.ts`**: readabilityモードでコンテンツが200文字未満の場合 `spaWarning` を結果に付加
- **`agent-loop.ts`**: `trackSpaDomainsFromBgFetch()` でSPA判定ドメインを追跡し、同一ドメインへの再bg_fetchに警告

### その他
- **`offscreen.html`**: `<script>` に `type="module"` 追加（ESM import エラー修正）
- **`models.generated.ts`**: モデル定義更新

## Test plan

- [x] `npm run build` 成功
- [x] 全899テスト通過
- [x] navigate ツールで同一URLに2回アクセス → 警告が resultStr に付加されることを確認
- [x] repl 経由の navigate でも同一URL追跡が動作することを確認
- [x] bg_fetch readability モードでSPAサイト → spaWarning 付加を確認
- [x] ストリーミング中のAI起因ナビゲーションで [ページ遷移] メッセージが抑制されることを確認
- [x] ユーザー手動遷移時は従来通り通知されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)