### PR TITLE
fix: ツール結果の長大表示にスクロール制限を追加

### DIFF
--- a/src/features/chat/ToolCallBlock.tsx
+++ b/src/features/chat/ToolCallBlock.tsx
@@ -4,7 +4,7 @@ import { ChevronDown, ChevronUp, FileCode, Globe, Image as ImageIcon, Terminal }
 import type { ToolCallInfo } from "@/ports/session-types";
 import { defaultConsoleLogService } from "./services/console-log";
 import { defaultToolRendererRegistry } from "./tool-renderers";
-import { ImageLightbox, ToolMessageContainer } from "./tool-renderers/components";
+import { ImageLightbox, ScrollableResult, ToolMessageContainer } from "./tool-renderers/components";
 import type { ToolRendererContext } from "./tool-renderers/types";
 
 export function formatArgs(args: Record<string, unknown> | unknown): string | null {
@@ -157,7 +157,9 @@ function GenericToolResult({ toolCall }: { toolCall: ToolCallInfo }) {
           <Text size="xs" fw={700} mb={6}>
             Result
           </Text>
-          <JsonValueNode value={parsedJson} />
+          <ScrollableResult>
+            <JsonValueNode value={parsedJson} />
+          </ScrollableResult>
         </Paper>
       ) : (
         <Text

--- a/src/features/chat/tool-renderers/components.tsx
+++ b/src/features/chat/tool-renderers/components.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type ReactNode } from "react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
 import {
   ActionIcon,
   Box,
@@ -266,6 +266,42 @@ async function downloadImageResource(imageUrl: string, filename: string): Promis
   document.body.removeChild(anchor);
 }
 
+export function ScrollableResult({ children }: { children: ReactNode }) {
+  const innerRef = useRef<HTMLDivElement>(null);
+  const [hasOverflow, setHasOverflow] = useState(false);
+
+  useEffect(() => {
+    const el = innerRef.current;
+    if (!el) return;
+    const check = () => setHasOverflow(el.scrollHeight > el.clientHeight + 4);
+    check();
+    const observer = new ResizeObserver(check);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [children]);
+
+  // Hide fade when scrolled to bottom
+  const handleScroll = () => {
+    const el = innerRef.current;
+    if (!el) return;
+    const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 8;
+    setHasOverflow(!atBottom && el.scrollHeight > el.clientHeight + 4);
+  };
+
+  return (
+    <div className="scrollable-result">
+      <div
+        ref={innerRef}
+        className={`scrollable-result-inner${hasOverflow ? " has-overflow" : ""}`}
+        onScroll={handleScroll}
+      >
+        {children}
+      </div>
+      <div className="scrollable-result-fade" />
+    </div>
+  );
+}
+
 function extractStreamingContent(inputDelta?: string): string {
   if (!inputDelta) return "";
 
@@ -459,15 +495,17 @@ function ReplRendererView({ toolCall, consoleLogService }: ToolRendererContext) 
           <Text size="xs" fw={700} mb={6}>
             Console / Output
           </Text>
-          {logEntries.map((entry) => (
-            <Text
-              key={entry.id}
-              size="xs"
-              style={{ whiteSpace: "pre-wrap", fontFamily: "monospace" }}
-            >
-              {entry.message}
-            </Text>
-          ))}
+          <ScrollableResult>
+            {logEntries.map((entry) => (
+              <Text
+                key={entry.id}
+                size="xs"
+                style={{ whiteSpace: "pre-wrap", fontFamily: "monospace" }}
+              >
+                {entry.message}
+              </Text>
+            ))}
+          </ScrollableResult>
         </Paper>
       )}
 
@@ -476,7 +514,9 @@ function ReplRendererView({ toolCall, consoleLogService }: ToolRendererContext) 
           <Text size="xs" fw={700} mb={6}>
             Return Value
           </Text>
-          <JsonValue value={parsed.returnValue} />
+          <ScrollableResult>
+            <JsonValue value={parsed.returnValue} />
+          </ScrollableResult>
         </Paper>
       )}
 

--- a/src/sidepanel/styles.css
+++ b/src/sidepanel/styles.css
@@ -254,6 +254,38 @@ body,
   }
 }
 
+/* Scrollable result container with bottom fade hint */
+.scrollable-result {
+  position: relative;
+}
+
+.scrollable-result-inner {
+  max-height: 200px;
+  overflow-y: auto;
+  scrollbar-width: thin;
+}
+
+.scrollable-result-fade {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 28px;
+  pointer-events: none;
+  background: linear-gradient(
+    to bottom,
+    transparent,
+    var(--mantine-color-body)
+  );
+  border-radius: 0 0 var(--mantine-radius-md) var(--mantine-radius-md);
+  opacity: 0;
+  transition: opacity 0.15s ease;
+}
+
+.scrollable-result-inner.has-overflow ~ .scrollable-result-fade {
+  opacity: 1;
+}
+
 /* Tool running pulse animation */
 .tool-running {
   animation: toolPulse 1.5s ease-in-out infinite;


### PR DESCRIPTION
## Summary
- Console/Output、Return Value、構造化JSONにmaxHeight: 200pxのスクロールコンテナを適用
- 下端フェードグラデーションで「続きがある」ことを視覚的に提示
- スクロール末尾到達でフェードが自動消去

## Test plan
- [ ] REPLで長いconsole.logを出力し、200px程度でスクロールになることを確認
- [ ] 大きなオブジェクトのReturn Valueがスクロール制限されることを確認
- [ ] フェードグラデーションが下端に表示され、末尾までスクロールすると消えることを確認
- [ ] 短い結果ではスクロールバーやフェードが出ないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)