### PR TITLE
fix: 全スクロール可能コンテナにフェードヒントを統一適用

### DIFF
--- a/src/features/chat/ArtifactToolMessage.tsx
+++ b/src/features/chat/ArtifactToolMessage.tsx
@@ -2,6 +2,7 @@ import { useState, useRef } from "react";
 import { Box, Group, Text, ActionIcon, Paper, Badge } from "@mantine/core";
 import { FileCode, ChevronDown, FileText, Trash, Edit, Plus, Eye } from "lucide-react";
 import { CodeView } from "../artifacts/CodeView";
+import { ScrollableResult } from "./tool-renderers/components";
 
 interface ArtifactToolMessageProps {
   command?: "create" | "update" | "rewrite" | "get" | "delete" | "logs";
@@ -150,15 +151,15 @@ export function ArtifactToolMessage({
           ref={contentRef}
           style={{
             borderTop: `1px solid ${colors.border}`,
-            maxHeight: 500,
-            overflow: "auto",
           }}
         >
-          {isDiff ? (
-            <DiffView oldStr={old_str || ""} newStr={new_str || ""} />
-          ) : (
-            <CodeView content={content || result?.content || ""} filename={filename} />
-          )}
+          <ScrollableResult maxHeight={500}>
+            {isDiff ? (
+              <DiffView oldStr={old_str || ""} newStr={new_str || ""} />
+            ) : (
+              <CodeView content={content || result?.content || ""} filename={filename} />
+            )}
+          </ScrollableResult>
 
           {isError && result?.content && (
             <Box p="sm" style={{ background: "var(--mantine-color-red-light)" }}>

--- a/src/features/chat/ElementCard.tsx
+++ b/src/features/chat/ElementCard.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { ActionIcon, Code, Collapse, Group, Paper, Text, UnstyledButton } from "@mantine/core";
 import { ChevronDown, ChevronUp, MousePointer2, X } from "lucide-react";
+import { ScrollableResult } from "./tool-renderers/components";
 import type { ElementInfo } from "@/ports/browser-executor";
 
 export function ElementCard({
@@ -51,9 +52,11 @@ export function ElementCard({
             </Group>
           </UnstyledButton>
           <Collapse expanded={showDOM}>
-            <Code block style={{ fontSize: 12, maxHeight: 120, overflow: "auto" }} mt={4}>
-              {element.surroundingHTML}
-            </Code>
+            <ScrollableResult maxHeight={120}>
+              <Code block style={{ fontSize: 12 }} mt={4}>
+                {element.surroundingHTML}
+              </Code>
+            </ScrollableResult>
           </Collapse>
         </>
       )}

--- a/src/features/chat/ToolCallBlock.tsx
+++ b/src/features/chat/ToolCallBlock.tsx
@@ -237,9 +237,11 @@ export function ToolCallBlock({ tc }: { tc: ToolCallInfo }) {
       ) : (
         <>
           {argsStr && (
-            <Code block style={{ fontSize: 13, maxHeight: 150, overflow: "auto", marginBottom: 8 }}>
-              {argsStr}
-            </Code>
+            <ScrollableResult maxHeight={150}>
+              <Code block style={{ fontSize: 13 }}>
+                {argsStr}
+              </Code>
+            </ScrollableResult>
           )}
           {(tc.result || tc.isRunning) && <GenericToolResult toolCall={tc} />}
         </>

--- a/src/features/chat/tool-renderers/bg-fetch-renderer.tsx
+++ b/src/features/chat/tool-renderers/bg-fetch-renderer.tsx
@@ -15,6 +15,7 @@ import {
   ExternalLink,
   XCircle,
 } from "lucide-react";
+import { ScrollableResult } from "./components";
 import type { ToolRenderer, ToolRendererContext } from "./types";
 
 interface FetchResultItem {
@@ -164,22 +165,22 @@ function FetchResultCard({ item }: { item: FetchResultItem }) {
               radius="sm"
               style={{
                 background: "var(--mantine-color-default-hover)",
-                maxHeight: 200,
-                overflow: "auto",
               }}
             >
-              <Text
-                size="xs"
-                style={{
-                  whiteSpace: "pre-wrap",
-                  wordBreak: "break-word",
-                  fontFamily: "monospace",
-                }}
-              >
-                {typeof item.body === "string"
-                  ? item.body.substring(0, 2000)
-                  : JSON.stringify(item.body, null, 2).substring(0, 2000)}
-              </Text>
+              <ScrollableResult maxHeight={200}>
+                <Text
+                  size="xs"
+                  style={{
+                    whiteSpace: "pre-wrap",
+                    wordBreak: "break-word",
+                    fontFamily: "monospace",
+                  }}
+                >
+                  {typeof item.body === "string"
+                    ? item.body.substring(0, 2000)
+                    : JSON.stringify(item.body, null, 2).substring(0, 2000)}
+                </Text>
+              </ScrollableResult>
             </Paper>
           )}
 

--- a/src/features/chat/tool-renderers/components.tsx
+++ b/src/features/chat/tool-renderers/components.tsx
@@ -266,7 +266,13 @@ async function downloadImageResource(imageUrl: string, filename: string): Promis
   document.body.removeChild(anchor);
 }
 
-export function ScrollableResult({ children }: { children: ReactNode }) {
+export function ScrollableResult({
+  children,
+  maxHeight = 200,
+}: {
+  children: ReactNode;
+  maxHeight?: number;
+}) {
   const innerRef = useRef<HTMLDivElement>(null);
   const [hasOverflow, setHasOverflow] = useState(false);
 
@@ -293,6 +299,7 @@ export function ScrollableResult({ children }: { children: ReactNode }) {
       <div
         ref={innerRef}
         className={`scrollable-result-inner${hasOverflow ? " has-overflow" : ""}`}
+        style={{ maxHeight }}
         onScroll={handleScroll}
       >
         {children}

--- a/src/sidepanel/styles.css
+++ b/src/sidepanel/styles.css
@@ -260,7 +260,6 @@ body,
 }
 
 .scrollable-result-inner {
-  max-height: 200px;
   overflow-y: auto;
   scrollbar-width: thin;
 }


### PR DESCRIPTION
## Summary
- `ScrollableResult`に`maxHeight` propsを追加し、箇所ごとに適切な高さを指定可能に
- ツール引数(150px)、周辺DOM(120px)、アーティファクト(500px)、bg_fetchレスポンス(200px)の4箇所にフェード付きスクロールを適用
- CSSの固定`max-height`をinline styleに移行し柔軟性向上

## Test plan
- [ ] ツール引数が長い場合、150pxでスクロール+フェードが表示されること
- [ ] ElementCardの周辺DOMが120pxでスクロール+フェードが表示されること
- [ ] アーティファクトの長いコード表示が500pxでスクロール+フェードが表示されること
- [ ] bg_fetchレスポンスが200pxでスクロール+フェードが表示されること
- [ ] 各箇所でスクロール末尾到達時にフェードが消えること

🤖 Generated with [Claude Code](https://claude.com/claude-code)