### PR TITLE
fix: アーティファクトタブが縮小されて横スクロールしない問題を修正

### DIFF
--- a/src/features/artifacts/ArtifactPanel.tsx
+++ b/src/features/artifacts/ArtifactPanel.tsx
@@ -313,6 +313,7 @@ export function ArtifactPanel() {
                     display: "flex",
                     alignItems: "center",
                     gap: 6,
+                    flexShrink: 0,
                     minWidth: 60,
                     maxWidth: 160,
                   }}


### PR DESCRIPTION
## Summary
- タブ (`Paper`) に `flexShrink: 0` を追加し、狭い幅でも縮まらず自然幅（最大160px）を維持
- 結果として Group の合計幅がビューポートを超え、PR #25 で追加した ScrollArea の横スクロールが機能する

## 背景
PR #25 で横スクロール自体は実装したが、タブが増えると全タブが `minWidth: 60` まで flex-shrink で潰れてしまい、コンテンツ幅がビューポートに収まるため結局スクロールが発動しなかった。ファイル名が短縮されて判別不能になっていた。

## Test plan
- [x] `just test` 全 919 テスト通過
- [ ] 手動: アーティファクトを 8-10 個作ってタブが溢れること確認、ファイル名が 160px 分読めること、横スクロールが機能すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)