### PR TITLE
fix: 初回メッセージでも現在ページ情報を AI に渡す

### DIFF
--- a/src/sidepanel/hooks/use-agent.ts
+++ b/src/sidepanel/hooks/use-agent.ts
@@ -96,7 +96,7 @@ export function useAgent() {
 
       if (state.currentTab.url && !isExcludedUrl(state.currentTab.url)) {
         const lastUrl = getLastKnownUrl(state.messages);
-        if (lastUrl !== null && lastUrl !== state.currentTab.url) {
+        if (lastUrl !== state.currentTab.url) {
           state.addNavigationMessage({
             url: state.currentTab.url,
             title: state.currentTab.title,


### PR DESCRIPTION
## Summary
- 新規セッションの1通目では navigation メッセージが追加されず、AI が現在開いているページの URL/タイトルを認識できなかった。
- そのため「これってどんなことするもの？」のような曖昧な質問が、現在ページではなく SiteSurf 拡張自体への質問と解釈されていた。
- `lastUrl !== null` の条件を外し、URL が変わっていれば（null も含めて）毎回 navigation を注入するよう修正。

## Test plan
- [ ] 新規セッションで適当なサイト（例: news サイト）を開き、`これってどんなサイト？` と聞く → ページ内容に基づいた回答が返ること
- [ ] 同じページで連続質問した場合に navigation メッセージが重複しないこと
- [ ] タブを切り替えて質問した場合、新しいページの navigation が差し込まれること
- [ ] chrome://, about: などの除外URL では navigation が追加されないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)