### PR TITLE
feat(W1-6): 2段階 truncate ヘルパー追加

### DIFF
--- a/src/shared/__tests__/truncate-utils.test.ts
+++ b/src/shared/__tests__/truncate-utils.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { TOOL_RESULT_SUMMARY_MAX_CHARS, truncateForSummary } from "../truncate-utils";
+
+describe("truncateForSummary", () => {
+  it("2000 chars 以下の入力はそのまま返す", () => {
+    const text = "a".repeat(TOOL_RESULT_SUMMARY_MAX_CHARS);
+    expect(truncateForSummary(text)).toBe(text);
+  });
+
+  it("空文字はそのまま返す", () => {
+    expect(truncateForSummary("")).toBe("");
+  });
+
+  it("2000 chars 超の入力は先頭 2000 chars + サフィックスで返す", () => {
+    const text = "b".repeat(TOOL_RESULT_SUMMARY_MAX_CHARS + 1);
+    const result = truncateForSummary(text);
+    expect(result).toBe(
+      "b".repeat(TOOL_RESULT_SUMMARY_MAX_CHARS) + "\n... (truncated for summarization)",
+    );
+  });
+
+  it("サフィックスが '... (truncated for summarization)' を含む", () => {
+    const text = "c".repeat(3000);
+    expect(truncateForSummary(text)).toContain("(truncated for summarization)");
+  });
+
+  it("TOOL_RESULT_SUMMARY_MAX_CHARS は 2000", () => {
+    expect(TOOL_RESULT_SUMMARY_MAX_CHARS).toBe(2000);
+  });
+});

--- a/src/shared/truncate-utils.ts
+++ b/src/shared/truncate-utils.ts
@@ -1,0 +1,9 @@
+// Stage 2 truncation for LLM compression prompts.
+// Stage 1 truncation (maxToolResultChars) runs at tool execution time via context-budget.
+// For small context windows where maxToolResultChars <= 2000, this is a no-op.
+export const TOOL_RESULT_SUMMARY_MAX_CHARS = 2000;
+
+export function truncateForSummary(text: string): string {
+  if (text.length <= TOOL_RESULT_SUMMARY_MAX_CHARS) return text;
+  return text.substring(0, TOOL_RESULT_SUMMARY_MAX_CHARS) + "\n... (truncated for summarization)";
+}


### PR DESCRIPTION
## Summary
- `src/shared/truncate-utils.ts` に `TOOL_RESULT_SUMMARY_MAX_CHARS = 2000` 定数と `truncateForSummary` 関数を追加
- 第1段階（`maxToolResultChars`）との関係とno-opケースをコメントで明記
- 単体テスト5件追加

## Test plan
- [ ] `npx tsc --noEmit` パス確認済み
- [ ] `vp check` パス確認済み
- [ ] `npx vitest run src/shared/__tests__/truncate-utils.test.ts` — 5/5 passed

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)