### PR TITLE
feat(W1-2): ContextBudget 導入 + 計測ログ

### DIFF
--- a/src/features/ai/__tests__/context-budget.test.ts
+++ b/src/features/ai/__tests__/context-budget.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { getContextBudget } from "../context-budget";
+import { DEFAULT_MAX_TOKENS } from "@/shared/token-constants";
+
+// gpt-4-32k has contextWindow = 32768
+const MODEL_32K = "gpt-4-32k";
+// claude-sonnet-4-6 has contextWindow = 200000
+const MODEL_200K = "claude-sonnet-4-6";
+
+describe("getContextBudget", () => {
+  it("32k model × default maxTokens: outputReserve = DEFAULT_MAX_TOKENS", () => {
+    // floor(32768 * 0.5) = 16384 === DEFAULT_MAX_TOKENS → no clamp
+    const budget = getContextBudget(MODEL_32K);
+    expect(budget.windowTokens).toBe(32768);
+    expect(budget.outputReserve).toBe(DEFAULT_MAX_TOKENS);
+    expect(budget.inputBudget).toBe(32768 - DEFAULT_MAX_TOKENS);
+  });
+
+  it("32k model × maxTokens=32000: clamp occurs, outputReserve = floor(32768*0.5)", () => {
+    // requestedOutput=32000 > floor(32768*0.5)=16384 → clamp
+    const budget = getContextBudget(MODEL_32K, 32000);
+    expect(budget.outputReserve).toBe(16384);
+    expect(budget.inputBudget).toBe(32768 - 16384);
+  });
+
+  it("200k model × default: maxToolResultChars = 20000, useToolResultStore = false", () => {
+    // inputBudget = 200000 - 16384 = 183616 >= 150000
+    const budget = getContextBudget(MODEL_200K);
+    expect(budget.maxToolResultChars).toBe(20_000);
+    expect(budget.useToolResultStore).toBe(false);
+  });
+
+  it("32k model: useToolResultStore = true", () => {
+    const budget = getContextBudget(MODEL_32K);
+    // inputBudget = 16384 < 80000
+    expect(budget.useToolResultStore).toBe(true);
+  });
+
+  it("unknown model: defaults to 128000 window", () => {
+    const budget = getContextBudget("nonexistent-model-xyz");
+    expect(budget.windowTokens).toBe(128_000);
+  });
+});

--- a/src/features/ai/context-budget.ts
+++ b/src/features/ai/context-budget.ts
@@ -1,0 +1,50 @@
+import { lookupModelContextWindow } from "@/shared/model-utils";
+import { DEFAULT_MAX_TOKENS } from "@/shared/token-constants";
+import { createLogger } from "@/shared/logger";
+
+const log = createLogger("context-budget");
+
+export interface ContextBudget {
+  windowTokens: number;
+  outputReserve: number;
+  inputBudget: number;
+  maxToolResultChars: number;
+  compressionThreshold: number;
+  trimThreshold: number;
+  useToolResultStore: boolean;
+}
+
+export function getContextBudget(model: string, settingsMaxTokens?: number): ContextBudget {
+  const windowTokens = lookupModelContextWindow(model);
+  const requestedOutput = settingsMaxTokens ?? DEFAULT_MAX_TOKENS;
+  const outputReserve = Math.min(requestedOutput, Math.floor(windowTokens * 0.5));
+
+  if (requestedOutput > outputReserve) {
+    log.info("maxTokens clamped", {
+      requested: requestedOutput,
+      effective: outputReserve,
+      windowTokens,
+    });
+  }
+
+  const inputBudget = windowTokens - outputReserve;
+
+  return {
+    windowTokens,
+    outputReserve,
+    inputBudget,
+    maxToolResultChars:
+      inputBudget >= 150_000
+        ? 20_000
+        : inputBudget >= 80_000
+          ? 10_000
+          : inputBudget >= 40_000
+            ? 4_000
+            : inputBudget >= 20_000
+              ? 2_000
+              : 1_000,
+    compressionThreshold: Math.floor(inputBudget * 0.6),
+    trimThreshold: Math.floor(inputBudget * 0.85),
+    useToolResultStore: inputBudget < 80_000,
+  };
+}

--- a/src/orchestration/agent-loop.ts
+++ b/src/orchestration/agent-loop.ts
@@ -17,6 +17,7 @@ import { createSecurityMiddleware, type SecurityMiddleware } from "@/features/se
 import { convertNavigationForAPI } from "./navigation-converter";
 import { calculateBackoff, isRetryable, RETRY_CONFIG } from "./retry";
 import { estimateTokens } from "./context-compressor";
