### PR TITLE
fix: provider別 AI 設定の復元と maxTokens 反映を修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sitesurf",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "AIと一緒にWebページを操作するChrome拡張機能",
   "license": "MIT",
   "bin": {

--- a/src/features/settings/__tests__/persistence.test.ts
+++ b/src/features/settings/__tests__/persistence.test.ts
@@ -23,9 +23,12 @@ describe("persistence", () => {
       enterpriseDomain: "",
       credentials: null,
       credentialsByProvider: {},
-      apiKeyByProvider: {},
-      baseUrlByProvider: {},
-      apiModeByProvider: {},
+      apiKeyByProvider: { anthropic: "sk-ant-test" },
+      baseUrlByProvider: { anthropic: "" },
+      apiModeByProvider: { anthropic: "auto" },
+      modelByProvider: { anthropic: "claude-sonnet-4-20250514" },
+      reasoningLevelByProvider: { anthropic: "medium" },
+      maxTokensByProvider: { anthropic: 8192 },
       reasoningLevel: "medium",
       maxTokens: 8192,
       enableMcpServer: false,
@@ -48,9 +51,12 @@ describe("persistence", () => {
       enterpriseDomain: "",
       credentials: null,
       credentialsByProvider: {},
-      apiKeyByProvider: {},
-      baseUrlByProvider: {},
-      apiModeByProvider: {},
+      apiKeyByProvider: { anthropic: "key1" },
+      baseUrlByProvider: { anthropic: "" },
+      apiModeByProvider: { anthropic: "auto" },
+      modelByProvider: { anthropic: "claude-sonnet-4-20250514" },
+      reasoningLevelByProvider: { anthropic: "medium" },
+      maxTokensByProvider: { anthropic: 8192 },
       reasoningLevel: "medium",
       maxTokens: 8192,
       enableMcpServer: false,
@@ -64,9 +70,12 @@ describe("persistence", () => {
       enterpriseDomain: "",
       credentials: null,
       credentialsByProvider: {},
-      apiKeyByProvider: {},
-      baseUrlByProvider: {},
-      apiModeByProvider: {},
+      apiKeyByProvider: { openai: "key2" },
+      baseUrlByProvider: { openai: "" },
+      apiModeByProvider: { openai: "auto" },
+      modelByProvider: { openai: "gpt-4o" },
+      reasoningLevelByProvider: { openai: "high" },
+      maxTokensByProvider: { openai: 8192 },
       reasoningLevel: "high",
       maxTokens: 8192,
       enableMcpServer: false,
@@ -77,5 +86,164 @@ describe("persistence", () => {
     const result = await loadSettings(storage);
 
     expect(result).toEqual(data2);
+  });
+
+  it("旧形式の単一値を現在の provider の map に移行する", async () => {
+    const storage = new InMemoryStorage();
+
+    await storage.set("sitesurf_settings", {
+      provider: "openai",
+      model: "gpt-4.1",
+      apiKey: "sk-test",
+      baseUrl: "",
+      apiMode: "auto",
+      enterpriseDomain: "",
+      credentials: null,
+      credentialsByProvider: {},
+      apiKeyByProvider: {},
+      baseUrlByProvider: {},
+      apiModeByProvider: {},
+      reasoningLevel: "high",
+      maxTokens: 32768,
+      enableMcpServer: false,
+    });
+
+    const result = await loadSettings(storage);
+
+    expect(result).toMatchObject({
+      provider: "openai",
+      model: "gpt-4.1",
+      credentials: null,
+      credentialsByProvider: {},
+      reasoningLevel: "high",
+      maxTokens: 32768,
+      modelByProvider: { openai: "gpt-4.1" },
+      reasoningLevelByProvider: { openai: "high" },
+      maxTokensByProvider: { openai: 32768 },
+    });
+  });
+
+  it("疎な legacy settings の credentials を現在 provider に移行する", async () => {
+    const storage = new InMemoryStorage();
+    const credentials = {
+      providerId: "openai",
+      accessToken: "token",
+      refreshToken: "refresh",
+      expiresAt: 123,
+      metadata: {},
+    };
+
+    await storage.set("sitesurf_settings", {
+      provider: "openai",
+      model: "gpt-4.1",
+      apiKey: "sk-test",
+      credentials,
+      reasoningLevel: "high",
+      maxTokens: 32768,
+      enableMcpServer: false,
+    });
+
+    const result = await loadSettings(storage);
+
+    expect(result).toMatchObject({
+      provider: "openai",
+      credentials,
+      credentialsByProvider: { openai: credentials },
+    });
+  });
+
+  it("現在 provider と一致しない credentials は restore しない", async () => {
+    const storage = new InMemoryStorage();
+    const credentials = {
+      providerId: "copilot",
+      accessToken: "token",
+      refreshToken: "refresh",
+      expiresAt: 123,
+      metadata: {},
+    };
+
+    await storage.set("sitesurf_settings", {
+      provider: "openai",
+      model: "gpt-4.1",
+      credentials,
+      credentialsByProvider: { openai: credentials },
+      enableMcpServer: false,
+    });
+
+    const result = await loadSettings(storage);
+
+    expect(result).toMatchObject({
+      provider: "openai",
+      credentials: null,
+      credentialsByProvider: {},
+    });
+  });
+
+  it("新旧形式が混在していても map の値を優先する", async () => {
+    const storage = new InMemoryStorage();
+
+    await storage.set("sitesurf_settings", {
+      provider: "openai",
+      model: "legacy-model",
+      apiKey: "sk-test",
+      baseUrl: "",
+      apiMode: "auto",
+      enterpriseDomain: "",
+      credentials: null,
+      credentialsByProvider: {},
+      apiKeyByProvider: {},
+      baseUrlByProvider: {},
+      apiModeByProvider: {},
+      modelByProvider: { openai: "gpt-4.1" },
+      reasoningLevelByProvider: { openai: "low" },
+      maxTokensByProvider: { openai: 4096 },
+      reasoningLevel: "high",
+      maxTokens: 32768,
+      enableMcpServer: false,
+    });
+
+    const result = await loadSettings(storage);
+
+    expect(result).toMatchObject({
+      provider: "openai",
+      model: "gpt-4.1",
+      reasoningLevel: "low",
+      maxTokens: 4096,
+      modelByProvider: { openai: "gpt-4.1" },
+      reasoningLevelByProvider: { openai: "low" },
+      maxTokensByProvider: { openai: 4096 },
+    });
+  });
+
+  it("provider map の model が空文字なら default model にフォールバックする", async () => {
+    const storage = new InMemoryStorage();
+
+    await storage.set("sitesurf_settings", {
+      provider: "anthropic",
+      model: "claude-opus-4-1",
+      apiKey: "sk-test",
+      baseUrl: "",
+      apiMode: "auto",
+      enterpriseDomain: "",
+      credentials: null,
+      credentialsByProvider: {},
+      apiKeyByProvider: {},
+      baseUrlByProvider: {},
+      apiModeByProvider: {},
+      modelByProvider: { anthropic: "" },
+      reasoningLevelByProvider: { anthropic: "medium" },
+      maxTokensByProvider: { anthropic: 8192 },
+      reasoningLevel: "medium",
+      maxTokens: 8192,
+      enableMcpServer: false,
+    });
+
+    const result = await loadSettings(storage);
+
+    expect(result).toMatchObject({
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+      modelByProvider: { anthropic: "" },
+    });
   });
 });

--- a/src/features/settings/persistence.ts
+++ b/src/features/settings/persistence.ts
@@ -1,24 +1,87 @@
 import type { StoragePort } from "@/ports/storage";
+import { PROVIDERS, type ProviderId } from "@/shared/constants";
 import type { Settings } from "./settings-store";
 import { DEFAULT_MAX_TOKENS } from "@/shared/token-constants";
 
 const STORAGE_KEY = "sitesurf_settings";
 const LEGACY_STORAGE_KEY = "tandemweb_settings";
 
+function resolveModel(model: string | undefined, fallback: string): string {
+  return model && model.length > 0 ? model : fallback;
+}
+
+function isProviderId(value: string): value is ProviderId {
+  return Object.hasOwn(PROVIDERS, value);
+}
+
+function matchesProvider(
+  credentials: Settings["credentials"] | undefined,
+  provider: ProviderId,
+): credentials is NonNullable<Settings["credentials"]> {
+  return credentials !== null && credentials !== undefined && credentials.providerId === provider;
+}
+
 export async function loadSettings(storage: StoragePort): Promise<Settings | null> {
   const raw =
     (await storage.get<Partial<Settings>>(STORAGE_KEY)) ??
     (await storage.get<Partial<Settings>>(LEGACY_STORAGE_KEY));
   if (!raw) return null;
+
+  const provider =
+    typeof raw.provider === "string" && isProviderId(raw.provider) ? raw.provider : "anthropic";
+  const credentialsByProvider = { ...raw.credentialsByProvider };
+  const apiKeyByProvider = { ...raw.apiKeyByProvider };
+  const baseUrlByProvider = { ...raw.baseUrlByProvider };
+  const apiModeByProvider = { ...raw.apiModeByProvider };
+  const modelByProvider = { ...raw.modelByProvider };
+  const reasoningLevelByProvider = { ...raw.reasoningLevelByProvider };
+  const maxTokensByProvider = { ...raw.maxTokensByProvider };
+
+  if (!matchesProvider(credentialsByProvider[provider], provider)) {
+    delete credentialsByProvider[provider];
+  }
+
+  if (credentialsByProvider[provider] === undefined && matchesProvider(raw.credentials, provider)) {
+    credentialsByProvider[provider] = raw.credentials;
+  }
+  if (apiKeyByProvider[provider] === undefined && raw.apiKey !== undefined) {
+    apiKeyByProvider[provider] = raw.apiKey;
+  }
+  if (baseUrlByProvider[provider] === undefined && raw.baseUrl !== undefined) {
+    baseUrlByProvider[provider] = raw.baseUrl;
+  }
+  if (apiModeByProvider[provider] === undefined && raw.apiMode !== undefined) {
+    apiModeByProvider[provider] = raw.apiMode;
+  }
+  if (modelByProvider[provider] === undefined && raw.model !== undefined) {
+    modelByProvider[provider] = raw.model;
+  }
+  if (reasoningLevelByProvider[provider] === undefined && raw.reasoningLevel !== undefined) {
+    reasoningLevelByProvider[provider] = raw.reasoningLevel;
+  }
+  if (maxTokensByProvider[provider] === undefined && raw.maxTokens !== undefined) {
+    maxTokensByProvider[provider] = raw.maxTokens;
+  }
+
   return {
-    ...raw,
-    apiMode: raw.apiMode ?? "auto",
-    apiKeyByProvider: raw.apiKeyByProvider ?? {},
-    baseUrlByProvider: raw.baseUrlByProvider ?? {},
-    apiModeByProvider: raw.apiModeByProvider ?? {},
-    maxTokens: raw.maxTokens ?? DEFAULT_MAX_TOKENS,
+    provider,
+    model: resolveModel(modelByProvider[provider] ?? raw.model, PROVIDERS[provider].defaultModel),
+    apiKey: apiKeyByProvider[provider] ?? raw.apiKey ?? "",
+    baseUrl: baseUrlByProvider[provider] ?? raw.baseUrl ?? "",
+    apiMode: apiModeByProvider[provider] ?? raw.apiMode ?? "auto",
+    enterpriseDomain: raw.enterpriseDomain ?? "",
+    credentials: credentialsByProvider[provider] ?? null,
+    credentialsByProvider,
+    apiKeyByProvider,
+    baseUrlByProvider,
+    apiModeByProvider,
+    modelByProvider,
+    reasoningLevelByProvider,
+    maxTokensByProvider,
+    reasoningLevel: reasoningLevelByProvider[provider] ?? raw.reasoningLevel ?? "medium",
+    maxTokens: maxTokensByProvider[provider] ?? raw.maxTokens ?? DEFAULT_MAX_TOKENS,
     enableMcpServer: raw.enableMcpServer ?? false,
-  } as Settings;
+  };
 }
 
 export async function saveSettings(storage: StoragePort, data: Settings): Promise<void> {

--- a/src/features/settings/settings-store.ts
+++ b/src/features/settings/settings-store.ts
@@ -1,5 +1,5 @@
 import type { StateCreator } from "zustand";
-import type { ProviderId } from "@/shared/constants";
+import { PROVIDERS, type ProviderId } from "@/shared/constants";
 import type { AuthCredentials } from "@/ports/auth-provider";
 import type { AppStore } from "@/store/types";
 import { DEFAULT_MAX_TOKENS } from "@/shared/token-constants";
@@ -21,6 +21,9 @@ export interface Settings {
   apiKeyByProvider: Partial<Record<ProviderId, string>>;
   baseUrlByProvider: Partial<Record<ProviderId, string>>;
   apiModeByProvider: Partial<Record<ProviderId, ApiMode>>;
+  modelByProvider: Partial<Record<ProviderId, string>>;
+  reasoningLevelByProvider: Partial<Record<ProviderId, ReasoningLevel>>;
+  maxTokensByProvider: Partial<Record<ProviderId, number>>;
   reasoningLevel: ReasoningLevel;
   maxTokens: number;
   enableMcpServer: boolean;
@@ -29,7 +32,12 @@ export interface Settings {
 export interface SettingsSlice {
   settings: Settings;
   setSettings(partial: Partial<Settings>): void;
+  hydrateSettings(settings: Settings): void;
   setCredentials(creds: AuthCredentials | null): void;
+}
+
+function resolveModel(model: string | undefined, fallback: string): string {
+  return model && model.length > 0 ? model : fallback;
 }
 
 export const createSettingsSlice: StateCreator<AppStore, [], [], SettingsSlice> = (set, _get) => ({
@@ -45,35 +53,63 @@ export const createSettingsSlice: StateCreator<AppStore, [], [], SettingsSlice> 
     apiKeyByProvider: {},
     baseUrlByProvider: {},
     apiModeByProvider: {},
+    modelByProvider: {},
+    reasoningLevelByProvider: {},
+    maxTokensByProvider: {},
     reasoningLevel: "medium",
     maxTokens: DEFAULT_MAX_TOKENS,
     enableMcpServer: false,
   },
   setSettings: (partial) =>
     set((s) => {
-      const next = { ...s.settings, ...partial };
       const currentProvider = s.settings.provider;
+      const targetProvider = partial.provider ?? currentProvider;
+      const next = { ...s.settings, ...partial };
 
-      if (partial.apiKey !== undefined) {
+      const providerChanged = targetProvider !== currentProvider;
+
+      if (!providerChanged && partial.apiKey !== undefined) {
         next.apiKeyByProvider = {
           ...next.apiKeyByProvider,
           [currentProvider]: partial.apiKey,
         };
+        next.apiKey = partial.apiKey;
       }
-      if (partial.baseUrl !== undefined) {
+      if (!providerChanged && partial.baseUrl !== undefined) {
         next.baseUrlByProvider = {
           ...next.baseUrlByProvider,
           [currentProvider]: partial.baseUrl,
         };
+        next.baseUrl = partial.baseUrl;
       }
-      if (partial.apiMode !== undefined) {
+      if (!providerChanged && partial.apiMode !== undefined) {
         next.apiModeByProvider = {
           ...next.apiModeByProvider,
           [currentProvider]: partial.apiMode,
         };
+        next.apiMode = partial.apiMode;
+      }
+      if (!providerChanged && partial.model !== undefined) {
+        next.modelByProvider = {
+          ...next.modelByProvider,
+          [currentProvider]: partial.model,
+        };
+        next.model = resolveModel(partial.model, PROVIDERS[currentProvider].defaultModel);
+      }
+      if (!providerChanged && partial.reasoningLevel !== undefined) {
+        next.reasoningLevelByProvider = {
+          ...next.reasoningLevelByProvider,
+          [currentProvider]: partial.reasoningLevel,
+        };
+      }
+      if (!providerChanged && partial.maxTokens !== undefined) {
+        next.maxTokensByProvider = {
+          ...next.maxTokensByProvider,
+          [currentProvider]: partial.maxTokens,
+        };
       }
 
-      if (partial.provider && partial.provider !== currentProvider) {
+      if (providerChanged) {
         const prevProvider = currentProvider;
         next.apiKeyByProvider = {
           ...next.apiKeyByProvider,
@@ -87,13 +123,81 @@ export const createSettingsSlice: StateCreator<AppStore, [], [], SettingsSlice> 
           ...next.apiModeByProvider,
           [prevProvider]: s.settings.apiMode,
         };
-        next.apiKey = next.apiKeyByProvider[partial.provider] ?? "";
-        next.baseUrl = next.baseUrlByProvider[partial.provider] ?? "";
-        next.apiMode = next.apiModeByProvider[partial.provider] ?? "auto";
-        next.credentials = next.credentialsByProvider[partial.provider] ?? null;
+        if (s.settings.model.length > 0) {
+          next.modelByProvider = {
+            ...next.modelByProvider,
+            [prevProvider]: s.settings.model,
+          };
+        }
+        next.reasoningLevelByProvider = {
+          ...next.reasoningLevelByProvider,
+          [prevProvider]: s.settings.reasoningLevel,
+        };
+        next.maxTokensByProvider = {
+          ...next.maxTokensByProvider,
+          [prevProvider]: s.settings.maxTokens,
+        };
+
+        next.apiKey = partial.apiKey ?? next.apiKeyByProvider[targetProvider] ?? "";
+        next.baseUrl = partial.baseUrl ?? next.baseUrlByProvider[targetProvider] ?? "";
+        next.apiMode = partial.apiMode ?? next.apiModeByProvider[targetProvider] ?? "auto";
+        next.credentials = next.credentialsByProvider[targetProvider] ?? null;
+
+        next.model = resolveModel(
+          next.modelByProvider[targetProvider] ?? partial.model,
+          PROVIDERS[targetProvider].defaultModel,
+        );
+        next.reasoningLevel =
+          next.reasoningLevelByProvider[targetProvider] ?? partial.reasoningLevel ?? "medium";
+        next.maxTokens =
+          next.maxTokensByProvider[targetProvider] ?? partial.maxTokens ?? DEFAULT_MAX_TOKENS;
+
+        if (partial.apiKey !== undefined) {
+          next.apiKeyByProvider = {
+            ...next.apiKeyByProvider,
+            [targetProvider]: partial.apiKey,
+          };
+        }
+        if (partial.baseUrl !== undefined) {
+          next.baseUrlByProvider = {
+            ...next.baseUrlByProvider,
+            [targetProvider]: partial.baseUrl,
+          };
+        }
+        if (partial.apiMode !== undefined) {
+          next.apiModeByProvider = {
+            ...next.apiModeByProvider,
+            [targetProvider]: partial.apiMode,
+          };
+        }
+        if (partial.model !== undefined && next.modelByProvider[targetProvider] === undefined) {
+          next.modelByProvider = {
+            ...next.modelByProvider,
+            [targetProvider]: partial.model,
+          };
+        }
+        if (
+          partial.reasoningLevel !== undefined &&
+          next.reasoningLevelByProvider[targetProvider] === undefined
+        ) {
+          next.reasoningLevelByProvider = {
+            ...next.reasoningLevelByProvider,
+            [targetProvider]: partial.reasoningLevel,
+          };
+        }
+        if (
+          partial.maxTokens !== undefined &&
+          next.maxTokensByProvider[targetProvider] === undefined
+        ) {
+          next.maxTokensByProvider = {
+            ...next.maxTokensByProvider,
+            [targetProvider]: partial.maxTokens,
+          };
+        }
       }
       return { settings: next };
     }),
+  hydrateSettings: (settings) => set({ settings }),
   setCredentials: (creds) =>
     set((s) => {
       const provider = s.settings.provider;

--- a/src/sidepanel/__tests__/initialize.test.ts
+++ b/src/sidepanel/__tests__/initialize.test.ts
@@ -1,0 +1,140 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { initializeApp } from "../initialize";
+import { initStore, useStore } from "@/store";
+import { InMemoryArtifactStorage, InMemoryStorage } from "@/adapters/storage/in-memory-storage";
+import type { AppDeps } from "@/shared/deps-context";
+import type { AIProvider, StreamTextParams } from "@/ports/ai-provider";
+import type { BrowserExecutor, TabInfo } from "@/ports/browser-executor";
+import type { Result, BrowserError, ToolError } from "@/shared/errors";
+import type {
+  NavigationResult,
+  PageContent,
+  ScriptResult,
+  ElementInfo,
+} from "@/ports/browser-executor";
+import type { SessionStoragePort } from "@/ports/session-storage";
+
+vi.mock("@/shared/port", () => ({
+  initialize: vi.fn(async () => {}),
+  sendMessage: vi.fn(async (message: { sessionId: string }) => ({
+    type: "lockResult" as const,
+    sessionId: message.sessionId,
+    success: true,
+  })),
+}));
+
+class NoopAIProvider implements AIProvider {
+  streamText(_params: StreamTextParams): AsyncIterable<never> {
+    return {
+      async *[Symbol.asyncIterator]() {},
+    };
+  }
+}
+
+class NoopBrowserExecutor implements BrowserExecutor {
+  async getActiveTab(): Promise<TabInfo> {
+    return { id: 1, url: "https://example.com", title: "Example" };
+  }
+  async openTab(_url: string): Promise<number> {
+    return 1;
+  }
+  async navigateTo(_tabId: number, _url: string): Promise<Result<NavigationResult, BrowserError>> {
+    throw new Error("unused");
+  }
+  async captureScreenshot(): Promise<string> {
+    return "";
+  }
+  onTabActivated(_callback: (tabId: number) => void): () => void {
+    return () => {};
+  }
+  onTabUpdated(_callback: (tabId: number, url: string) => void): () => void {
+    return () => {};
+  }
+  onTabRemoved(_callback: (tabId: number) => void): () => void {
+    return () => {};
+  }
+  async readPageContent(
+    _tabId: number,
+    _maxDepth?: number,
+  ): Promise<Result<PageContent, BrowserError>> {
+    throw new Error("unused");
+  }
+  async executeScript(
+    _tabId: number,
+    _code: string,
+    _signal?: AbortSignal,
+  ): Promise<Result<ScriptResult, ToolError>> {
+    throw new Error("unused");
+  }
+  async injectElementPicker(
+    _tabId: number,
+    _message?: string,
+  ): Promise<Result<ElementInfo | null, BrowserError>> {
+    throw new Error("unused");
+  }
+}
+
+class NoopSessionStorage implements SessionStoragePort {
+  async listSessions() {
+    return [];
+  }
+  async getMetadata() {
+    return null;
+  }
+  async getLatestSessionId() {
+    return null;
+  }
+  async getSession() {
+    return null;
+  }
+  async saveSession() {}
+  async updateTitle() {}
+  async deleteSession() {}
+}
+
+function createDeps(storage: InMemoryStorage): AppDeps {
+  return {
+    createAIProvider: () => new NoopAIProvider(),
+    authProviders: {},
+    browserExecutor: new NoopBrowserExecutor(),
+    storage,
+    sessionStorage: new NoopSessionStorage(),
+    artifactStorage: new InMemoryArtifactStorage(),
+  };
+}
+
+describe("initializeApp", () => {
+  beforeEach(() => {
+    initStore(new InMemoryArtifactStorage());
+    useStore.setState(useStore.getInitialState());
+  });
+
+  it("読み込んだ settings を副作用なしで復元する", async () => {
+    const storage = new InMemoryStorage();
+    const loadedSettings = {
+      provider: "openai" as const,
+      model: "gpt-4.1",
+      apiKey: "sk-test",
+      baseUrl: "",
+      apiMode: "auto" as const,
+      enterpriseDomain: "",
+      credentials: null,
+      credentialsByProvider: {},
+      apiKeyByProvider: { openai: "sk-test" },
+      baseUrlByProvider: { openai: "" },
+      apiModeByProvider: { openai: "auto" },
+      modelByProvider: { openai: "gpt-4.1" },
+      reasoningLevelByProvider: { openai: "high" as const },
+      maxTokensByProvider: { openai: 8192 },
+      reasoningLevel: "high" as const,
+      maxTokens: 8192,
+      enableMcpServer: false,
+    };
+    await storage.set("sitesurf_settings", loadedSettings);
+
+    await initializeApp(createDeps(storage), 1);
+
+    expect(useStore.getState().settings).toEqual(loadedSettings);
+  });
+});

--- a/src/sidepanel/hooks/__tests__/use-agent.test.ts
+++ b/src/sidepanel/hooks/__tests__/use-agent.test.ts
@@ -1,0 +1,192 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useAgent } from "../use-agent";
+import { DepsProvider, type AppDeps } from "@/shared/deps-context";
+import { initStore, useStore } from "@/store";
+import { InMemoryArtifactStorage, InMemoryStorage } from "@/adapters/storage/in-memory-storage";
+import { SkillRegistry } from "@/shared/skill-registry";
+import type { AIProvider, StreamTextParams } from "@/ports/ai-provider";
+import type { BrowserExecutor, TabInfo } from "@/ports/browser-executor";
+import type { Result, BrowserError, ToolError } from "@/shared/errors";
+import type {
+  NavigationResult,
+  PageContent,
+  ScriptResult,
+  ElementInfo,
+} from "@/ports/browser-executor";
+import type { SessionStoragePort } from "@/ports/session-storage";
+
+const runAgentLoopMock = vi.fn(() => Promise.resolve());
+
+vi.mock("@/orchestration/agent-loop", () => ({
+  runAgentLoop: (params: unknown) => runAgentLoopMock(params),
+}));
+
+vi.mock("@/features/tools", () => ({
+  AGENT_TOOL_DEFS: [],
+  createToolExecutorWithSkills: vi.fn(() => vi.fn()),
+  loadSkillRegistry: vi.fn(async () => new SkillRegistry()),
+}));
+
+vi.mock("@/features/sessions/auto-save", () => ({
+  createAutoSaver: vi.fn(() => ({ saveImmediately: vi.fn() })),
+}));
+
+vi.mock("@/features/settings/skill-registry-sync", () => ({
+  subscribeSkillRegistryReload: vi.fn(() => () => {}),
+}));
+
+vi.mock("@/features/ai/system-prompt-v2", () => ({
+  getSystemPromptV2: vi.fn(() => "system-prompt"),
+}));
+
+vi.mock("@/shared/utils", () => ({
+  isExcludedUrl: vi.fn(() => false),
+  getLastKnownUrl: vi.fn(() => null),
+}));
+
+vi.mock("@/features/security/audit-logger", () => ({
+  createStorageBackedSecurityAuditLogger: vi.fn(() => ({})),
+}));
+
+vi.mock("@/features/security/middleware", () => ({
+  createSecurityMiddleware: vi.fn(() => ({})),
+}));
+
+class NoopAIProvider implements AIProvider {
+  streamText(_params: StreamTextParams): AsyncIterable<never> {
+    return {
+      async *[Symbol.asyncIterator]() {},
+    };
+  }
+}
+
+class NoopBrowserExecutor implements BrowserExecutor {
+  async getActiveTab(): Promise<TabInfo> {
+    return { id: 1, url: "https://example.com", title: "Example" };
+  }
+  async openTab(_url: string): Promise<number> {
+    return 1;
+  }
+  async navigateTo(_tabId: number, _url: string): Promise<Result<NavigationResult, BrowserError>> {
+    throw new Error("unused");
+  }
+  async captureScreenshot(): Promise<string> {
+    return "";
+  }
+  onTabActivated(_callback: (tabId: number) => void): () => void {
+    return () => {};
+  }
+  onTabUpdated(_callback: (tabId: number, url: string) => void): () => void {
+    return () => {};
+  }
+  onTabRemoved(_callback: (tabId: number) => void): () => void {
+    return () => {};
+  }
+  async readPageContent(
+    _tabId: number,
+    _maxDepth?: number,
+  ): Promise<Result<PageContent, BrowserError>> {
+    throw new Error("unused");
+  }
+  async executeScript(
+    _tabId: number,
+    _code: string,
+    _signal?: AbortSignal,
+  ): Promise<Result<ScriptResult, ToolError>> {
+    throw new Error("unused");
+  }
+  async injectElementPicker(
+    _tabId: number,
+    _message?: string,
+  ): Promise<Result<ElementInfo | null, BrowserError>> {
+    throw new Error("unused");
+  }
+}
+
+class NoopSessionStorage implements SessionStoragePort {
+  async listSessions() {
+    return [];
+  }
+  async getMetadata() {
+    return null;
+  }
+  async getLatestSessionId() {
+    return null;
+  }
+  async getSession() {
+    return null;
+  }
+  async saveSession() {}
+  async updateTitle() {}
+  async deleteSession() {}
+}
+
+function createDeps(storage: InMemoryStorage): AppDeps {
+  return {
+    createAIProvider: () => new NoopAIProvider(),
+    authProviders: {},
+    browserExecutor: new NoopBrowserExecutor(),
+    storage,
+    sessionStorage: new NoopSessionStorage(),
+    artifactStorage: new InMemoryArtifactStorage(),
+  };
+}
+
+describe("useAgent", () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+
+  beforeEach(() => {
+    runAgentLoopMock.mockClear();
+    initStore(new InMemoryArtifactStorage());
+    useStore.setState(useStore.getInitialState());
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("handleSend は maxTokens を agent loop に渡す", async () => {
+    const storage = new InMemoryStorage();
+    const deps = createDeps(storage);
+    let agent: ReturnType<typeof useAgent> | null = null;
+
+    function TestComponent() {
+      agent = useAgent();
+      return null;
+    }
+
+    useStore.getState().setSettings({
+      provider: "openai",
+      model: "gpt-4.1",
+      apiKey: "sk-test",
+      maxTokens: 12345,
+    });
+
+    await act(async () => {
+      root.render(createElement(DepsProvider, { value: deps }, createElement(TestComponent)));
+    });
+
+    await act(async () => {
+      await agent?.handleSend("hello");
+    });
+
+    expect(runAgentLoopMock).toHaveBeenCalledTimes(1);
+    expect(runAgentLoopMock.mock.calls[0]?.[0]).toMatchObject({
+      settings: {
+        provider: "openai",
+        model: "gpt-4.1",
+        maxTokens: 12345,
+      },
+    });
+  });
+});

--- a/src/sidepanel/hooks/use-agent.ts
+++ b/src/sidepanel/hooks/use-agent.ts
@@ -201,6 +201,7 @@ export function useAgent() {
           enterpriseDomain: settings.enterpriseDomain,
           oauthToken: credentials?.accessToken,
           reasoningLevel: settings.reasoningLevel,
+          maxTokens: settings.maxTokens,
         },
         session,
         tools: AGENT_TOOL_DEFS,

--- a/src/sidepanel/initialize.ts
+++ b/src/sidepanel/initialize.ts
@@ -49,7 +49,7 @@ async function restoreTheme(storage: AppDeps["storage"]): Promise<void> {
 async function restoreSettings(storage: AppDeps["storage"]): Promise<void> {
   const settings = await loadSettings(storage);
   if (settings) {
-    useStore.getState().setSettings(settings);
+    useStore.getState().hydrateSettings(settings);
   }
 }
 

--- a/src/store/__tests__/index.test.ts
+++ b/src/store/__tests__/index.test.ts
@@ -4,6 +4,7 @@ import type { AIMessage } from "@/ports/ai-provider";
 import { ok, err } from "@/shared/errors";
 import type { ToolError } from "@/shared/errors";
 import type { ArtifactStoragePort } from "@/ports/artifact-storage";
+import { DEFAULT_MAX_TOKENS } from "@/shared/token-constants";
 
 const mockArtifactStorage: ArtifactStoragePort & { setSessionId(id: string | null): void } = {
   createOrUpdate: async () => {},
@@ -262,6 +263,131 @@ describe("AppStore", () => {
       });
       useStore.getState().setCredentials(null);
       expect(useStore.getState().settings.credentials).toBeNull();
+    });
+
+    it("model・reasoningLevel・maxTokens を現在 provider の map に保存する", () => {
+      useStore.getState().setSettings({
+        model: "claude-opus-4-1",
+        reasoningLevel: "high",
+        maxTokens: 32768,
+      });
+
+      const s = useStore.getState().settings;
+      expect(s.model).toBe("claude-opus-4-1");
+      expect(s.reasoningLevel).toBe("high");
+      expect(s.maxTokens).toBe(32768);
+      expect(s.modelByProvider).toEqual({ anthropic: "claude-opus-4-1" });
+      expect(s.reasoningLevelByProvider).toEqual({ anthropic: "high" });
+      expect(s.maxTokensByProvider).toEqual({ anthropic: 32768 });
+    });
+
+    it("provider 切替時に保存済みの provider 別設定を復元する", () => {
+      useStore.getState().setSettings({
+        provider: "openai",
+        model: "gpt-4o",
+        reasoningLevel: "low",
+        maxTokens: 4096,
+      });
+      useStore
+        .getState()
+        .setSettings({ model: "gpt-4.1", reasoningLevel: "high", maxTokens: 8192 });
+
+      useStore.getState().setSettings({
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+        reasoningLevel: "medium",
+        maxTokens: 16384,
+      });
+      useStore.getState().setSettings({
+        model: "claude-opus-4-1",
+        reasoningLevel: "none",
+        maxTokens: 32768,
+      });
+
+      useStore.getState().setSettings({ provider: "openai", model: "gpt-5.4" });
+
+      const s = useStore.getState().settings;
+      expect(s.provider).toBe("openai");
+      expect(s.model).toBe("gpt-4.1");
+      expect(s.reasoningLevel).toBe("high");
+      expect(s.maxTokens).toBe(8192);
+    });
+
+    it("未設定の provider に切り替えたときは標準の既定値にフォールバックする", () => {
+      useStore.getState().setSettings({
+        model: "claude-opus-4-1",
+        reasoningLevel: "high",
+        maxTokens: 32768,
+      });
+
+      useStore.getState().setSettings({ provider: "google" });
+
+      const s = useStore.getState().settings;
+      expect(s.provider).toBe("google");
+      expect(s.model).toBe("gemini-2.5-flash");
+      expect(s.reasoningLevel).toBe("medium");
+      expect(s.maxTokens).toBe(DEFAULT_MAX_TOKENS);
+    });
+
+    it("空文字 model を保存した provider へ戻っても default model を使う", () => {
+      useStore.getState().setSettings({ provider: "openai", model: "gpt-4.1" });
+      useStore.getState().setSettings({ provider: "anthropic" });
+
+      const s = useStore.getState().settings;
+      expect(s.provider).toBe("anthropic");
+      expect(s.model).toBe("claude-sonnet-4-6");
+    });
+
+    it("同一 provider で model を空文字にしても runtime snapshot は default model を使う", () => {
+      useStore.getState().setSettings({ model: "" });
+
+      const s = useStore.getState().settings;
+      expect(s.provider).toBe("anthropic");
+      expect(s.model).toBe("claude-sonnet-4-6");
+    });
+
+    it("provider 切替と同時に渡した auth 系 partial を切替先に反映する", () => {
+      useStore.getState().setSettings({
+        provider: "openai",
+        apiKey: "sk-test",
+        baseUrl: "https://example.com/v1",
+        apiMode: "responses",
+      });
+
+      const s = useStore.getState().settings;
+      expect(s.provider).toBe("openai");
+      expect(s.apiKey).toBe("sk-test");
+      expect(s.baseUrl).toBe("https://example.com/v1");
+      expect(s.apiMode).toBe("responses");
+      expect(s.apiKeyByProvider).toEqual({ anthropic: "", openai: "sk-test" });
+      expect(s.baseUrlByProvider).toEqual({ anthropic: "", openai: "https://example.com/v1" });
+      expect(s.apiModeByProvider).toEqual({ anthropic: "auto", openai: "responses" });
+    });
+
+    it("hydrateSettings は読み込んだ settings を副作用なしでそのまま復元する", () => {
+      const loadedSettings = {
+        provider: "openai" as const,
+        model: "gpt-4.1",
+        apiKey: "sk-test",
+        baseUrl: "",
+        apiMode: "auto" as const,
+        enterpriseDomain: "",
+        credentials: null,
+        credentialsByProvider: {},
+        apiKeyByProvider: { openai: "sk-test" },
+        baseUrlByProvider: {},
+        apiModeByProvider: {},
+        modelByProvider: { openai: "gpt-4.1" },
+        reasoningLevelByProvider: { openai: "high" as const },
+        maxTokensByProvider: { openai: 8192 },
+        reasoningLevel: "high" as const,
+        maxTokens: 8192,
+        enableMcpServer: false,
+      };
+
+      useStore.getState().hydrateSettings(loadedSettings);
+
+      expect(useStore.getState().settings).toEqual(loadedSettings);
     });
   });
 


### PR DESCRIPTION
## Summary
- model・reasoningLevel・maxTokens を provider 別に保持できるよう settings store / persistence を更新し、旧保存形式の migration と hydrate 経路を安定化しました
- restore 時の empty model と credentials mismatch を正規化し、provider 切替時の auth 系 partial 反映も対称にそろえました
- use-agent から agent loop へ maxTokens を渡すようにして、実際の AI リクエストにも設定が反映されるようにしました

## Testing
- vp test src/sidepanel/hooks/__tests__/use-agent.test.ts src/features/settings/__tests__/persistence.test.ts src/store/__tests__/index.test.ts src/sidepanel/__tests__/initialize.test.ts
- vp check src/sidepanel/hooks/use-agent.ts src/sidepanel/hooks/__tests__/use-agent.test.ts
- vp build