### PR TITLE
refactor(W1-3): agent-loop ハードコード定数を ContextBudget に差し替え

### DIFF
--- a/src/orchestration/__tests__/agent-loop.test.ts
+++ b/src/orchestration/__tests__/agent-loop.test.ts
@@ -7,10 +7,12 @@ import type { AuthProvider, AuthCredentials } from "@/ports/auth-provider";
 import type { BrowserExecutor } from "@/ports/browser-executor";
 import { SkillRegistry } from "@/features/tools/skills";
 import { createSecurityMiddleware } from "@/features/security/middleware";
+import { getContextBudget } from "@/features/ai/context-budget";
 import { ok, err } from "@/shared/errors";
 import { initStore, useStore } from "@/store/index";
 import { defaultConsoleLogService } from "@/features/chat/services/console-log";
 import type { ArtifactStoragePort } from "@/ports/artifact-storage";
+import { estimateTokens } from "@/shared/token-utils";
 
 const mockArtifactStorage: ArtifactStoragePort & { setSessionId(id: string | null): void } = {
   createOrUpdate: async () => {},
@@ -821,6 +823,104 @@ describe("tool execution error", () => {
         sessionId: "session-1",
         confidence: "high",
       }),
+    );
+  });
+});
+
+describe("context budget integration", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    streamTextCalls = [];
+    initStore(mockArtifactStorage);
+  });
+
+  it("truncates tool results using budget.maxToolResultChars", async () => {
+    setStreamEvents(
+      [
+        { type: "tool-call", id: "tc-budget", name: "read_page", args: {} },
+        { type: "finish", finishReason: "tool-calls" },
+      ],
+      [{ type: "finish", finishReason: "stop" }],
+    );
+
+    const params = createParams({
+      settings: {
+        provider: "openai",
+        model: "gpt-4",
+        apiKey: "sk-test",
+        baseUrl: "",
+        enterpriseDomain: "",
+      },
+      toolExecutor: vi.fn().mockResolvedValue({ ok: true, value: { text: "x".repeat(1200) } }),
+    });
+
+    await runAgentLoop(params);
+
+    const secondCall = streamTextCalls[1] as {
+      messages: Array<{ role: string; result?: string; toolName?: string }>;
+    };
+    const toolMessage = secondCall.messages.find((message) => message.role === "tool");
+    const budget = getContextBudget("gpt-4");
+
+    expect(toolMessage?.toolName).toBe("read_page");
+    expect(toolMessage?.result).toMatch(/^\{"text":"/);
+    expect(toolMessage?.result).toMatch(/\n\.\.\. \(truncated\)$/);
+    expect(toolMessage?.result).toHaveLength(
+      budget.maxToolResultChars + "\n... (truncated)".length,
+    );
+  });
+
+  it("retries context overflow after trimming down to budget.compressionThreshold", async () => {
+    setStreamEvents(
+      [{ type: "error", error: { code: "ai_unknown", message: "token limit exceeded" } }],
+      [{ type: "finish", finishReason: "stop" }],
+    );
+
+    const session = createMockSession({
+      history: [
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "a".repeat(600) }],
+        },
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "b".repeat(600) }],
+        },
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "c".repeat(600) }],
+        },
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "d".repeat(600) }],
+        },
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "e".repeat(600) }],
+        },
+      ],
+    });
+
+    const params = createParams({
+      session,
+      settings: {
+        provider: "openai",
+        model: "gpt-4",
+        apiKey: "sk-test",
+        baseUrl: "",
+        enterpriseDomain: "",
+      },
+    });
+
+    await runAgentLoop(params);
+
+    const retriedCall = streamTextCalls[1] as { messages: Parameters<typeof estimateTokens>[0] };
+    const budget = getContextBudget("gpt-4");
+
+    expect(estimateTokens(retriedCall.messages)).toBeLessThanOrEqual(budget.compressionThreshold);
+    expect(retriedCall.messages).toHaveLength(4);
+    expect(params.chatStore.addSystemMessage).toHaveBeenCalledWith(
+      "📝 コンテキストが大きすぎるため、古いメッセージを圧縮して再試行します...",
     );
   });
 });