+import { getContextBudget } from "@/features/ai/context-budget";
 import type { SkillRegistry } from "@/shared/skill-registry";
 import { buildSkillDetectionMessage, isSkillDetectionMessage } from "./skill-detector";
 import { useStore } from "@/store/index";
@@ -187,6 +188,16 @@ export async function runAgentLoop(params: AgentLoopParams): Promise<void> {
   const securityMiddleware = deps.securityMiddleware ?? defaultSecurityMiddleware;
 
   log.info("streamText 開始", { model: settings.model, provider: settings.provider });
+
+  const budget = getContextBudget(settings.model, settings.maxTokens);
+  log.info("context budget", {
+    model: settings.model,
+    windowTokens: budget.windowTokens,
+    inputBudget: budget.inputBudget,
+    maxToolResultChars: budget.maxToolResultChars,
+    useToolResultStore: budget.useToolResultStore,
+  });
+
   chatStore.setStreaming(true);
 
   // Get current URL for skill detection
@@ -217,6 +228,11 @@ export async function runAgentLoop(params: AgentLoopParams): Promise<void> {
     let aiProvider = deps.createAIProvider(settings);
 
     for (let turn = 0; turn < MAX_TURNS; turn++) {
+      log.info("turn start", {
+        turn,
+        estimateTokens: estimateTokens(messages),
+        messagesCount: messages.length,
+      });
       let hasToolCall = false;
       let assistantText = "";
       let retryCount = 0;

--- a/src/shared/model-utils.ts
+++ b/src/shared/model-utils.ts
@@ -1,0 +1,51 @@
+const CONTEXT_WINDOWS: Record<string, number> = {
+  // Anthropic
+  "claude-3-haiku-20240307": 200000,
+  "claude-3-sonnet-20240229": 200000,
+  "claude-3-opus-20240229": 200000,
+  "claude-3-5-haiku-20241022": 200000,
+  "claude-3-5-haiku-latest": 200000,
+  "claude-3-5-sonnet-20240620": 200000,
+  "claude-3-5-sonnet-20241022": 200000,
+  "claude-3-7-sonnet-20250219": 200000,
+  "claude-haiku-4-5": 200000,
+  "claude-haiku-4-5-20251001": 200000,
+  "claude-opus-4-0": 200000,
+  "claude-opus-4-1": 200000,
+  "claude-opus-4-1-20250805": 200000,
+  "claude-opus-4-20250514": 200000,
+  "claude-opus-4-5": 200000,
+  "claude-opus-4-5-20251101": 200000,
+  "claude-opus-4-6": 200000,
+  "claude-opus-4-7": 200000,
+  "claude-sonnet-4-0": 200000,
+  "claude-sonnet-4-20250514": 200000,
+  "claude-sonnet-4-5": 200000,
+  "claude-sonnet-4-5-20250929": 200000,
+  "claude-sonnet-4-6": 200000,
+  // OpenAI
+  "gpt-4": 8192,
+  "gpt-4-32k": 32768,
+  "gpt-4-turbo": 128000,
+  "gpt-4.1": 1047576,
+  "gpt-4.1-mini": 1047576,
+  "gpt-4.1-nano": 1047576,
+  "gpt-4o": 128000,
+  "gpt-4o-2024-05-13": 128000,
+  "gpt-4o-2024-08-06": 128000,
+  "gpt-5.4": 128000,
+  o1: 200000,
+  "o1-mini": 128000,
+  o3: 200000,
+  "o3-mini": 200000,
+  "o4-mini": 200000,
+  // Google
+  "gemini-2.0-flash": 1000000,
+  "gemini-2.5-flash": 1000000,
+  "gemini-2.5-pro": 1000000,
+  "gemini-2.5-flash-preview": 1000000,
+};
+
+export function lookupModelContextWindow(model: string): number {
+  return CONTEXT_WINDOWS[model] ?? 128_000;
+}


### PR DESCRIPTION
## Summary

- `src/shared/model-utils.ts` を新規作成し、`lookupModelContextWindow(model)` を実装（静的マップ、未知モデルは 128k デフォルト）
- `src/features/ai/context-budget.ts` を新規作成し、`ContextBudget` 型と `getContextBudget(model, settingsMaxTokens?)` を実装
- `src/features/ai/__tests__/context-budget.test.ts` に 5 ケースのユニットテストを追加
- `src/orchestration/agent-loop.ts` にループ開始前の budget ログと各ターン開始ログを挿入（定数差し替えは W1-3 で実施）

Closes #31

## Test plan

- [x] `npx vitest run src/features/ai/__tests__/context-budget.test.ts` → 5/5 passed
- [x] `vp check` → format + lint 全 pass
- [x] `npx tsc --noEmit` → 既存エラーのみ（変更に起因しない）

🤖 Generated with [Claude Code](https://claude.com/claude-code)