### PR TITLE
feat(W1-1): estimateTokens v2 — tool/image/tool-call をカウント

### DIFF
--- a/src/shared/__tests__/token-utils.test.ts
+++ b/src/shared/__tests__/token-utils.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { estimateTokens } from "../token-utils";
+import type { AIMessage } from "@/ports/ai-provider";
+
+describe("estimateTokens", () => {
+  it("空の配列は 0 を返す", () => {
+    expect(estimateTokens([])).toBe(0);
+  });
+
+  it("tool メッセージのみの場合 result の長さを返す", () => {
+    const messages: AIMessage[] = [
+      { role: "tool", toolCallId: "1", toolName: "fn", result: "hello" },
+    ];
+    expect(estimateTokens(messages)).toBe(5);
+  });
+
+  it("image を含む user メッセージは text + 6000 を返す", () => {
+    const messages: AIMessage[] = [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "abc" },
+          { type: "image", mimeType: "image/png", data: "base64data" },
+        ],
+      },
+    ];
+    expect(estimateTokens(messages)).toBe(3 + 6000);
+  });
+
+  it("tool-call を含む assistant メッセージは text + JSON.stringify(args).length を返す", () => {
+    const args = { key: "value" };
+    const messages: AIMessage[] = [
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "thinking" },
+          { type: "tool-call", id: "c1", name: "fn", args },
+        ],
+      },
+    ];
+    expect(estimateTokens(messages)).toBe("thinking".length + JSON.stringify(args).length);
+  });
+
+  it("user/assistant/tool が混在したメッセージ配列を合算する", () => {
+    const args = { x: 1 };
+    const messages: AIMessage[] = [
+      { role: "user", content: [{ type: "text", text: "hi" }] },
+      {
+        role: "assistant",
+        content: [{ type: "tool-call", id: "c1", name: "fn", args }],
+      },
+      { role: "tool", toolCallId: "c1", toolName: "fn", result: "done" },
+    ];
+    expect(estimateTokens(messages)).toBe(2 + JSON.stringify(args).length + 4);
+  });
+});

--- a/src/shared/token-utils.ts
+++ b/src/shared/token-utils.ts
@@ -3,10 +3,16 @@ import type { AIMessage } from "@/ports/ai-provider";
 export function estimateTokens(messages: AIMessage[]): number {
   let chars = 0;
   for (const msg of messages) {
-    if ("content" in msg && Array.isArray(msg.content)) {
+    if (msg.role === "tool") {
+      chars += msg.result.length;
+    } else if ("content" in msg && Array.isArray(msg.content)) {
       for (const part of msg.content) {
-        if ("text" in part && part.text) {
+        if (part.type === "text") {
           chars += part.text.length;
+        } else if (part.type === "image") {
+          chars += 6000; // ~1500 tokens
+        } else if (part.type === "tool-call") {
+          chars += JSON.stringify(part.args).length;
         }
       }
     }


### PR DESCRIPTION
## Summary
- `estimateTokens` に tool メッセージの `result.length` カウントを追加
- image パートを固定 6000 chars (~1500 tokens) で加算
- tool-call パートを `JSON.stringify(args).length` で加算
- `src/shared/__tests__/token-utils.test.ts` に5ケースのテストを追加

## Test plan
- [ ] `npx vitest run src/shared/__tests__/token-utils.test.ts` が全件グリーン
- [ ] `vp check` が通る (format + lint + 型チェック)

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)