### PR TITLE
fix: ScrollableResultのuseEffect無限ループを修正

### DIFF
--- a/src/features/chat/tool-renderers/components.tsx
+++ b/src/features/chat/tool-renderers/components.tsx
@@ -284,7 +284,7 @@ export function ScrollableResult({
     const observer = new ResizeObserver(check);
     observer.observe(el);
     return () => observer.disconnect();
-  }, [children]);
+  }, []);
 
   // Hide fade when scrolled to bottom
   const handleScroll = () => {


### PR DESCRIPTION
## Summary
- チャット結果出力中に発生していた React error #185 (Maximum update depth exceeded) を修正
- `ScrollableResult` の `useEffect` 依存配列から `children` を削除し、`ResizeObserver` のみでoverflow検知を行うように変更
- ReactNodeは毎レンダーで新参照になるため無限ループが発生していた

## Test plan
- [ ] チャットでツール結果がストリーミング表示される際にエラーが出ないことを確認
- [ ] スクロール可能なツール結果でフェードヒントが正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)