### PR TITLE
feat(W1-5): URL 訪問追跡拡張 + system prompt 注入（pi-mono方式）

### DIFF
--- a/src/features/ai/__tests__/system-prompt-v2.test.ts
+++ b/src/features/ai/__tests__/system-prompt-v2.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { getSystemPromptV2 } from "../system-prompt-v2";
+import { getSystemPromptV2, generateVisitedUrlsSection } from "../system-prompt-v2";
+import type { VisitedUrlEntry } from "../system-prompt-v2";
 import type { SkillMatch } from "@/shared/skill-types";
 
 const mockSkillMatch: SkillMatch = {
@@ -103,5 +104,36 @@ describe("getSystemPromptV2", () => {
   it("contains CRITICAL rules", () => {
     const prompt = getSystemPromptV2({});
     expect(prompt).toContain("CRITICAL");
+  });
+});
+
+describe("generateVisitedUrlsSection", () => {
+  function makeEntry(url: string, title: string, visitCount: number): VisitedUrlEntry {
+    return { url, title, visitedAt: Date.now(), visitCount, lastMethod: "navigate" };
+  }
+
+  it("returns empty string for empty entries", () => {
+    expect(generateVisitedUrlsSection([])).toBe("");
+  });
+
+  it("returns section header and URL lines for non-empty entries", () => {
+    const section = generateVisitedUrlsSection([makeEntry("https://example.com", "Example", 2)]);
+    expect(section).toContain("## Current Session: Visited URLs");
+    expect(section).toContain("https://example.com");
+    expect(section).toContain("Example");
+    expect(section).toContain("[2x, via navigate]");
+  });
+
+  it("omits section from getSystemPromptV2 when visitedUrls is empty", () => {
+    const prompt = getSystemPromptV2({ visitedUrls: [] });
+    expect(prompt).not.toContain("## Current Session: Visited URLs");
+  });
+
+  it("injects section into getSystemPromptV2 when visitedUrls provided", () => {
+    const prompt = getSystemPromptV2({
+      visitedUrls: [makeEntry("https://example.com", "Example", 1)],
+    });
+    expect(prompt).toContain("## Current Session: Visited URLs");
+    expect(prompt).toContain("https://example.com");
   });
 });

--- a/src/features/ai/index.ts
+++ b/src/features/ai/index.ts
@@ -1,3 +1,3 @@
-export type { SystemPromptOptions } from "./system-prompt-v2";
-export { getSystemPromptV2 } from "./system-prompt-v2";
+export type { SystemPromptOptions, VisitedUrlEntry } from "./system-prompt-v2";
+export { getSystemPromptV2, generateVisitedUrlsSection } from "./system-prompt-v2";
 export { PromptCache, createPromptCacheKey } from "./prompt-cache";

--- a/src/features/ai/system-prompt-v2.ts
+++ b/src/features/ai/system-prompt-v2.ts
@@ -2,10 +2,19 @@ import type { SkillMatch } from "@/shared/skill-types";
 import { assembleSections, type SectionKey } from "./sections";
 import { PromptCache, createPromptCacheKey } from "./prompt-cache";
 
+export interface VisitedUrlEntry {
+  url: string;
+  title: string;
+  visitedAt: number;
+  visitCount: number;
+  lastMethod: "navigate" | "read_page" | "bg_fetch";
+}
+
 export interface SystemPromptOptions {
   includeSkills?: boolean;
   skills?: SkillMatch[];
   locale?: string;
+  visitedUrls?: VisitedUrlEntry[];
 }
 
 const cache = new PromptCache();
@@ -85,22 +94,29 @@ function renderSkillEntries(skills: SkillMatch[]): string {
   return lines.join("\n");
 }
 
+export function generateVisitedUrlsSection(entries: VisitedUrlEntry[]): string {
+  if (entries.length === 0) return "";
+  const lines = entries.map(
+    (e) => `- ${e.url} (${e.title}) [${e.visitCount}x, via ${e.lastMethod}]`,
+  );
+  return `## Current Session: Visited URLs\n${lines.join("\n")}`;
+}
+
 export function getSystemPromptV2(options: SystemPromptOptions): string {
   const key = createPromptCacheKey(options);
   const cached = cache.get(key);
 
+  let base: string;
   if (cached !== null) {
-    return cached;
+    base = cached;
+  } else {
+    const baseSections = assembleSections(BASE_SECTIONS);
+    const skillsSection =
+      options.includeSkills && options.skills ? generateSkillsSection(options.skills) : "";
+    base = skillsSection ? `${baseSections}\n\n${skillsSection}` : baseSections;
+    cache.set(key, base);
   }
 
-  const base = assembleSections(BASE_SECTIONS);
-
-  const skillsSection =
-    options.includeSkills && options.skills ? generateSkillsSection(options.skills) : "";
-
-  const prompt = skillsSection ? `${base}\n\n${skillsSection}` : base;
-
-  cache.set(key, prompt);
-
-  return prompt;
+  const visitedSection = generateVisitedUrlsSection(options.visitedUrls ?? []);
+  return visitedSection ? `${base}\n\n${visitedSection}` : base;
 }

--- a/src/orchestration/__tests__/agent-loop.test.ts
+++ b/src/orchestration/__tests__/agent-loop.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import { runAgentLoop } from "../agent-loop";
+import { runAgentLoop, trackVisitedUrl, pruneVisitedUrls } from "../agent-loop";
 import type { AgentLoopParams, ChatActions } from "../agent-loop";
+import type { VisitedUrlEntry } from "@/features/ai/system-prompt-v2";
 import type { Session } from "@/ports/session-types";
 import type { AIProvider, StreamEvent } from "@/ports/ai-provider";
 import type { AuthProvider, AuthCredentials } from "@/ports/auth-provider";
@@ -922,5 +923,148 @@ describe("context budget integration", () => {
     expect(params.chatStore.addSystemMessage).toHaveBeenCalledWith(
       "📝 コンテキストが大きすぎるため、古いメッセージを圧縮して再試行します...",
     );
+  });
+});
+
+describe("trackVisitedUrl", () => {
+  function makeMap(): Map<string, VisitedUrlEntry> {
+    return new Map<string, VisitedUrlEntry>();
+  }
+
+  it("increments visitCount when same URL is visited multiple times", () => {
+    const map = makeMap();
+    trackVisitedUrl(map, "https://example.com/", "Example", "navigate");
+    trackVisitedUrl(map, "https://example.com/", "Example", "navigate");
+    const entry = map.get("https://example.com");
+    expect(entry?.visitCount).toBe(2);
+  });
+
+  it("normalizes trailing slash when tracking", () => {
+    const map = makeMap();
+    trackVisitedUrl(map, "https://example.com/", "Example", "navigate");
+    trackVisitedUrl(map, "https://example.com", "Example", "navigate");
+    expect(map.size).toBe(1);
+    expect(map.get("https://example.com")?.visitCount).toBe(2);
+  });
+
+  it("returns null for first visits below threshold", () => {
+    const map = makeMap();
+    const result = trackVisitedUrl(map, "https://example.com", "Example", "navigate");
+    expect(result).toBeNull();
+  });
+
+  it("returns warning string at revisit threshold", () => {
+    const map = makeMap();
+    for (let i = 0; i < 5; i++) {
+      trackVisitedUrl(map, "https://example.com", "Example", "navigate");
+    }
+    const warning = trackVisitedUrl(map, "https://example.com", "Example", "navigate");
+    expect(warning).toContain("WARNING");
+    expect(warning).toContain("6 time(s)");
+  });
+});
+
+describe("pruneVisitedUrls", () => {
+  function makeEntry(visitCount: number, visitedAt: number): VisitedUrlEntry {
+    return {
+      url: "https://example.com",
+      title: "Example",
+      visitedAt,
+      visitCount,
+      lastMethod: "navigate",
+    };
+  }
+
+  it("does nothing when at or below MAX_VISITED_URLS", () => {
+    const map = new Map<string, VisitedUrlEntry>();
+    for (let i = 0; i < 20; i++) {
+      map.set(`url-${i}`, makeEntry(1, i));
+    }
+    pruneVisitedUrls(map);
+    expect(map.size).toBe(20);
+  });
+
+  it("removes oldest entry when 21st URL is added", () => {
+    const map = new Map<string, VisitedUrlEntry>();
+    for (let i = 0; i < 20; i++) {
+      map.set(`url-${i}`, makeEntry(2, i));
+    }
+    map.set("url-20", makeEntry(2, 20));
+    pruneVisitedUrls(map);
+    expect(map.size).toBe(20);
+    expect(map.has("url-0")).toBe(false);
+  });
+
+  it("removes entry with lowest visitCount when visit counts differ", () => {
+    const map = new Map<string, VisitedUrlEntry>();
+    for (let i = 0; i < 20; i++) {
+      map.set(`url-${i}`, makeEntry(3, i));
+    }
+    map.set("url-low", makeEntry(1, 999));
+    pruneVisitedUrls(map);
+    expect(map.size).toBe(20);
+    expect(map.has("url-low")).toBe(false);
+  });
+});
+
+describe("visited URLs in system prompt", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    streamTextCalls = [];
+    initStore(mockArtifactStorage);
+  });
+
+  it("includes visited URLs section in system prompt after navigation", async () => {
+    setStreamEvents(
+      [
+        {
+          type: "tool-call",
+          id: "nav-1",
+          name: "navigate",
+          args: { url: "https://example.com" },
+        },
+        { type: "finish", finishReason: "tool-calls" },
+      ],
+      [
+        { type: "text-delta", text: "Done" },
+        { type: "finish", finishReason: "stop" },
+      ],
+    );
+
+    const toolExecutor = vi.fn().mockResolvedValue({
+      ok: true,
+      value: { finalUrl: "https://example.com", title: "Example Page", tabId: 1 },
+    });
+    const browserExecutor = {
+      getActiveTab: vi.fn().mockResolvedValue({
+        id: 1,
+        url: "https://example.com",
+        title: "Example Page",
+      }),
+    } as unknown as BrowserExecutor;
+
+    const params = createParams({
+      toolExecutor,
+      deps: { createAIProvider: () => createMockAIProvider(), browserExecutor },
+    });
+    await runAgentLoop(params);
+
+    const secondCall = streamTextCalls[1] as { systemPrompt: string };
+    expect(secondCall.systemPrompt).toContain("## Current Session: Visited URLs");
+    expect(secondCall.systemPrompt).toContain("https://example.com");
+    expect(secondCall.systemPrompt).toContain("Example Page");
+  });
+
+  it("does not include visited URLs section in system prompt when no URLs visited", async () => {
+    setStreamEvents([
+      { type: "text-delta", text: "Hello" },
+      { type: "finish", finishReason: "stop" },
+    ]);
+
+    const params = createParams();
+    await runAgentLoop(params);
+
+    const firstCall = streamTextCalls[0] as { systemPrompt: string };
+    expect(firstCall.systemPrompt).not.toContain("## Current Session: Visited URLs");
   });
 });

