### PR TITLE
feat: bg_fetch のON/OFF設定を追加

### DIFF
--- a/src/features/settings/SettingsPanel.tsx
+++ b/src/features/settings/SettingsPanel.tsx
@@ -325,6 +325,19 @@ export function SettingsPanel() {
               <Stack gap="md" pb="sm">
                 <div>
                   <Switch
+                    label="バックグラウンドフェッチを有効にする"
+                    description={
+                      settings.enableBgFetch
+                        ? "AIがWebページを直接取得できます"
+                        : "AIによるWebページの直接取得を無効化します"
+                    }
+                    checked={settings.enableBgFetch}
+                    onChange={(e) => setSettings({ enableBgFetch: e.currentTarget.checked })}
+                  />
+                </div>
+
+                <div>
+                  <Switch
                     label="MCP Server 接続を有効にする"
                     description={
                       settings.enableMcpServer

--- a/src/features/settings/__tests__/persistence.test.ts
+++ b/src/features/settings/__tests__/persistence.test.ts
@@ -32,6 +32,7 @@ describe("persistence", () => {
       reasoningLevel: "medium",
       maxTokens: 8192,
       enableMcpServer: false,
+      enableBgFetch: false,
     };
 
     await saveSettings(storage, data);
@@ -60,6 +61,7 @@ describe("persistence", () => {
       reasoningLevel: "medium",
       maxTokens: 8192,
       enableMcpServer: false,
+      enableBgFetch: false,
     };
     const data2: Settings = {
       provider: "openai",
@@ -79,6 +81,7 @@ describe("persistence", () => {
       reasoningLevel: "high",
       maxTokens: 8192,
       enableMcpServer: false,
+      enableBgFetch: false,
     };
 
     await saveSettings(storage, data1);
@@ -106,6 +109,7 @@ describe("persistence", () => {
       reasoningLevel: "high",
       maxTokens: 32768,
       enableMcpServer: false,
+      enableBgFetch: false,
     });
 
     const result = await loadSettings(storage);
@@ -141,6 +145,7 @@ describe("persistence", () => {
       reasoningLevel: "high",
       maxTokens: 32768,
       enableMcpServer: false,
+      enableBgFetch: false,
     });
 
     const result = await loadSettings(storage);
@@ -168,6 +173,7 @@ describe("persistence", () => {
       credentials,
       credentialsByProvider: { openai: credentials },
       enableMcpServer: false,
+      enableBgFetch: false,
     });
 
     const result = await loadSettings(storage);
@@ -200,6 +206,7 @@ describe("persistence", () => {
       reasoningLevel: "high",
       maxTokens: 32768,
       enableMcpServer: false,
+      enableBgFetch: false,
     });
 
     const result = await loadSettings(storage);
@@ -236,6 +243,7 @@ describe("persistence", () => {
       reasoningLevel: "medium",
       maxTokens: 8192,
       enableMcpServer: false,
+      enableBgFetch: false,
     });
 
     const result = await loadSettings(storage);

--- a/src/features/settings/persistence.ts
+++ b/src/features/settings/persistence.ts
@@ -81,6 +81,7 @@ export async function loadSettings(storage: StoragePort): Promise<Settings | nul
     reasoningLevel: reasoningLevelByProvider[provider] ?? raw.reasoningLevel ?? "medium",
     maxTokens: maxTokensByProvider[provider] ?? raw.maxTokens ?? DEFAULT_MAX_TOKENS,
     enableMcpServer: raw.enableMcpServer ?? false,
+    enableBgFetch: raw.enableBgFetch ?? false,
   };
 }
 

--- a/src/features/settings/settings-store.ts
+++ b/src/features/settings/settings-store.ts
@@ -27,6 +27,7 @@ export interface Settings {
   reasoningLevel: ReasoningLevel;
   maxTokens: number;
   enableMcpServer: boolean;
+  enableBgFetch: boolean;
 }
 
 export interface SettingsSlice {
@@ -59,6 +60,7 @@ export const createSettingsSlice: StateCreator<AppStore, [], [], SettingsSlice> 
     reasoningLevel: "medium",
     maxTokens: DEFAULT_MAX_TOKENS,
     enableMcpServer: false,
+    enableBgFetch: false,
   },
   setSettings: (partial) =>
     set((s) => {

--- a/src/features/tools/__tests__/integration.test.ts
+++ b/src/features/tools/__tests__/integration.test.ts
@@ -5,6 +5,7 @@ import {
   createToolExecutorWithSkills,
   ALL_TOOL_DEFS,
   AGENT_TOOL_DEFS,
+  getAgentToolDefs,
 } from "../index";
 import { SkillRegistry, type SkillMatch } from "../skills";
 import type { BrowserExecutor, PageContent } from "@/ports/browser-executor";
@@ -165,6 +166,23 @@ describe("2段階抽出ワークフロー", () => {
       expect(names).toContain("create_skill_draft");
       expect(names).toContain("update_skill_draft");
       expect(names).toContain("delete_skill_draft");
+      expect(names).not.toContain("skill");
+    });
+
+    it("getAgentToolDefs: 引数なしで bg_fetch を除外する", () => {
+      const names = getAgentToolDefs().map((t) => t.name);
+      expect(names).not.toContain("bg_fetch");
+      expect(names).not.toContain("skill");
+    });
+
+    it("getAgentToolDefs: enableBgFetch=false で bg_fetch を除外する", () => {
+      const names = getAgentToolDefs({ enableBgFetch: false }).map((t) => t.name);
+      expect(names).not.toContain("bg_fetch");
+    });
+
+    it("getAgentToolDefs: enableBgFetch=true で bg_fetch を含む", () => {
+      const names = getAgentToolDefs({ enableBgFetch: true }).map((t) => t.name);
+      expect(names).toContain("bg_fetch");
       expect(names).not.toContain("skill");
     });
   });

--- a/src/features/tools/index.ts
+++ b/src/features/tools/index.ts
@@ -111,6 +111,14 @@ export const AGENT_TOOL_DEFS: ToolDefinition[] = ALL_TOOL_DEFS.filter(
   (tool) => tool.name !== "skill",
 );
 
+export function getAgentToolDefs(options?: { enableBgFetch?: boolean }): ToolDefinition[] {
+  const defs = AGENT_TOOL_DEFS;
+  if (!options?.enableBgFetch) {
+    return defs.filter((tool) => tool.name !== "bg_fetch");
+  }
+  return defs;
+}
+
 export type { ToolExecutor };
 
 export function createToolExecutorWithSkills(
@@ -163,8 +171,16 @@ export function createToolExecutorWithSkills(
           selector: args.selector,
           maxWidth: typeof args.maxWidth === "number" ? args.maxWidth : undefined,
         });
-      case "bg_fetch":
+      case "bg_fetch": {
+        const bgFetchEnabled = useStore.getState().settings.enableBgFetch;
+        if (!bgFetchEnabled) {
+          return {
+            ok: false as const,
+            error: { code: "tool_script_error" as const, message: "bg_fetch is disabled in settings" },
+          };
+        }
         return executeBgFetch(args);
+      }
       case "skill": {
         const tab = await browser.getActiveTab();
         return executeSkill(storage, skillRegistry, tab.url, args as SkillAction);

--- a/src/sidepanel/hooks/__tests__/use-agent.test.ts
+++ b/src/sidepanel/hooks/__tests__/use-agent.test.ts
@@ -28,6 +28,7 @@ vi.mock("@/orchestration/agent-loop", () => ({
 
 vi.mock("@/features/tools", () => ({
   AGENT_TOOL_DEFS: [],
+  getAgentToolDefs: vi.fn(() => []),
   createToolExecutorWithSkills: vi.fn(() => vi.fn()),
   loadSkillRegistry: vi.fn(async () => new SkillRegistry()),
 }));

--- a/src/sidepanel/hooks/use-agent.ts
+++ b/src/sidepanel/hooks/use-agent.ts
@@ -4,7 +4,7 @@ import { useStore } from "@/store/index";
 import { isExcludedUrl, getLastKnownUrl } from "@/shared/utils";
 import { runAgentLoop } from "@/orchestration/agent-loop";
 import { getSystemPromptV2 } from "@/features/ai/system-prompt-v2";
-import { AGENT_TOOL_DEFS, createToolExecutorWithSkills, loadSkillRegistry } from "@/features/tools";
+import { getAgentToolDefs, createToolExecutorWithSkills, loadSkillRegistry } from "@/features/tools";
 import { createAutoSaver } from "@/features/sessions/auto-save";
 import { saveSettings } from "@/features/settings/persistence";
 import { subscribeSkillRegistryReload } from "@/features/settings/skill-registry-sync";
@@ -204,7 +204,7 @@ export function useAgent() {
           maxTokens: settings.maxTokens,
         },
         session,
-        tools: AGENT_TOOL_DEFS,
+        tools: getAgentToolDefs({ enableBgFetch: settings.enableBgFetch }),
         systemPrompt,
         autoSaver: autoSaverRef.current,
         toolExecutor: createToolExecutorWithSkills(

--- a/src/store/__tests__/index.test.ts
+++ b/src/store/__tests__/index.test.ts
@@ -383,6 +383,7 @@ describe("AppStore", () => {
         reasoningLevel: "high" as const,
         maxTokens: 8192,
         enableMcpServer: false,
+        enableBgFetch: false,
       };
 
       useStore.getState().hydrateSettings(loadedSettings);


### PR DESCRIPTION
## Summary
- `enableBgFetch` 設定をシステムタブに追加（デフォルトOFF）
- ツール定義フィルタ（`getAgentToolDefs`）でAIへの提供を制御
- エグゼキューター側でも二重ガード（設定OFF時は実行拒否）

## Test plan
- [x] `getAgentToolDefs` のユニットテスト（引数なし/false/true）
- [x] 永続化テスト（既存データの `?? false` フォールバック）
- [x] 型チェック通過
- [x] 全テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)