--- a/src/orchestration/agent-loop.ts
+++ b/src/orchestration/agent-loop.ts
@@ -17,7 +17,7 @@ import { createSecurityMiddleware, type SecurityMiddleware } from "@/features/se
 import { convertNavigationForAPI } from "./navigation-converter";
 import { calculateBackoff, isRetryable, RETRY_CONFIG } from "./retry";
 import { estimateTokens } from "./context-compressor";
-import { getContextBudget } from "@/features/ai/context-budget";
+import { getContextBudget, type ContextBudget } from "@/features/ai/context-budget";
 import type { SkillRegistry } from "@/shared/skill-registry";
 import { buildSkillDetectionMessage, isSkillDetectionMessage } from "./skill-detector";
 import { useStore } from "@/store/index";
@@ -94,8 +94,6 @@ export interface AgentLoopParams {
 export type { ToolExecutor } from "@/ports/tool-executor";
 
 const MAX_TURNS = 25;
-const MAX_TOOL_RESULT_CHARS = 30_000;
-const CONTEXT_TOKEN_LIMIT = 100_000;
 const URL_REVISIT_THRESHOLD = 6;
 
 /** 末尾スラッシュを除去してURLを正規化する */
@@ -139,18 +137,18 @@ function trackSpaDomainsFromBgFetch(spaDetectedDomains: Set<string>, toolValue: 
   return warning;
 }
 
-function trimMessagesForContext(messages: AIMessage[]): void {
+function trimMessagesForContext(messages: AIMessage[], budget: ContextBudget): void {
   for (const msg of messages) {
     if (msg.role === "tool" && typeof msg.result === "string") {
       if (msg.result.includes("data:image/")) {
         msg.result = "[screenshot captured]";
-      } else if (msg.result.length > MAX_TOOL_RESULT_CHARS) {
-        msg.result = msg.result.substring(0, MAX_TOOL_RESULT_CHARS) + "\n... (truncated)";
+      } else if (msg.result.length > budget.maxToolResultChars) {
+        msg.result = msg.result.substring(0, budget.maxToolResultChars) + "\n... (truncated)";
       }
     }
   }
 
-  while (messages.length > 4 && estimateTokens(messages) > CONTEXT_TOKEN_LIMIT) {
+  while (messages.length > 4 && estimateTokens(messages) > budget.trimThreshold) {
     const oldest = messages.findIndex(
       (m, i) => i > 0 && (m.role === "tool" || m.role === "assistant"),
     );
@@ -441,7 +439,7 @@ export async function runAgentLoop(params: AgentLoopParams): Promise<void> {
 
       while (retryCount <= RETRY_CONFIG.maxRetries) {
         let hasError = false;
-        trimMessagesForContext(messages);
+        trimMessagesForContext(messages, budget);
         chatStore.startNewAssistantMessage();
 
         for await (const event of aiProvider.streamText({
@@ -564,7 +562,7 @@ export async function runAgentLoop(params: AgentLoopParams): Promise<void> {
 
                 while (
                   messages.length > 4 &&
-                  estimateTokens(messages) > CONTEXT_TOKEN_LIMIT * 0.7
+                  estimateTokens(messages) > budget.compressionThreshold
                 ) {
                   const idx = messages.findIndex(
                     (m, i) => i > 0 && (m.role === "tool" || m.role === "assistant"),

--- a/src/sidepanel/hooks/__tests__/use-agent.test.ts
+++ b/src/sidepanel/hooks/__tests__/use-agent.test.ts
@@ -20,7 +20,7 @@ import type {
 } from "@/ports/browser-executor";
 import type { SessionStoragePort } from "@/ports/session-storage";
 
-const runAgentLoopMock = vi.fn(() => Promise.resolve());
+const runAgentLoopMock = vi.fn<(params: unknown) => Promise<void>>(() => Promise.resolve());
 
 vi.mock("@/orchestration/agent-loop", () => ({
   runAgentLoop: (params: unknown) => runAgentLoopMock(params),


### PR DESCRIPTION
## Summary
- replace agent-loop hardcoded tool/context thresholds with ContextBudget values
- pass ContextBudget into trimMessagesForContext and use compressionThreshold on overflow retry
- add regression tests for budget-driven trimming and fix use-agent test typing for tsc

## Testing
- pnpm vitest run src/orchestration/__tests__/agent-loop.test.ts src/sidepanel/hooks/__tests__/use-agent.test.ts
- npx tsc --noEmit
- vp check

Closes #32