--- a/src/orchestration/agent-loop.ts
+++ b/src/orchestration/agent-loop.ts
@@ -18,6 +18,7 @@ import { convertNavigationForAPI } from "./navigation-converter";
 import { calculateBackoff, isRetryable, RETRY_CONFIG } from "./retry";
 import { estimateTokens } from "./context-compressor";
 import { getContextBudget, type ContextBudget } from "@/features/ai/context-budget";
+import { generateVisitedUrlsSection, type VisitedUrlEntry } from "@/features/ai/system-prompt-v2";
 import type { SkillRegistry } from "@/shared/skill-registry";
 import { buildSkillDetectionMessage, isSkillDetectionMessage } from "./skill-detector";
 import { useStore } from "@/store/index";
@@ -95,21 +96,58 @@ export type { ToolExecutor } from "@/ports/tool-executor";
 
 const MAX_TURNS = 25;
 const URL_REVISIT_THRESHOLD = 6;
+const MAX_VISITED_URLS = 20;
 
 /** 末尾スラッシュを除去してURLを正規化する */
 function normalizeUrl(url: string): string {
   return url.replace(/\/$/, "");
 }
 
+/** URLからホスト名を抽出する（パース失敗時はURLをそのまま返す） */
+function extractHostname(url: string): string {
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return url;
+  }
+}
+
 /** 訪問済みURLの再訪問警告メッセージを生成する（再訪問でなければ null） */
