### PR TITLE
fix: アーティファクトタブが多いときに横スクロールできない問題を修正

### DIFF
--- a/src/features/artifacts/ArtifactPanel.tsx
+++ b/src/features/artifacts/ArtifactPanel.tsx
@@ -50,6 +50,7 @@ export function ArtifactPanel() {
   >(new Map());
   const [loading, setLoading] = useState<Set<string>>(new Set());
   const tabListRef = useRef<HTMLDivElement>(null);
+  const tabViewportRef = useRef<HTMLDivElement>(null);
   const loadVersionRef = useRef(0);
   const artifactDataRef = useRef(artifactData);
   const loadingRef = useRef(loading);
@@ -280,7 +281,16 @@ export function ArtifactPanel() {
           flexShrink: 0,
         }}
       >
-        <ScrollArea scrollbarSize={4}>
+        <ScrollArea
+          scrollbarSize={8}
+          type="auto"
+          viewportRef={tabViewportRef}
+          onWheel={(e) => {
+            const viewport = tabViewportRef.current;
+            if (!viewport || e.deltaY === 0) return;
+            viewport.scrollLeft += e.deltaY;
+          }}
+        >
           <Group ref={tabListRef} gap={4} px="xs" py={4} wrap="nowrap">
             {artifacts.map((artifact) => {
               const isActive = selectedArtifact === artifact.name;


### PR DESCRIPTION
## Summary
- タブ一覧の `ScrollArea` を `scrollbarSize={8}` + `type="auto"` に変更してバー常時表示
- `onWheel` で縦ホイール (deltaY) を `scrollLeft` に転写、ホイール回すだけで横スクロール可能に

## 背景
アーティファクトが増えてタブが溢れると選択不能になる問題の修正。原因は3点：
1. `scrollbarSize={4}` でバーが細く掴めない
2. `type="hover"` デフォルトでホバーしないとバーが出ない
3. 縦マウスホイール→横スクロール変換がなかった

## Test plan
- [x] `just test` 全 919 テスト通過（ビジュアル変更なので新テストなし）
- [ ] 手動: アーティファクトを10個以上作ってタブを溢れさせ、(a) バーが見える (b) ホイールで横移動 (c) 現在選択タブが `scrollIntoView` で視野に戻る

🤖 Generated with [Claude Code](https://claude.com/claude-code)