### PR TITLE
fix: repl後のartifactパネル自動オープンをHTML/Markdown新規作成時のみに限定

### DIFF
--- a/src/orchestration/agent-loop.ts
+++ b/src/orchestration/agent-loop.ts
@@ -411,12 +411,13 @@ export async function runAgentLoop(params: AgentLoopParams): Promise<void> {
           const prevNames = new Set(useStore.getState().artifacts.map((a) => a.name));
           await useStore.getState().loadArtifacts();
           const { artifacts } = useStore.getState();
-          if (artifacts.length > 0) {
-            useStore.getState().setArtifactPanelOpen(true);
-            // 新しいアーティファクトがあれば自動選択
-            const newArtifact = artifacts.find((a) => !prevNames.has(a.name));
-            if (newArtifact) {
-              useStore.getState().selectArtifact(newArtifact.name);
+          const newArtifact = artifacts.find((a) => !prevNames.has(a.name));
+          if (newArtifact) {
+            useStore.getState().selectArtifact(newArtifact.name);
+            // プレビュー価値の高い HTML/Markdown だけ自動でパネルを開く。
+            // JSON/画像/テキスト等は選択のみ行い、既存のパネル状態を維持する。
+            if (newArtifact.type === "html" || newArtifact.type === "markdown") {
+              useStore.getState().setArtifactPanelOpen(true);
             }
           }
         }


### PR DESCRIPTION
## Summary
- `repl` ツール実行後の artifact パネル自動オープンを「**新規作成** かつ **HTML/Markdown** のとき」だけに変更
- 選択 (`selectArtifact`) は新規 artifact があれば常に実行するため、手動でパネルを開けば該当 artifact が見える

## 背景
`src/orchestration/agent-loop.ts:410-422` が repl 後にアーティファクトが1件でも存在すれば型に関わらずパネルを開いていた。JSON/画像/テキスト生成時にも毎回開かれて煩わしい、との報告。`src/features/tools/handlers/artifacts-handler.ts:81-83`（artifacts ツールの create 時）は元から HTML/Markdown 限定なので、それに揃える形。

## Test plan
- [x] `just test` 全 919 テスト通過
- [ ] 手動: repl で JSON artifact を生成 → パネルが自動で開かないこと
- [ ] 手動: repl で HTML artifact を生成 → パネルが自動で開くこと
- [ ] 手動: artifacts ツールで Markdown create → 従来通り自動で開くこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)