-function trackVisitedUrl(visitedUrls: Map<string, number>, url: string): string | null {
+export function trackVisitedUrl(
+  visitedUrls: Map<string, VisitedUrlEntry>,
+  url: string,
+  title: string,
+  method: VisitedUrlEntry["lastMethod"],
+): string | null {
   const normalized = normalizeUrl(url);
-  const count = (visitedUrls.get(normalized) ?? 0) + 1;
-  visitedUrls.set(normalized, count);
-  if (count >= URL_REVISIT_THRESHOLD) {
-    return `\n\n⚠️ WARNING: This URL has already been visited ${count} time(s) in this session. Do NOT navigate to it again. Use the information you already collected from previous visits. If you have enough information, proceed to analysis/response instead of collecting more pages.`;
+  const existing = visitedUrls.get(normalized);
+  const entry: VisitedUrlEntry = {
+    url,
+    title,
+    visitedAt: Date.now(),
+    visitCount: (existing?.visitCount ?? 0) + 1,
+    lastMethod: method,
+  };
+  visitedUrls.set(normalized, entry);
+  pruneVisitedUrls(visitedUrls);
+  if (entry.visitCount >= URL_REVISIT_THRESHOLD) {
+    return `\n\n⚠️ WARNING: This URL has already been visited ${entry.visitCount} time(s) in this session. Do NOT navigate to it again. Use the information you already collected from previous visits. If you have enough information, proceed to analysis/response instead of collecting more pages.`;
   }
   return null;
+}
+
+/** MAX_VISITED_URLS を超えたとき、訪問回数が少なく古いエントリを削除する */
+export function pruneVisitedUrls(visitedUrls: Map<string, VisitedUrlEntry>): void {
+  if (visitedUrls.size <= MAX_VISITED_URLS) return;
+  const entries = [...visitedUrls.entries()];
+  entries.sort(([, a], [, b]) => {
+    if (a.visitCount !== b.visitCount) return a.visitCount - b.visitCount;
+    return a.visitedAt - b.visitedAt;
+  });
+  const toRemove = entries.length - MAX_VISITED_URLS;
+  for (let i = 0; i < toRemove; i++) {
+    visitedUrls.delete(entries[i][0]);
+  }
 }
 
 /** bg_fetch 結果から SPA ドメインを検出・追跡し、警告メッセージを返す */
@@ -208,7 +246,7 @@ export async function runAgentLoop(params: AgentLoopParams): Promise<void> {
   }
 
   // 訪問済みURL追跡: 同一URLへの繰り返しナビゲーションを検出・警告する
-  const visitedUrls = new Map<string, number>(); // URL → 訪問回数
+  const visitedUrls = new Map<string, VisitedUrlEntry>();
   // SPA と判定されたドメインの追跡: bg_fetch で SPA 警告が出たドメインを記録
   const spaDetectedDomains = new Set<string>();
   // setToolNavigating(false) の遅延タイマー。連続 navigate 時に前のタイマーをキャンセルし、
@@ -364,9 +402,10 @@ export async function runAgentLoop(params: AgentLoopParams): Promise<void> {
         let loopWarningEmitted = false;
 
         if (name === "navigate" && toolResult.ok) {
-          const navResult = toolResult.value as { finalUrl?: string };
+          const navResult = toolResult.value as { finalUrl?: string; title?: string };
           if (navResult.finalUrl) {
-            const warning = trackVisitedUrl(visitedUrls, navResult.finalUrl);
+            const title = navResult.title || extractHostname(navResult.finalUrl);
+            const warning = trackVisitedUrl(visitedUrls, navResult.finalUrl, title, "navigate");
             if (warning) {
               resultStr += warning;
               loopWarningEmitted = true;
@@ -376,6 +415,13 @@ export async function runAgentLoop(params: AgentLoopParams): Promise<void> {
 
         if (name === "bg_fetch" && toolResult.ok) {
           resultStr += trackSpaDomainsFromBgFetch(spaDetectedDomains, toolResult.value);
+          const items = Array.isArray(toolResult.value) ? toolResult.value : [toolResult.value];
+          for (const item of items) {
+            const it = item as { url?: string };
+            if (it.url) {
+              trackVisitedUrl(visitedUrls, it.url, extractHostname(it.url), "bg_fetch");
+            }
+          }
         }
 
         // navigate/repl 後のURL変化検出: スキル再構築 + repl 訪問追跡
@@ -386,7 +432,8 @@ export async function runAgentLoop(params: AgentLoopParams): Promise<void> {
             // repl 経由のナビゲーションは currentUrl と同じでも追跡する。
             // navigate ツール直接呼び出しは上で追跡済みなのでここでは repl のみ。
             if (name === "repl" && newUrl) {
-              const warning = trackVisitedUrl(visitedUrls, newUrl);
+              const title = tab.title || extractHostname(newUrl);
+              const warning = trackVisitedUrl(visitedUrls, newUrl, title, "navigate");
               if (warning) {
                 resultStr += warning;
                 loopWarningEmitted = true;
@@ -437,6 +484,11 @@ export async function runAgentLoop(params: AgentLoopParams): Promise<void> {
         }
       };
 
+      const visitedSection = generateVisitedUrlsSection([...visitedUrls.values()]);
+      const effectiveSystemPrompt = visitedSection
+        ? `${systemPrompt}\n\n${visitedSection}`
+        : systemPrompt;
+
       while (retryCount <= RETRY_CONFIG.maxRetries) {
         let hasError = false;
         trimMessagesForContext(messages, budget);
@@ -444,7 +496,7 @@ export async function runAgentLoop(params: AgentLoopParams): Promise<void> {
 
         for await (const event of aiProvider.streamText({
           model: settings.model,
-          systemPrompt,
+          systemPrompt: effectiveSystemPrompt,
           messages,
           tools,
           maxTokens: settings.maxTokens,


### PR DESCRIPTION
## Summary

- `VisitedUrlEntry` 型を `system-prompt-v2.ts` に定義・エクスポート（url, title, visitedAt, visitCount, lastMethod）
- `visitedUrls` Map を `Map<string, number>` から `Map<string, VisitedUrlEntry>` に変更
- `trackVisitedUrl` を拡張し title / lastMethod を記録するよう更新
- `pruneVisitedUrls` を追加し 20 URL 超過時に VC 昇順・古い順で削除
- `bg_fetch` 経由の URL も訪問追跡対象に追加
- `SystemPromptOptions.visitedUrls` を追加し `generateVisitedUrlsSection` で `## Current Session: Visited URLs` を生成
- agent-loop の毎ターン先頭で `effectiveSystemPrompt` を再構築して動的注入（キャッシュ汚染なし）

## Test plan

- [x] `trackVisitedUrl`: 同一 URL で visitCount が増える
- [x] `trackVisitedUrl`: 正規化（末尾スラッシュ除去）が機能する
- [x] `trackVisitedUrl`: 閾値未満は null、閾値到達で警告文字列を返す
- [x] `pruneVisitedUrls`: 20 件以下はそのまま
- [x] `pruneVisitedUrls`: 21 件目追加で最古エントリ削除
- [x] `pruneVisitedUrls`: visitCount が低いエントリを優先削除
- [x] `generateVisitedUrlsSection`: 空配列で空文字列
- [x] `generateVisitedUrlsSection`: URL 行のフォーマット確認
- [x] `getSystemPromptV2`: visitedUrls 空でセクション省略
- [x] `getSystemPromptV2`: visitedUrls ありでセクション注入
- [x] agent-loop: navigate 後の第 2 ターンで system prompt に URL セクション含まれる
- [x] agent-loop: URL 未訪問の第 1 ターンで system prompt に URL セクションなし
- [x] `npx tsc --noEmit` パス
- [x] `vp check` パス
- [x] 既存テスト全て緑 (944 tests)

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)