### PR TITLE
feat: 設定に「セキュリティ」タブを追加し監査ログを分離

### DIFF
--- a/src/features/settings/SettingsPanel.tsx
+++ b/src/features/settings/SettingsPanel.tsx
@@ -17,7 +17,7 @@ import {
 } from "@mantine/core";
 import { useMediaQuery } from "@mantine/hooks";
 import { notifications } from "@mantine/notifications";
-import { Bot, Cog, Puzzle, X } from "lucide-react";
+import { Bot, Cog, Puzzle, ShieldCheck, X } from "lucide-react";
 
 import { PROVIDERS } from "@/shared/constants";
 import { useDeps } from "@/shared/deps-context";
@@ -185,6 +185,9 @@ export function SettingsPanel() {
               </Tabs.Tab>
               <Tabs.Tab value="system" leftSection={<Cog size={14} />}>
                 システム
+              </Tabs.Tab>
+              <Tabs.Tab value="security" aria-label="セキュリティ">
+                <ShieldCheck size={14} />
               </Tabs.Tab>
             </Tabs.List>
             <ActionIcon size="sm" variant="subtle" onClick={handleClose} aria-label="閉じる">
@@ -367,9 +370,15 @@ export function SettingsPanel() {
                   </Text>
                 </div>
 
-                <SecurityAuditSettingsSection entries={auditEntries} loading={auditLoading} />
-
                 <SaveButton onClick={handleSave} />
+              </Stack>
+            </Box>
+          </Tabs.Panel>
+
+          <Tabs.Panel value="security" pt="xs" style={{ flex: 1, minHeight: 0 }}>
+            <Box style={PANEL_SCROLL_STYLE}>
+              <Stack gap="md" pb="sm">
+                <SecurityAuditSettingsSection entries={auditEntries} loading={auditLoading} />
               </Stack>
             </Box>
           </Tabs.Panel>


### PR DESCRIPTION
## Summary
- 設定画面に「セキュリティ」タブを新設（ShieldCheck アイコンのみ、`aria-label` 付き）
- 監査ログ表示 `SecurityAuditSettingsSection` をシステムタブから移動
- プロンプトインジェクション検知トグルは動作設定として**システムタブに残す**

## 背景
システムタブに bg_fetch / MCP / 検知トグル / 監査ログが全部並び、スクロールしないと全容が把握しづらくなっていた。監査ログは分量が増える表示なので別タブへ。

## Test plan
- [x] `just test` 全 919 テスト通過
- [ ] 手動: 設定を開きタブ切替で監査ログが表示されること、システムタブに検知トグル/bg_fetch/MCP が残ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)