### PR TITLE
refactor(W1-4): COMPRESS_THRESHOLDS 廃止 + buildMessagesForAPI 統合

### DIFF
--- a/src/orchestration/__tests__/context-compressor.test.ts
+++ b/src/orchestration/__tests__/context-compressor.test.ts
@@ -1,13 +1,8 @@
 import { describe, expect, it } from "vitest";
-import {
-  compressIfNeeded,
-  buildMessagesForAPI,
-  estimateTokens,
-  COMPRESS_THRESHOLDS,
-} from "../context-compressor";
+import { compressIfNeeded, estimateTokens } from "../context-compressor";
 import type { AIProvider, AIMessage, StreamEvent } from "@/ports/ai-provider";
 import type { Session } from "@/ports/session-types";
-import type { ProviderId } from "@/shared/constants";
+import type { ContextBudget } from "@/features/ai/context-budget";
 
 function createMockAIProvider(summaryText: string): AIProvider {
   return {
@@ -49,31 +44,18 @@ function createSession(overrides: Partial<Session> = {}): Session {
   };
 }
 
-describe("COMPRESS_THRESHOLDS", () => {
-  it("全プロバイダーの閾値が定義されている", () => {
-    const providerIds: ProviderId[] = [
-      "anthropic",
-      "openai",
-      "google",
-      "copilot",
-      "kimi",
-      "kimi-coding",
-      "zai",
-      "zai-coding",
-      "local",
-    ];
-    for (const id of providerIds) {
-      expect(COMPRESS_THRESHOLDS[id]).toBeGreaterThan(0);
-    }
-  });
-
-  it("ローカルLLMの閾値が最も低い", () => {
-    expect(COMPRESS_THRESHOLDS.local).toBeLessThan(COMPRESS_THRESHOLDS.anthropic);
-    expect(COMPRESS_THRESHOLDS.local).toBeLessThan(COMPRESS_THRESHOLDS.openai);
-    expect(COMPRESS_THRESHOLDS.local).toBeLessThan(COMPRESS_THRESHOLDS.google);
-    expect(COMPRESS_THRESHOLDS.local).toBeLessThan(COMPRESS_THRESHOLDS.copilot);
-  });
-});
+function createBudget(overrides: Partial<ContextBudget> = {}): ContextBudget {
+  return {
+    windowTokens: 32_768,
+    outputReserve: 16_384,
+    inputBudget: 16_384,
+    maxToolResultChars: 1_000,
+    compressionThreshold: 9_830,
+    trimThreshold: 13_926,
+    useToolResultStore: true,
+    ...overrides,
+  };
+}
 
 describe("estimateTokens", () => {
   it("空メッセージ配列で 0 を返す", () => {
@@ -124,60 +106,12 @@ describe("estimateTokens", () => {
   });
 });
 
-describe("buildMessagesForAPI", () => {
-  it("summary なしの場合 history をそのまま返す", () => {
-    const history: AIMessage[] = [createUserMessage("hello"), createAssistantMessage("hi")];
-    const session = createSession({ history });
-    const result = buildMessagesForAPI(session);
-    expect(result).toEqual(history);
-  });
-
-  it("summary ありの場合 user/assistant ペアを先頭に挿入する", () => {
-    const history: AIMessage[] = [createUserMessage("次の質問")];
-    const session = createSession({
-      history,
-      summary: { text: "以前の会話の内容", compressedAt: Date.now(), originalMessageCount: 20 },
-    });
-    const result = buildMessagesForAPI(session);
-
-    expect(result).toHaveLength(3);
-    expect(result[0]).toEqual({
-      role: "user",
-      content: [{ type: "text", text: "[以前の会話の要約]\n以前の会話の内容" }],
-    });
-    expect(result[1]).toEqual({
-      role: "assistant",
-      content: [
-        { type: "text", text: "理解しました。要約の内容を踏まえて引き続きお手伝いします。" },
-      ],
-    });
-    expect(result[2]).toEqual(createUserMessage("次の質問"));
-  });
-
-  it("summary ありでも history の順序を維持する", () => {
-    const history: AIMessage[] = [
-      createUserMessage("Q1"),
-      createAssistantMessage("A1"),
-      createUserMessage("Q2"),
-    ];
-    const session = createSession({
-      history,
-      summary: { text: "要約", compressedAt: Date.now(), originalMessageCount: 10 },
-    });
-    const result = buildMessagesForAPI(session);
-
-    expect(result).toHaveLength(5);
-    expect(result[2]).toEqual(createUserMessage("Q1"));
-    expect(result[3]).toEqual(createAssistantMessage("A1"));
-    expect(result[4]).toEqual(createUserMessage("Q2"));
-  });
-});
-
 describe("compressIfNeeded", () => {
-  it("閾値未満の場合は圧縮しない", async () => {
+  it("budget.trimThreshold 未満の場合は圧縮しない", async () => {
     const provider = createMockAIProvider("summary");
     const session = createSession({ history: [createUserMessage("short")] });
-    const result = await compressIfNeeded(provider, session, "test-model", "anthropic");
+    const budget = createBudget({ trimThreshold: 100 });
+    const result = await compressIfNeeded(provider, session, budget, "test-model", "anthropic");
 
     expect(result.compressed).toBe(false);
     expect(result.session).toBe(session);
@@ -188,8 +122,9 @@ describe("compressIfNeeded", () => {
     const longText = "x".repeat(200_000);
     const history: AIMessage[] = Array.from({ length: 15 }, () => createUserMessage(longText));
     const session = createSession({ history });
+    const budget = createBudget({ trimThreshold: 100 });
 
-    const result = await compressIfNeeded(provider, session, "test-model", "anthropic");
+    const result = await compressIfNeeded(provider, session, budget, "test-model", "anthropic");
     expect(result.compressed).toBe(false);
   });
 
@@ -198,8 +133,9 @@ describe("compressIfNeeded", () => {
     const longText = "x".repeat(200_000);
     const history: AIMessage[] = Array.from({ length: 15 }, () => createUserMessage(longText));
     const session = createSession({ history });
+    const budget = createBudget({ trimThreshold: 100 });
 
-    const result = await compressIfNeeded(provider, session, "test-model", "anthropic", {
+    const result = await compressIfNeeded(provider, session, budget, "test-model", "anthropic", {
       userConfirmed: true,
     });
     expect(result.compressed).toBe(true);
@@ -212,8 +148,9 @@ describe("compressIfNeeded", () => {
     const longText = "x".repeat(10_000);
     const history: AIMessage[] = Array.from({ length: 15 }, () => createUserMessage(longText));
     const session = createSession({ history });
+    const budget = createBudget({ trimThreshold: 100 });
 
-    const result = await compressIfNeeded(provider, session, "llama3.2", "local");
+    const result = await compressIfNeeded(provider, session, budget, "llama3.2", "local");
     expect(result.compressed).toBe(true);
     expect(result.session.summary?.text).toBe("ローカル要約");
   });
@@ -229,8 +166,9 @@ describe("compressIfNeeded", () => {
       ...history.slice(-5),
     ];
     const session = createSession({ history: longHistory });
+    const budget = createBudget({ trimThreshold: 100 });
 
-    const result = await compressIfNeeded(provider, session, "llama3.2", "local");
+    const result = await compressIfNeeded(provider, session, budget, "llama3.2", "local");
     expect(result.compressed).toBe(true);
     expect(result.session.history).toHaveLength(10);
   });
@@ -240,8 +178,9 @@ describe("compressIfNeeded", () => {
     const longText = "x".repeat(1_000);
     const history: AIMessage[] = Array.from({ length: 10 }, () => createUserMessage(longText));
     const session = createSession({ history });
+    const budget = createBudget({ trimThreshold: 100 });
 
-    const result = await compressIfNeeded(provider, session, "llama3.2", "local");
+    const result = await compressIfNeeded(provider, session, budget, "llama3.2", "local");
     expect(result.compressed).toBe(false);
   });
 
@@ -250,8 +189,9 @@ describe("compressIfNeeded", () => {
     const longText = "x".repeat(10_000);
     const history: AIMessage[] = Array.from({ length: 15 }, () => createUserMessage(longText));
     const session = createSession({ history });
+    const budget = createBudget({ trimThreshold: 100 });
 
-    const result = await compressIfNeeded(provider, session, "llama3.2", "local");
+    const result = await compressIfNeeded(provider, session, budget, "llama3.2", "local");
     expect(result.compressed).toBe(false);
     expect(result.session).toBe(session);
   });
@@ -264,8 +204,9 @@ describe("compressIfNeeded", () => {
       history,
       summary: { text: "前回の要約", compressedAt: Date.now() - 60_000, originalMessageCount: 30 },
     });
+    const budget = createBudget({ trimThreshold: 100 });
 
-    const result = await compressIfNeeded(provider, session, "llama3.2", "local");
+    const result = await compressIfNeeded(provider, session, budget, "llama3.2", "local");
     expect(result.compressed).toBe(true);
     expect(result.session.summary?.originalMessageCount).toBe(35);
     expect(result.session.summary?.text).toBe("再要約結果");
@@ -277,8 +218,9 @@ describe("compressIfNeeded", () => {
     const history: AIMessage[] = Array.from({ length: 15 }, () => createUserMessage(longText));
     const session = createSession({ history });
     const before = Date.now();
+    const budget = createBudget({ trimThreshold: 100 });
 
-    const result = await compressIfNeeded(provider, session, "llama3.2", "local");
+    const result = await compressIfNeeded(provider, session, budget, "llama3.2", "local");
     const after = Date.now();
 
     expect(result.session.summary?.compressedAt).toBeGreaterThanOrEqual(before);
@@ -291,8 +233,9 @@ describe("compressIfNeeded", () => {
     const history: AIMessage[] = Array.from({ length: 15 }, () => createUserMessage(longText));
     const messages = [{ id: "1", role: "user" as const, content: "hello", timestamp: Date.now() }];
     const session = createSession({ history, messages });
+    const budget = createBudget({ trimThreshold: 100 });
 
-    const result = await compressIfNeeded(provider, session, "llama3.2", "local");
+    const result = await compressIfNeeded(provider, session, budget, "llama3.2", "local");
     expect(result.session.messages).toBe(messages);
   });
 });

--- a/src/orchestration/context-compressor.ts
+++ b/src/orchestration/context-compressor.ts
@@ -1,24 +1,11 @@
-import type { AIMessage, AIProvider, UserMessage, AssistantMessage } from "@/ports/ai-provider";
+import type { AIMessage, AIProvider, UserMessage } from "@/ports/ai-provider";
 import type { Session, ConversationSummary } from "@/ports/session-types";
+import type { ContextBudget } from "@/features/ai/context-budget";
 import type { ProviderId } from "@/shared/constants";
 import { createLogger } from "@/shared/logger";
 import { estimateTokens } from "@/shared/token-utils";
 
 export { estimateTokens } from "@/shared/token-utils";
-
-export const COMPRESS_THRESHOLDS: Record<ProviderId, number> = {
-  anthropic: 150_000,
-  openai: 90_000,
-  "openai-codex": 90_000,
-  google: 700_000,
-  copilot: 90_000,
-  kimi: 90_000,
-  "kimi-coding": 90_000,
-  zai: 90_000,
-  "zai-coding": 90_000,
-  ollama: 5_000,
-  local: 5_000,
-};
 
 const KEEP_RECENT = 10;
 const log = createLogger("compressor");
@@ -45,15 +32,19 @@ export interface CompressResult {
 export async function compressIfNeeded(
   aiProvider: AIProvider,
   session: Session,
+  budget: ContextBudget,
   model: string,
   provider: ProviderId,
   options: { userConfirmed?: boolean } = {},
 ): Promise<CompressResult> {
-  const threshold = COMPRESS_THRESHOLDS[provider];
   const tokenCount = estimateTokens(session.history);
-  if (tokenCount < threshold) return { session, compressed: false };
+  if (tokenCount < budget.trimThreshold) return { session, compressed: false };
 
-  log.info("コンテキスト圧縮開始", { tokenCount, threshold, provider });
+  log.info("コンテキスト圧縮開始", {
+    tokenCount,
+    trimThreshold: budget.trimThreshold,
+    provider,
+  });
 
   if (provider !== "local" && provider !== "ollama" && !options.userConfirmed) {
     return { session, compressed: false };
@@ -87,25 +78,6 @@ export async function compressIfNeeded(
     log.error("コンテキスト圧縮失敗", e);
     return { session, compressed: false };
   }
-}
-
-export function buildMessagesForAPI(session: Session): AIMessage[] {
-  const messages: AIMessage[] = [];
-  if (session.summary) {
-    const summaryUser: UserMessage = {
-      role: "user",
-      content: [{ type: "text", text: `[以前の会話の要約]\n${session.summary.text}` }],
-    };
-    const summaryAssistant: AssistantMessage = {
-      role: "assistant",
-      content: [
-        { type: "text", text: "理解しました。要約の内容を踏まえて引き続きお手伝いします。" },
-      ],
-    };
-    messages.push(summaryUser, summaryAssistant);
-  }
-  messages.push(...session.history);
-  return messages;
 }
 
 async function summarizeMessages(

--- a/src/sidepanel/hooks/__tests__/use-agent.test.ts
+++ b/src/sidepanel/hooks/__tests__/use-agent.test.ts
@@ -20,7 +20,7 @@ import type {
 } from "@/ports/browser-executor";
 import type { SessionStoragePort } from "@/ports/session-storage";
 
-const runAgentLoopMock = vi.fn(() => Promise.resolve());
+const runAgentLoopMock = vi.fn(async (_params: unknown) => Promise.resolve());
 
 vi.mock("@/orchestration/agent-loop", () => ({
   runAgentLoop: (params: unknown) => runAgentLoopMock(params),
@@ -182,7 +182,8 @@ describe("useAgent", () => {
     });
 
     expect(runAgentLoopMock).toHaveBeenCalledTimes(1);
-    expect(runAgentLoopMock.mock.calls[0]?.[0]).toMatchObject({
+    const [firstCall] = runAgentLoopMock.mock.calls;
+    expect(firstCall?.[0]).toMatchObject({
       settings: {
         provider: "openai",
         model: "gpt-4.1",


### PR DESCRIPTION
## Summary
- remove `COMPRESS_THRESHOLDS` and drive compression off `ContextBudget.trimThreshold`
- delete the duplicate session-based `buildMessagesForAPI` from `context-compressor.ts`
- update compressor tests to use `ContextBudget` and keep typecheck green

## Verification
- npx tsc --noEmit
- vp check
- vp test

Closes #33