### PR TITLE
feat: Wave 2 Layer 3 stored tool result context

### DIFF
--- a/docs/spike/tool-result-rewrite.md
+++ b/docs/spike/tool-result-rewrite.md
@@ -1,0 +1,36 @@
+# tool_result 差し替えスパイク
+
+Issue #36 / Wave 2-0 の事前確認メモ。
+
+## 結論
+
+- SiteSurf の現在実装は Vercel AI SDK の UI message / `toSDKMessages` を直接使っていない。
+- 代わりに `src/ports/ai-provider.ts` の独自 `AIMessage` 形式を `runAgentLoop()` で保持し、各アダプタへそのまま渡している。
+- そのため **Layer 3 の「tool result を後から要約へ差し替える」処理はアプリ側メッセージ配列の書き換えで実装可能**。
+- `node_modules/ai/src/ui/convert-to-model-messages.ts` を確認した限り、AI SDK 側も `toolCallId` / `tool-result` を入力配列から都度組み立てる実装で、 immutable な内部参照に依存していない。
+
+## 確認内容
+
+### 1. SiteSurf 側の実際の経路
+
+- `src/orchestration/agent-loop.ts`
+  - `messages: AIMessage[]` を自前で保持
+  - 各ターン前に `manageContextMessages()` で内容を書き換え
+  - `aiProvider.streamText({ messages, ... })` にそのまま渡す
+- `src/ports/ai-provider.ts`
+  - `ToolResultMessage` は単純な `{ role: "tool", toolCallId, toolName, result }`
+  - `result` は文字列なので、要約文字列への置換が容易
+
+### 2. Vercel AI SDK 側の確認
+
+- `node_modules/ai/src/ui/convert-to-model-messages.ts`
+  - `toolCallId` と `tool-result` を入力パーツから毎回変換している
+  - 変換前オブジェクトの identity 固定を前提とした実装は見当たらない
+- `node_modules/ai/docs/03-agents/04-loop-control.mdx`
+  - `prepareStep` 内で tool result を要約して送る例があり、送信前の message 変換は想定ユースケース
+
+## 実装判断
+
+- Wave 2 は **tool result 本体を Store に退避し、履歴上は summary + key に置換する方針で進める**。
+- `get_tool_result` で pull 取得した完全版も、次ターン以降は再び summary へ戻す。
+- live provider 実験（Anthropic / OpenAI / Google / local の実 API 呼び出し）はこの worktree では未実施。必要なら別途手動確認を追加する。

--- a/src/adapters/auth/__tests__/openai-oauth-integration.test.ts
+++ b/src/adapters/auth/__tests__/openai-oauth-integration.test.ts
@@ -5,6 +5,7 @@ import type { AuthCallbacks, AuthCredentials } from "@/ports/auth-provider";
 import { runAgentLoop, type AgentLoopParams, type ChatActions } from "@/orchestration/agent-loop";
 import type { Session } from "@/ports/session-types";
 import type { AIProvider, StreamEvent, ProviderConfig } from "@/ports/ai-provider";
+import type { ToolResultStorePort } from "@/ports/tool-result-store";
 import { ok, err } from "@/shared/errors";
 import { SkillRegistry } from "@/shared/skill-registry";
 
@@ -23,6 +24,13 @@ vi.stubGlobal("crypto", {
   },
   subtle: { digest: mockDigest },
 });
+
+const mockToolResultStore: ToolResultStorePort = {
+  save: async () => {},
+  get: async () => null,
+  list: async () => [],
+  deleteSession: async () => {},
+};
 
 function createMockBrowser(overrides: Partial<BrowserExecutor> = {}): BrowserExecutor {
   return {
@@ -583,6 +591,7 @@ describe("OpenAI OAuth Integration Tests", () => {
           createAIProvider: () => mockAIProvider,
           browserExecutor: browser,
           authProvider: mockAuthProvider,
+          toolResultStore: mockToolResultStore,
         },
         chatStore,
         settings: {
@@ -643,6 +652,7 @@ describe("OpenAI OAuth Integration Tests", () => {
           createAIProvider: () => mockAIProvider,
           browserExecutor: browser,
           authProvider: mockAuthProvider,
+          toolResultStore: mockToolResultStore,
         },
         chatStore,
         settings: {

--- a/src/adapters/storage/__tests__/indexeddb-tool-result-store.test.ts
+++ b/src/adapters/storage/__tests__/indexeddb-tool-result-store.test.ts
@@ -1,0 +1,87 @@
+import "fake-indexeddb/auto";
+import { beforeEach, describe, expect, it } from "vitest";
+import { IndexedDBToolResultStore } from "../indexeddb-tool-result-store";
+
+describe("IndexedDBToolResultStore", () => {
+  let store: IndexedDBToolResultStore;
+
+  beforeEach(() => {
+    store = new IndexedDBToolResultStore();
+  });
+
+  it("saves and retrieves a stored tool result", async () => {
+    await store.save("session-1", {
+      key: "tc_one",
+      toolName: "read_page",
+      fullValue: "full result",
+      summary: "summary",
+      turnIndex: 2,
+    });
+
+    const result = await store.get("session-1", "tc_one");
+
+    expect(result).toMatchObject({
+      key: "tc_one",
+      sessionId: "session-1",
+      toolName: "read_page",
+      fullValue: "full result",
+      summary: "summary",
+      turnIndex: 2,
+    });
+  });
+
+  it("isolates results by sessionId", async () => {
+    await store.save("session-1", {
+      key: "tc_shared",
+      toolName: "read_page",
+      fullValue: "full result",
+      summary: "summary",
+      turnIndex: 0,
+    });
+
+    await expect(store.get("session-2", "tc_shared")).resolves.toBeNull();
+  });
+
+  it("lists newest results first for a session", async () => {
+    await store.save("session-list", {
+      key: "tc_old",
+      toolName: "navigate",
+      fullValue: "old",
+      summary: "old",
+      turnIndex: 0,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 2));
+    await store.save("session-list", {
+      key: "tc_new",
+      toolName: "read_page",
+      fullValue: "new",
+      summary: "new",
+      turnIndex: 1,
+    });
+
+    const results = await store.list("session-list");
+    expect(results.map((result) => result.key)).toEqual(["tc_new", "tc_old"]);
+  });
+
+  it("deletes only one session namespace", async () => {
+    await store.save("session-1", {
+      key: "tc_a",
+      toolName: "read_page",
+      fullValue: "a",
+      summary: "a",
+      turnIndex: 0,
+    });
+    await store.save("session-2", {
+      key: "tc_b",
+      toolName: "read_page",
+      fullValue: "b",
+      summary: "b",
+      turnIndex: 0,
+    });
+
+    await store.deleteSession("session-1");
+
+    await expect(store.get("session-1", "tc_a")).resolves.toBeNull();
+    await expect(store.get("session-2", "tc_b")).resolves.toMatchObject({ key: "tc_b" });
+  });
+});

--- a/src/adapters/storage/in-memory-storage.ts
+++ b/src/adapters/storage/in-memory-storage.ts
@@ -1,4 +1,5 @@
 import type { ArtifactFile, ArtifactStoragePort } from "@/ports/artifact-storage";
+import type { StoredToolResult, ToolResultStorePort } from "@/ports/tool-result-store";
 import type { StoragePort } from "@/ports/storage";
 
 export class InMemoryArtifactStorage implements ArtifactStoragePort {
@@ -64,5 +65,42 @@ export class InMemoryStorage implements StoragePort {
 
   async remove(key: string): Promise<void> {
     this.store.delete(key);
+  }
+}
+
+export class InMemoryToolResultStore implements ToolResultStorePort {
+  private results = new Map<string, StoredToolResult>();
+
+  async save(
+    sessionId: string,
+    result: Omit<StoredToolResult, "createdAt" | "sessionId">,
+  ): Promise<void> {
+    this.results.set(result.key, {
+      ...result,
+      sessionId,
+      createdAt: Date.now(),
+    });
+  }
+
+  async get(sessionId: string, key: string): Promise<StoredToolResult | null> {
+    const result = this.results.get(key);
+    if (!result || result.sessionId !== sessionId) {
+      return null;
+    }
+    return result;
+  }
+
+  async list(sessionId: string): Promise<StoredToolResult[]> {
+    return [...this.results.values()]
+      .filter((result) => result.sessionId === sessionId)
+      .sort((left, right) => right.createdAt - left.createdAt);
+  }
+
+  async deleteSession(sessionId: string): Promise<void> {
+    for (const [key, result] of this.results.entries()) {
+      if (result.sessionId === sessionId) {
+        this.results.delete(key);
+      }
+    }
   }
 }

--- a/src/adapters/storage/indexeddb-tool-result-store.ts
+++ b/src/adapters/storage/indexeddb-tool-result-store.ts
@@ -1,0 +1,137 @@
+import type { StoredToolResult, ToolResultStorePort } from "@/ports/tool-result-store";
+import { createLogger } from "@/shared/logger";
+
+const log = createLogger("indexeddb-tool-result-store");
+
+const DB_NAME = "tandemweb";
+const DB_VERSION = 2;
+const STORE_NAME = "tool-results";
+const SESSION_INDEX = "sessionId";
+const SESSION_CREATED_INDEX = "sessionId_createdAt";
+
+export class IndexedDBToolResultStore implements ToolResultStorePort {
+  private db: IDBDatabase | null = null;
+
+  private async getDB(): Promise<IDBDatabase> {
+    if (this.db) return this.db;
+
+    return new Promise((resolve, reject) => {
+      const req = indexedDB.open(DB_NAME, DB_VERSION);
+
+      req.onupgradeneeded = () => {
+        const db = req.result;
+
+        if (!db.objectStoreNames.contains("sessions")) {
+          db.createObjectStore("sessions", { keyPath: "id" });
+        }
+
+        if (!db.objectStoreNames.contains("sessions-metadata")) {
+          const meta = db.createObjectStore("sessions-metadata", { keyPath: "id" });
+          meta.createIndex("lastModified", "lastModified");
+        }
+
+        if (!db.objectStoreNames.contains(STORE_NAME)) {
+          const store = db.createObjectStore(STORE_NAME, { keyPath: "key" });
+          store.createIndex(SESSION_INDEX, "sessionId", { unique: false });
+          store.createIndex(SESSION_CREATED_INDEX, ["sessionId", "createdAt"], { unique: false });
+        }
+      };
+
+      req.onsuccess = () => {
+        this.db = req.result;
+        resolve(this.db);
+      };
+
+      req.onerror = () => {
+        log.error("IndexedDB open error", req.error);
+        reject(req.error);
+      };
+    });
+  }
+
+  async save(
+    sessionId: string,
+    result: Omit<StoredToolResult, "createdAt" | "sessionId">,
+  ): Promise<void> {
+    const db = await this.getDB();
+    const record: StoredToolResult = {
+      ...result,
+      sessionId,
+      createdAt: Date.now(),
+    };
+
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(STORE_NAME, "readwrite");
+      tx.objectStore(STORE_NAME).put(record);
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => {
+        log.error("save tool result error", tx.error);
+        reject(tx.error);
+      };
+    });
+  }
+
+  async get(sessionId: string, key: string): Promise<StoredToolResult | null> {
+    const db = await this.getDB();
+
+    return new Promise((resolve, reject) => {
+      const req = db.transaction(STORE_NAME, "readonly").objectStore(STORE_NAME).get(key);
+      req.onsuccess = () => {
+        const value = (req.result as StoredToolResult | undefined) ?? null;
+        if (value?.sessionId !== sessionId) {
+          resolve(null);
+          return;
+        }
+        resolve(value);
+      };
+      req.onerror = () => reject(req.error);
+    });
+  }
+
+  async list(sessionId: string): Promise<StoredToolResult[]> {
+    const db = await this.getDB();
+
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(STORE_NAME, "readonly");
+      const index = tx.objectStore(STORE_NAME).index(SESSION_CREATED_INDEX);
+      const range = IDBKeyRange.bound([sessionId, 0], [sessionId, Number.MAX_SAFE_INTEGER]);
+      const req = index.openCursor(range, "prev");
+      const results: StoredToolResult[] = [];
+
+      req.onsuccess = () => {
+        const cursor = req.result;
+        if (cursor) {
+          results.push(cursor.value as StoredToolResult);
+          cursor.continue();
+          return;
+        }
+        resolve(results);
+      };
+      req.onerror = () => reject(req.error);
+    });
+  }
+
+  async deleteSession(sessionId: string): Promise<void> {
+    const db = await this.getDB();
+
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(STORE_NAME, "readwrite");
+      const index = tx.objectStore(STORE_NAME).index(SESSION_INDEX);
+      const req = index.openKeyCursor(IDBKeyRange.only(sessionId));
+
+      req.onsuccess = () => {
+        const cursor = req.result;
+        if (cursor) {
+          tx.objectStore(STORE_NAME).delete(cursor.primaryKey);
+          cursor.continue();
+        }
+      };
+
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => {
+        log.error("delete session tool results error", tx.error);
+        reject(tx.error);
+      };
+    });
+  }
+}

--- a/src/features/ai/__tests__/system-prompt-v2.test.ts
+++ b/src/features/ai/__tests__/system-prompt-v2.test.ts
@@ -104,4 +104,11 @@ describe("getSystemPromptV2", () => {
     const prompt = getSystemPromptV2({});
     expect(prompt).toContain("CRITICAL");
   });
+
+  it("includes stored tool result guidance when enabled", () => {
+    const prompt = getSystemPromptV2({ includeToolResultStore: true });
+    expect(prompt).toContain("Stored Tool Results");
+    expect(prompt).toContain("get_tool_result");
+    expect(prompt).toContain("after 1 turn");
+  });
 });

--- a/src/features/ai/prompt-cache.ts
+++ b/src/features/ai/prompt-cache.ts
@@ -15,6 +15,7 @@ interface CacheEntry {
 export function createPromptCacheKey(options: SystemPromptOptions): string {
   const parts: string[] = [
     `skills:${options.includeSkills ?? false}`,
+    `tool-results:${options.includeToolResultStore ?? false}`,
     `locale:${options.locale ?? "default"}`,
   ];
 

--- a/src/features/ai/system-prompt-v2.ts
+++ b/src/features/ai/system-prompt-v2.ts
@@ -5,6 +5,7 @@ import { PromptCache, createPromptCacheKey } from "./prompt-cache";
 export interface SystemPromptOptions {
   includeSkills?: boolean;
   skills?: SkillMatch[];
+  includeToolResultStore?: boolean;
   locale?: string;
 }
 
@@ -97,8 +98,18 @@ export function getSystemPromptV2(options: SystemPromptOptions): string {
 
   const skillsSection =
     options.includeSkills && options.skills ? generateSkillsSection(options.skills) : "";
+  const toolResultSection = options.includeToolResultStore
+    ? [
+        "# Stored Tool Results",
+        "",
+        "When a tool result includes `Stored: tool_result://<key>`, only a summary is in context.",
+        'Use `get_tool_result({"key": "<key>"})` when you need the full content.',
+        "The retrieved full content automatically returns to summary form after 1 turn, so only re-fetch it when immediately needed.",
+      ].join("\n")
+    : "";
 
-  const prompt = skillsSection ? `${base}\n\n${skillsSection}` : base;
+  const sections = [base, skillsSection, toolResultSection].filter((section) => section.length > 0);
+  const prompt = sections.join("\n\n");
 
   cache.set(key, prompt);
 

--- a/src/features/tools/__tests__/get-tool-result.test.ts
+++ b/src/features/tools/__tests__/get-tool-result.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { InMemoryToolResultStore } from "@/adapters/storage/in-memory-storage";
+import { executeGetToolResult, getToolResultToolDef } from "../get-tool-result";
+
+describe("get_tool_result", () => {
+  it("returns stored result for a matching session", async () => {
+    const store = new InMemoryToolResultStore();
+    await store.save("session-1", {
+      key: "tc_key",
+      toolName: "read_page",
+      fullValue: "FULL",
+      summary: "SUMMARY",
+      turnIndex: 0,
+    });
+
+    const result = await executeGetToolResult(store, "session-1", { key: "tc_key" });
+
+    expect(result).toEqual({
+      ok: true,
+      value: {
+        key: "tc_key",
+        toolName: "read_page",
+        fullValue: "FULL",
+        summary: "SUMMARY",
+      },
+    });
+  });
+
+  it("defines key as a required parameter", () => {
+    const parameters = getToolResultToolDef.parameters as { required?: string[] };
+    expect(parameters.required).toContain("key");
+  });
+});

--- a/src/features/tools/__tests__/integration.test.ts
+++ b/src/features/tools/__tests__/integration.test.ts
@@ -10,13 +10,18 @@ import {
 import { SkillRegistry, type SkillMatch } from "../skills";
 import type { BrowserExecutor, PageContent } from "@/ports/browser-executor";
 import { ok } from "@/shared/errors";
-import { InMemoryArtifactStorage, InMemoryStorage } from "@/adapters/storage/in-memory-storage";
+import {
+  InMemoryArtifactStorage,
+  InMemoryStorage,
+  InMemoryToolResultStore,
+} from "@/adapters/storage/in-memory-storage";
 
 function createToolExecutor(name: string, args: Record<string, unknown>, browser: BrowserExecutor) {
   return createToolExecutorWithSkills(
     new SkillRegistry(),
     new InMemoryArtifactStorage(),
     new InMemoryStorage(),
+    new InMemoryToolResultStore(),
   )(name, args, browser);
 }
 
@@ -172,6 +177,7 @@ describe("2段階抽出ワークフロー", () => {
     it("getAgentToolDefs: 引数なしで bg_fetch を除外する", () => {
       const names = getAgentToolDefs().map((t) => t.name);
       expect(names).not.toContain("bg_fetch");
+      expect(names).not.toContain("get_tool_result");
       expect(names).not.toContain("skill");
     });
 
@@ -183,7 +189,13 @@ describe("2段階抽出ワークフロー", () => {
     it("getAgentToolDefs: enableBgFetch=true で bg_fetch を含む", () => {
       const names = getAgentToolDefs({ enableBgFetch: true }).map((t) => t.name);
       expect(names).toContain("bg_fetch");
+      expect(names).not.toContain("get_tool_result");
       expect(names).not.toContain("skill");
+    });
+
+    it("getAgentToolDefs: enableToolResultStore=true で get_tool_result を含む", () => {
+      const names = getAgentToolDefs({ enableToolResultStore: true }).map((t) => t.name);
+      expect(names).toContain("get_tool_result");
     });
   });
 
@@ -229,6 +241,7 @@ describe("2段階抽出ワークフロー", () => {
         registry,
         new InMemoryArtifactStorage(),
         storage,
+        new InMemoryToolResultStore(),
       );
 
       const createResult = await executor(
@@ -274,6 +287,7 @@ describe("2段階抽出ワークフロー", () => {
         registry,
         new InMemoryArtifactStorage(),
         storage,
+        new InMemoryToolResultStore(),
       );
 
       const createResult = await executor(

--- a/src/features/tools/__tests__/result-summarizer.test.ts
+++ b/src/features/tools/__tests__/result-summarizer.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatRetrievedToolResult,
+  formatStoredToolResultSummary,
+  restoreRetrievedToolResultToSummary,
+  shouldStore,
+  summarizeToolResult,
+} from "../result-summarizer";
+
+describe("result-summarizer", () => {
+  it("summarizes read_page results with url and preview", () => {
+    const summary = summarizeToolResult({
+      toolName: "read_page",
+      args: {},
+      fullResult: JSON.stringify({ text: "Welcome to SiteSurf" }),
+      rawValue: { text: "Welcome to SiteSurf\nThis is the body" },
+      isError: false,
+      currentUrl: "https://example.com",
+    });
+
+    expect(summary).toContain("URL: https://example.com");
+    expect(summary).toContain("Body preview:");
+  });
+
+  it("does not store short results", () => {
+    expect(
+      shouldStore({
+        toolName: "read_page",
+        fullResult: "x".repeat(499),
+        summary: "short",
+        isError: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not store when summary and full result are nearly identical", () => {
+    expect(
+      shouldStore({
+        toolName: "read_page",
+        fullResult: "x".repeat(700),
+        summary: "x".repeat(550),
+        isError: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("restores fetched full content back to stored summary format", () => {
+    const full = formatRetrievedToolResult({
+      key: "tc_abc",
+      toolName: "read_page",
+      fullValue: "FULL CONTENT",
+      summary: "Body preview: hello",
+    });
+
+    expect(restoreRetrievedToolResultToSummary(full)).toBe(
+      formatStoredToolResultSummary("read_page", "Body preview: hello", "tc_abc"),
+    );
+  });
+});

--- a/src/features/tools/get-tool-result.ts
+++ b/src/features/tools/get-tool-result.ts
@@ -1,0 +1,57 @@
+import type { ToolDefinition } from "@/ports/ai-provider";
+import type { ToolResultStorePort } from "@/ports/tool-result-store";
+import { err, ok, type Result, type ToolError } from "@/shared/errors";
+
+export interface GetToolResultArgs {
+  key: string;
+}
+
+export interface GetToolResultValue {
+  key: string;
+  toolName: string;
+  fullValue: string;
+  summary: string;
+}
+
+export const getToolResultToolDef: ToolDefinition = {
+  name: "get_tool_result",
+  description:
+    "Retrieve the full content of a previous tool result by key. " +
+    "Keys appear in summaries as 'tool_result://<key>'. " +
+    "After one turn, the retrieved content returns to summary form.",
+  parameters: {
+    type: "object",
+    properties: {
+      key: {
+        type: "string",
+        description: "Key from a previous tool result summary",
+      },
+    },
+    required: ["key"],
+  },
+};
+
+export async function executeGetToolResult(
+  store: ToolResultStorePort,
+  sessionId: string,
+  args: GetToolResultArgs,
+): Promise<Result<GetToolResultValue, ToolError>> {
+  if (!args.key) {
+    return err({ code: "tool_script_error", message: "key is required" });
+  }
+
+  const result = await store.get(sessionId, args.key);
+  if (!result) {
+    return err({
+      code: "tool_script_error",
+      message: `Stored tool result not found for key: ${args.key}`,
+    });
+  }
+
+  return ok({
+    key: result.key,
+    toolName: result.toolName,
+    fullValue: result.fullValue,
+    summary: result.summary,
+  });
+}

--- a/src/features/tools/index.ts
+++ b/src/features/tools/index.ts
@@ -1,6 +1,7 @@
 import type { ToolDefinition } from "@/ports/ai-provider";
 import type { ArtifactStoragePort } from "@/ports/artifact-storage";
 import type { StoragePort } from "@/ports/storage";
+import type { ToolResultStorePort } from "@/ports/tool-result-store";
 import type { ToolExecutionHooks, ToolExecutor } from "@/ports/tool-executor";
 import { SkillRegistry } from "@/shared/skill-registry";
 import { useStore } from "@/store/index";
@@ -38,6 +39,12 @@ import {
   type DeleteSkillDraftResult,
 } from "./skill";
 import { bgFetchToolDef, executeBgFetch } from "./bg-fetch";
+import {
+  getToolResultToolDef,
+  executeGetToolResult,
+  type GetToolResultArgs,
+  type GetToolResultValue,
+} from "./get-tool-result";
 import { artifactsTool } from "./definitions/artifacts-tool";
 import { handleArtifactsTool } from "./handlers/artifacts-handler";
 
@@ -60,6 +67,7 @@ export {
   executeDeleteSkillDraft,
 };
 export { bgFetchToolDef, executeBgFetch };
+export { getToolResultToolDef, executeGetToolResult };
 export { artifactsTool, handleArtifactsTool };
 export type {
   SkillAction,
@@ -80,6 +88,7 @@ export type {
 export type { ScreenshotResult } from "./screenshot";
 export type { ExtractImageResult } from "./extract-image";
 export type { ArtifactsParams } from "./handlers/artifacts-handler";
+export type { GetToolResultArgs, GetToolResultValue } from "./get-tool-result";
 export { loadSkillRegistry } from "./skills";
 export type { SkillRegistry } from "@/shared/skill-registry";
 export type {
@@ -105,16 +114,23 @@ export const ALL_TOOL_DEFS: ToolDefinition[] = [
   deleteSkillDraftToolDef,
   artifactsTool,
   bgFetchToolDef,
+  getToolResultToolDef,
 ];
 
 export const AGENT_TOOL_DEFS: ToolDefinition[] = ALL_TOOL_DEFS.filter(
   (tool) => tool.name !== "skill",
 );
 
-export function getAgentToolDefs(options?: { enableBgFetch?: boolean }): ToolDefinition[] {
-  const defs = AGENT_TOOL_DEFS;
+export function getAgentToolDefs(options?: {
+  enableBgFetch?: boolean;
+  enableToolResultStore?: boolean;
+}): ToolDefinition[] {
+  let defs = AGENT_TOOL_DEFS;
   if (!options?.enableBgFetch) {
-    return defs.filter((tool) => tool.name !== "bg_fetch");
+    defs = defs.filter((tool) => tool.name !== "bg_fetch");
+  }
+  if (!options?.enableToolResultStore) {
+    defs = defs.filter((tool) => tool.name !== "get_tool_result");
   }
   return defs;
 }
@@ -125,6 +141,7 @@ export function createToolExecutorWithSkills(
   skillRegistry: SkillRegistry,
   artifactStorage: ArtifactStoragePort & { setSessionId(id: string | null): void },
   storage: StoragePort,
+  toolResultStore: ToolResultStorePort,
 ): ToolExecutor {
   return async (name, args, browser, signal, hooks?: ToolExecutionHooks) => {
     // Ensure storage session ID matches current session
@@ -183,6 +200,22 @@ export function createToolExecutorWithSkills(
           };
         }
         return executeBgFetch(args);
+      }
+      case "get_tool_result": {
+        if (!currentSessionId) {
+          return {
+            ok: false as const,
+            error: {
+              code: "tool_script_error" as const,
+              message: "No active session for get_tool_result",
+            },
+          };
+        }
+        return executeGetToolResult(
+          toolResultStore,
+          currentSessionId,
+          args as unknown as GetToolResultArgs,
+        );
       }
       case "skill": {
         const tab = await browser.getActiveTab();

--- a/src/features/tools/result-summarizer.ts
+++ b/src/features/tools/result-summarizer.ts
@@ -1,0 +1,185 @@
+import type { StoredToolResult } from "@/ports/tool-result-store";
+
+const MAX_SUMMARY_CHARS = 300;
+
+export interface SummarizeToolResultInput {
+  toolName: string;
+  args: Record<string, unknown>;
+  fullResult: string;
+  rawValue?: unknown;
+  isError: boolean;
+  currentUrl?: string;
+  consoleTail?: string[];
+}
+
+function truncate(text: string, limit: number): string {
+  return text.length > limit ? `${text.slice(0, limit)}…` : text;
+}
+
+function normalizeWhitespace(text: string): string {
+  return text.replace(/\s+/g, " ").trim();
+}
+
+function previewText(value: string, limit = 200): string {
+  return truncate(normalizeWhitespace(value), limit);
+}
+
+function getRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function getString(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function summarizeReadPage(input: SummarizeToolResultInput): string {
+  const record = getRecord(input.rawValue);
+  const text = getString(record?.text) ?? input.fullResult;
+  const firstLine = text
+    .split("\n")
+    .map((line) => line.trim())
+    .find((line) => line.length > 0);
+
+  const parts = [
+    firstLine ? `H1: ${truncate(firstLine, 80)}` : null,
+    input.currentUrl ? `URL: ${input.currentUrl}` : null,
+    `Body preview: ${previewText(text)}`,
+  ].filter(Boolean);
+
+  return parts.join(" / ");
+}
+
+function summarizeBgFetch(input: SummarizeToolResultInput): string {
+  const items = Array.isArray(input.rawValue) ? input.rawValue : [input.rawValue];
+  const urls = items
+    .map((item) => {
+      const record = getRecord(item);
+      const url = getString(record?.url);
+      if (!url) return null;
+      const body = getRecord(record?.body);
+      const title = getString(body?.title);
+      return title ? `${url} (${truncate(title, 50)})` : url;
+    })
+    .filter((value): value is string => value !== null)
+    .slice(0, 3);
+
+  const successCount = items.filter((item) => getRecord(item)?.ok === true).length;
+  const failCount = items.length - successCount;
+  return `Fetched ${items.length} URL(s): ${urls.join(", ") || "no urls"} / success: ${successCount}/fail: ${failCount}`;
+}
+
+function summarizeRepl(input: SummarizeToolResultInput): string {
+  const valueType = Array.isArray(input.rawValue)
+    ? "array"
+    : input.rawValue === null
+      ? "null"
+      : typeof input.rawValue;
+  const consoleText =
+    input.consoleTail && input.consoleTail.length > 0
+      ? ` / console: ${previewText(input.consoleTail.join(" | "), 120)}`
+      : "";
+  return `return type: ${valueType} / value preview: ${previewText(input.fullResult)}${consoleText}`;
+}
+
+function summarizeNavigate(input: SummarizeToolResultInput): string {
+  const record = getRecord(input.rawValue);
+  const finalUrl = getString(record?.finalUrl) ?? input.currentUrl ?? "unknown";
+  return `→ ${finalUrl}`;
+}
+
+function summarizeArtifacts(input: SummarizeToolResultInput): string {
+  const command = getString(input.args.command) ?? "unknown";
+  const filename = getString(input.args.filename) ?? "unknown";
+  if (command === "get") {
+    return `${filename} retrieved`;
+  }
+  return `${command}: ${filename}`;
+}
+
+export function summarizeToolResult(input: SummarizeToolResultInput): string {
+  if (input.isError) {
+    return truncate(`ERROR: ${previewText(input.fullResult, 180)}`, MAX_SUMMARY_CHARS);
+  }
+
+  if (input.fullResult === "[screenshot captured]" || input.toolName === "screenshot") {
+    return "[screenshot captured]";
+  }
+
+  const summary = (() => {
+    switch (input.toolName) {
+      case "read_page":
+        return summarizeReadPage(input);
+      case "bg_fetch":
+        return summarizeBgFetch(input);
+      case "repl":
+      case "browserjs":
+        return summarizeRepl(input);
+      case "navigate":
+        return summarizeNavigate(input);
+      case "artifacts":
+        return summarizeArtifacts(input);
+      case "get_tool_result":
+        return previewText(input.fullResult, MAX_SUMMARY_CHARS);
+      default:
+        return previewText(input.fullResult, MAX_SUMMARY_CHARS);
+    }
+  })();
+
+  return truncate(summary, MAX_SUMMARY_CHARS);
+}
+
+export function shouldStore(input: {
+  toolName: string;
+  fullResult: string;
+  summary: string;
+  isError: boolean;
+}): boolean {
+  if (input.isError) return false;
+  if (input.toolName === "get_tool_result") return false;
+  if (input.fullResult === "[screenshot captured]") return false;
+  if (input.fullResult.length < 500) return false;
+  if (input.fullResult.length - input.summary.length < 200) return false;
+  return true;
+}
+
+export function createToolResultKey(): string {
+  return `tc_${crypto.randomUUID().replace(/-/g, "").slice(0, 12)}`;
+}
+
+export function formatStoredToolResultSummary(
+  toolName: string,
+  summary: string,
+  key?: string,
+): string {
+  const lines = [`[${toolName}]`, summary];
+  if (key) {
+    lines.push(`Stored: tool_result://${key}`);
+    lines.push(`Use get_tool_result("${key}") for full content.`);
+  }
+  return lines.join("\n");
+}
+
+export function formatRetrievedToolResult(
+  result: Pick<StoredToolResult, "key" | "toolName" | "fullValue" | "summary">,
+): string {
+  return [
+    "[get_tool_result]",
+    `Restored: tool_result://${result.key}`,
+    `Original tool: ${result.toolName}`,
+    "Summary:",
+    result.summary,
+    "---",
+    result.fullValue,
+  ].join("\n");
+}
+
+export function restoreRetrievedToolResultToSummary(result: string): string | null {
+  const match = result.match(
+    /^\[get_tool_result\]\nRestored: tool_result:\/\/([^\n]+)\nOriginal tool: ([^\n]+)\nSummary:\n([\s\S]*?)\n---\n[\s\S]*$/,
+  );
+  if (!match) return null;
+  const [, key, toolName, summary] = match;
+  return formatStoredToolResultSummary(toolName, summary.trim(), key);
+}

--- a/src/orchestration/__tests__/agent-loop.test.ts
+++ b/src/orchestration/__tests__/agent-loop.test.ts
@@ -12,6 +12,7 @@ import { ok, err } from "@/shared/errors";
 import { initStore, useStore } from "@/store/index";
 import { defaultConsoleLogService } from "@/features/chat/services/console-log";
 import type { ArtifactStoragePort } from "@/ports/artifact-storage";
+import type { ToolResultStorePort } from "@/ports/tool-result-store";
 import { estimateTokens } from "@/shared/token-utils";
 
 const mockArtifactStorage: ArtifactStoragePort & { setSessionId(id: string | null): void } = {
@@ -25,6 +26,13 @@ const mockArtifactStorage: ArtifactStoragePort & { setSessionId(id: string | nul
   deleteFile: async () => {},
   clearAll: async () => {},
   setSessionId: () => {},
+};
+
+const mockToolResultStore: ToolResultStorePort = {
+  save: async () => {},
+  get: async () => null,
+  list: async () => [],
+  deleteSession: async () => {},
 };
 
 vi.mock("@/shared/utils", () => ({
@@ -128,6 +136,7 @@ function createParams(overrides?: Partial<AgentLoopParams>): AgentLoopParams {
     deps: {
       createAIProvider: () => createMockAIProvider(),
       browserExecutor: {} as BrowserExecutor,
+      toolResultStore: mockToolResultStore,
     },
     chatStore: createMockChatStore(),
     settings: {
@@ -209,6 +218,56 @@ describe("runAgentLoop", () => {
       ok: true,
       value: { content: "page text" },
     });
+  });
+
+  it("stores large tool results as summaries when tool result store is enabled", async () => {
+    setStreamEvents(
+      [
+        { type: "tool-call", id: "tc-store", name: "read_page", args: {} },
+        { type: "finish", finishReason: "tool-calls" },
+      ],
+      [
+        { type: "text-delta", text: "done" },
+        { type: "finish", finishReason: "stop" },
+      ],
+    );
+
+    const save = vi.fn(async () => undefined);
+    const syncHistory = vi.fn();
+    const params = createParams({
+      settings: {
+        provider: "openai",
+        model: "gpt-4",
+        apiKey: "sk-test",
+        baseUrl: "",
+        enterpriseDomain: "",
+      },
+      deps: {
+        createAIProvider: () => createMockAIProvider(),
+        browserExecutor: {
+          getActiveTab: vi.fn().mockResolvedValue({ url: "https://example.com", title: "Example" }),
+        } as unknown as BrowserExecutor,
+        toolResultStore: { ...mockToolResultStore, save },
+      },
+      chatStore: createMockChatStore({ syncHistory }),
+      toolExecutor: vi.fn().mockResolvedValue({
+        ok: true,
+        value: { text: "A".repeat(1200), simplifiedDom: "" },
+      }),
+    });
+
+    await runAgentLoop(params);
+
+    expect(save).toHaveBeenCalledTimes(1);
+    const [messages] = syncHistory.mock.calls.at(-1) ?? [];
+    expect(messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          role: "tool",
+          result: expect.stringContaining("Stored: tool_result://"),
+        }),
+      ]),
+    );
   });
 
   it("repl 実行時は console log callback を渡して realtime log service に反映できる", async () => {
@@ -315,7 +374,11 @@ describe("runAgentLoop", () => {
     const params = createParams({
       chatStore,
       skillRegistry: registry,
-      deps: { createAIProvider: () => createMockAIProvider(), browserExecutor },
+      deps: {
+        createAIProvider: () => createMockAIProvider(),
+        browserExecutor,
+        toolResultStore: mockToolResultStore,
+      },
     });
     await runAgentLoop(params);
 
@@ -393,6 +456,7 @@ describe("auth refresh on ai_auth_invalid", () => {
         createAIProvider: () => createMockAIProvider(),
         browserExecutor: {} as BrowserExecutor,
         authProvider: mockAuthProvider,
+        toolResultStore: mockToolResultStore,
       },
       credentials: createMockCredentials(),
       onCredentialsUpdate,
@@ -433,6 +497,7 @@ describe("auth refresh on ai_auth_invalid", () => {
         createAIProvider: () => createMockAIProvider(),
         browserExecutor: {} as BrowserExecutor,
         authProvider: mockAuthProvider,
+        toolResultStore: mockToolResultStore,
       },
       credentials: createMockCredentials(),
       onCredentialsUpdate,
@@ -464,6 +529,7 @@ describe("auth refresh on ai_auth_invalid", () => {
         createAIProvider: () => createMockAIProvider(),
         browserExecutor: {} as BrowserExecutor,
         authProvider: mockAuthProvider,
+        toolResultStore: mockToolResultStore,
       },
     });
 
@@ -764,6 +830,7 @@ describe("tool execution error", () => {
         createAIProvider: () => createMockAIProvider(),
         browserExecutor: {} as BrowserExecutor,
         securityMiddleware: createSecurityMiddleware({ auditLogger }),
+        toolResultStore: mockToolResultStore,
       },
     });
     vi.mocked(params.toolExecutor).mockResolvedValueOnce({
@@ -806,6 +873,7 @@ describe("tool execution error", () => {
         createAIProvider: () => createMockAIProvider(),
         browserExecutor: {} as BrowserExecutor,
         securityMiddleware: createSecurityMiddleware({ auditLogger }),
+        toolResultStore: mockToolResultStore,
       },
     });
     vi.mocked(params.toolExecutor).mockResolvedValueOnce({
@@ -860,14 +928,10 @@ describe("context budget integration", () => {
       messages: Array<{ role: string; result?: string; toolName?: string }>;
     };
     const toolMessage = secondCall.messages.find((message) => message.role === "tool");
-    const budget = getContextBudget("gpt-4");
 
     expect(toolMessage?.toolName).toBe("read_page");
-    expect(toolMessage?.result).toMatch(/^\{"text":"/);
-    expect(toolMessage?.result).toMatch(/\n\.\.\. \(truncated\)$/);
-    expect(toolMessage?.result).toHaveLength(
-      budget.maxToolResultChars + "\n... (truncated)".length,
-    );
+    expect(toolMessage?.result).toContain("Stored: tool_result://");
+    expect(toolMessage?.result).toContain("Body preview:");
   });
 
   it("retries context overflow after trimming down to budget.compressionThreshold", async () => {

--- a/src/orchestration/__tests__/context-manager.test.ts
+++ b/src/orchestration/__tests__/context-manager.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { manageContextMessages } from "../context-manager";
+import { formatRetrievedToolResult } from "@/features/tools/result-summarizer";
+import type { ContextBudget } from "@/features/ai/context-budget";
+import type { AIMessage } from "@/ports/ai-provider";
+
+const budget: ContextBudget = {
+  windowTokens: 32768,
+  outputReserve: 4096,
+  inputBudget: 28672,
+  maxToolResultChars: 1000,
+  compressionThreshold: 15000,
+  trimThreshold: 20000,
+  useToolResultStore: true,
+};
+
+describe("context-manager", () => {
+  it("replaces old get_tool_result full content with the stored summary form", () => {
+    const messages: AIMessage[] = [
+      {
+        role: "tool",
+        toolCallId: "tool-1",
+        toolName: "get_tool_result",
+        result: formatRetrievedToolResult({
+          key: "tc_1",
+          toolName: "read_page",
+          fullValue: "FULL CONTENT",
+          summary: "Body preview: hello",
+        }),
+      },
+      { role: "assistant", content: [{ type: "text", text: "I used it." }] },
+    ];
+
+    manageContextMessages(messages, budget);
+
+    expect((messages[0] as Extract<AIMessage, { role: "tool" }>).result).toContain(
+      'Use get_tool_result("tc_1") for full content.',
+    );
+    expect((messages[0] as Extract<AIMessage, { role: "tool" }>).result).not.toContain(
+      "FULL CONTENT",
+    );
+  });
+
+  it("keeps the latest fetched full content available until a later turn exists", () => {
+    const messages: AIMessage[] = [
+      {
+        role: "tool",
+        toolCallId: "tool-1",
+        toolName: "get_tool_result",
+        result: formatRetrievedToolResult({
+          key: "tc_1",
+          toolName: "read_page",
+          fullValue: "FULL CONTENT",
+          summary: "Body preview: hello",
+        }),
+      },
+    ];
+
+    manageContextMessages(messages, budget);
+
+    expect((messages[0] as Extract<AIMessage, { role: "tool" }>).result).toContain("FULL CONTENT");
+  });
+});

--- a/src/orchestration/agent-loop.ts
+++ b/src/orchestration/agent-loop.ts
@@ -17,7 +17,8 @@ import { createSecurityMiddleware, type SecurityMiddleware } from "@/features/se
 import { convertNavigationForAPI } from "./navigation-converter";
 import { calculateBackoff, isRetryable, RETRY_CONFIG } from "./retry";
 import { estimateTokens } from "./context-compressor";
-import { getContextBudget, type ContextBudget } from "@/features/ai/context-budget";
+import { getContextBudget } from "@/features/ai/context-budget";
+import type { ToolResultStorePort } from "@/ports/tool-result-store";
 import type { SkillRegistry } from "@/shared/skill-registry";
 import { buildSkillDetectionMessage, isSkillDetectionMessage } from "./skill-detector";
 import { useStore } from "@/store/index";
@@ -25,6 +26,15 @@ import {
   defaultConsoleLogService,
   normalizeConsoleLogEntry,
 } from "@/features/chat/services/console-log";
+import {
+  createToolResultKey,
+  formatRetrievedToolResult,
+  formatStoredToolResultSummary,
+  shouldStore,
+  summarizeToolResult,
+} from "@/features/tools/result-summarizer";
+import { manageContextMessages } from "./context-manager";
+import type { GetToolResultValue } from "@/features/tools";
 
 const log = createLogger("agent-loop");
 const defaultSecurityMiddleware = createSecurityMiddleware();
@@ -34,6 +44,7 @@ export interface AgentLoopDeps {
   browserExecutor: BrowserExecutor;
   authProvider?: AuthProvider;
   securityMiddleware?: SecurityMiddleware;
+  toolResultStore: ToolResultStorePort;
 }
 
 export interface ChatActions {
@@ -135,29 +146,6 @@ function trackSpaDomainsFromBgFetch(spaDetectedDomains: Set<string>, toolValue: 
     // Ignore
   }
   return warning;
-}
-
-function trimMessagesForContext(messages: AIMessage[], budget: ContextBudget): void {
-  for (const msg of messages) {
-    if (msg.role === "tool" && typeof msg.result === "string") {
-      if (msg.result.includes("data:image/")) {
-        msg.result = "[screenshot captured]";
-      } else if (msg.result.length > budget.maxToolResultChars) {
-        msg.result = msg.result.substring(0, budget.maxToolResultChars) + "\n... (truncated)";
-      }
-    }
-  }
-
-  while (messages.length > 4 && estimateTokens(messages) > budget.trimThreshold) {
-    const oldest = messages.findIndex(
-      (m, i) => i > 0 && (m.role === "tool" || m.role === "assistant"),
-    );
-    if (oldest > 0) {
-      messages.splice(oldest, 1);
-    } else {
-      break;
-    }
-  }
 }
 
 function isContextOverflowError(error: AppError): boolean {
@@ -318,14 +306,14 @@ export async function runAgentLoop(params: AgentLoopParams): Promise<void> {
           }
         }
         pendingToolCalls.push({ id, name, args, providerOptions });
-        let resultStr = toolResult.ok
+        let fullResult = toolResult.ok
           ? JSON.stringify(toolResult.value)
           : `Error: ${toolResult.error.message}`;
 
         const securityEnabled = useStore.getState().settings.enableSecurityMiddleware;
 
-        if (securityEnabled && !resultStr.includes("data:image/")) {
-          const securityResult = await securityMiddleware.processToolOutput(resultStr, {
+        if (securityEnabled && !fullResult.includes("data:image/")) {
+          const securityResult = await securityMiddleware.processToolOutput(fullResult, {
             source: name,
             sessionId: session.id,
           });
@@ -342,7 +330,7 @@ export async function runAgentLoop(params: AgentLoopParams): Promise<void> {
                 message: securityResult.alert.message,
               },
             };
-            resultStr = JSON.stringify(blockedPayload);
+            fullResult = JSON.stringify(blockedPayload);
             toolResult = toolResult.ok
               ? { ok: true, value: blockedPayload }
               : {
@@ -355,8 +343,8 @@ export async function runAgentLoop(params: AgentLoopParams): Promise<void> {
           }
         }
 
-        if (resultStr.includes("data:image/")) {
-          resultStr = "[screenshot captured]";
+        if (fullResult.includes("data:image/")) {
+          fullResult = "[screenshot captured]";
         }
 
         // --- ツール別ポスト処理: 訪問追跡・SPA検出・スキル再構築 ---
@@ -368,14 +356,14 @@ export async function runAgentLoop(params: AgentLoopParams): Promise<void> {
           if (navResult.finalUrl) {
             const warning = trackVisitedUrl(visitedUrls, navResult.finalUrl);
             if (warning) {
-              resultStr += warning;
+              fullResult += warning;
               loopWarningEmitted = true;
             }
           }
         }
 
         if (name === "bg_fetch" && toolResult.ok) {
-          resultStr += trackSpaDomainsFromBgFetch(spaDetectedDomains, toolResult.value);
+          fullResult += trackSpaDomainsFromBgFetch(spaDetectedDomains, toolResult.value);
         }
 
         // navigate/repl 後のURL変化検出: スキル再構築 + repl 訪問追跡
@@ -388,7 +376,7 @@ export async function runAgentLoop(params: AgentLoopParams): Promise<void> {
             if (name === "repl" && newUrl) {
               const warning = trackVisitedUrl(visitedUrls, newUrl);
               if (warning) {
-                resultStr += warning;
+                fullResult += warning;
                 loopWarningEmitted = true;
               }
             }
@@ -414,10 +402,49 @@ export async function runAgentLoop(params: AgentLoopParams): Promise<void> {
         }
 
         chatStore.updateToolCallResult(id, toolResult);
+
+        let resultForHistory = fullResult;
+        if (name === "get_tool_result" && toolResult.ok) {
+          resultForHistory = formatRetrievedToolResult(toolResult.value as GetToolResultValue);
+        } else {
+          const summary = summarizeToolResult({
+            toolName: name,
+            args,
+            fullResult,
+            rawValue: toolResult.ok ? toolResult.value : toolResult.error,
+            isError: !toolResult.ok,
+            currentUrl,
+            consoleTail:
+              name === "repl"
+                ? defaultConsoleLogService
+                    .get(id)
+                    .slice(-3)
+                    .map((entry) => entry.message)
+                : undefined,
+          });
+
+          if (
+            budget.useToolResultStore &&
+            shouldStore({ toolName: name, fullResult, summary, isError: !toolResult.ok })
+          ) {
+            const key = createToolResultKey();
+            await deps.toolResultStore.save(session.id, {
+              key,
+              toolName: name,
+              fullValue: fullResult,
+              summary,
+              turnIndex: turn,
+            });
+            resultForHistory = formatStoredToolResultSummary(name, summary, key);
+          } else {
+            resultForHistory = formatStoredToolResultSummary(name, summary);
+          }
+        }
+
         pendingToolResults.push({
           toolCallId: id,
           toolName: name,
-          result: resultStr,
+          result: resultForHistory,
           isError: !toolResult.ok,
         });
 
@@ -439,7 +466,7 @@ export async function runAgentLoop(params: AgentLoopParams): Promise<void> {
 
       while (retryCount <= RETRY_CONFIG.maxRetries) {
         let hasError = false;
-        trimMessagesForContext(messages, budget);
+        manageContextMessages(messages, budget);
         chatStore.startNewAssistantMessage();
 
         for await (const event of aiProvider.streamText({

--- a/src/orchestration/context-manager.ts
+++ b/src/orchestration/context-manager.ts
@@ -1,0 +1,55 @@
+import type { AIMessage } from "@/ports/ai-provider";
+import type { ContextBudget } from "@/features/ai/context-budget";
+import { estimateTokens } from "@/shared/token-utils";
+import { restoreRetrievedToolResultToSummary } from "@/features/tools/result-summarizer";
+
+function truncateToolResult(result: string, maxChars: number): string {
+  if (result.includes("data:image/")) {
+    return "[screenshot captured]";
+  }
+  if (result.length <= maxChars) {
+    return result;
+  }
+  return `${result.slice(0, maxChars)}\n... (truncated)`;
+}
+
+function replaceExpiredRetrievedResults(messages: AIMessage[]): void {
+  for (let index = 0; index < messages.length; index++) {
+    const message = messages[index];
+    if (message?.role !== "tool" || typeof message.result !== "string") {
+      continue;
+    }
+
+    const restored = restoreRetrievedToolResultToSummary(message.result);
+    if (!restored) {
+      continue;
+    }
+
+    const hasLaterMessage = messages
+      .slice(index + 1)
+      .some((candidate) => candidate.role !== "tool");
+    if (hasLaterMessage) {
+      message.result = restored;
+    }
+  }
+}
+
+export function manageContextMessages(messages: AIMessage[], budget: ContextBudget): void {
+  for (const message of messages) {
+    if (message.role === "tool" && typeof message.result === "string") {
+      message.result = truncateToolResult(message.result, budget.maxToolResultChars);
+    }
+  }
+
+  replaceExpiredRetrievedResults(messages);
+
+  while (messages.length > 4 && estimateTokens(messages) > budget.trimThreshold) {
+    const oldest = messages.findIndex(
+      (message, index) => index > 0 && (message.role === "tool" || message.role === "assistant"),
+    );
+    if (oldest <= 0) {
+      break;
+    }
+    messages.splice(oldest, 1);
+  }
+}

--- a/src/ports/tool-result-store.ts
+++ b/src/ports/tool-result-store.ts
@@ -1,0 +1,16 @@
+export interface StoredToolResult {
+  key: string;
+  sessionId: string;
+  toolName: string;
+  fullValue: string;
+  summary: string;
+  createdAt: number;
+  turnIndex: number;
+}
+
+export interface ToolResultStorePort {
+  save(sessionId: string, result: Omit<StoredToolResult, "createdAt" | "sessionId">): Promise<void>;
+  get(sessionId: string, key: string): Promise<StoredToolResult | null>;
+  list(sessionId: string): Promise<StoredToolResult[]>;
+  deleteSession(sessionId: string): Promise<void>;
+}

--- a/src/shared/deps-context.tsx
+++ b/src/shared/deps-context.tsx
@@ -5,6 +5,7 @@ import type { AuthProvider } from "@/ports/auth-provider";
 import type { BrowserExecutor } from "@/ports/browser-executor";
 import type { StoragePort } from "@/ports/storage";
 import type { SessionStoragePort } from "@/ports/session-storage";
+import type { ToolResultStorePort } from "@/ports/tool-result-store";
 
 export interface AppDeps {
   createAIProvider: (config: ProviderConfig) => AIProvider;
@@ -13,6 +14,7 @@ export interface AppDeps {
   storage: StoragePort;
   sessionStorage: SessionStoragePort;
   artifactStorage: ArtifactStoragePort;
+  toolResultStore: ToolResultStorePort;
 }
 
 const DepsContext = createContext<AppDeps | null>(null);

--- a/src/sidepanel/__tests__/initialize.test.ts
+++ b/src/sidepanel/__tests__/initialize.test.ts
@@ -2,7 +2,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { initializeApp } from "../initialize";
 import { initStore, useStore } from "@/store";
-import { InMemoryArtifactStorage, InMemoryStorage } from "@/adapters/storage/in-memory-storage";
+import {
+  InMemoryArtifactStorage,
+  InMemoryStorage,
+  InMemoryToolResultStore,
+} from "@/adapters/storage/in-memory-storage";
 import type { AppDeps } from "@/shared/deps-context";
 import type { AIProvider, StreamTextParams } from "@/ports/ai-provider";
 import type { BrowserExecutor, TabInfo } from "@/ports/browser-executor";
@@ -101,6 +105,7 @@ function createDeps(storage: InMemoryStorage): AppDeps {
     storage,
     sessionStorage: new NoopSessionStorage(),
     artifactStorage: new InMemoryArtifactStorage(),
+    toolResultStore: new InMemoryToolResultStore(),
   };
 }
 

--- a/src/sidepanel/hooks/__tests__/use-agent.test.ts
+++ b/src/sidepanel/hooks/__tests__/use-agent.test.ts
@@ -7,7 +7,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAgent } from "../use-agent";
 import { DepsProvider, type AppDeps } from "@/shared/deps-context";
 import { initStore, useStore } from "@/store";
-import { InMemoryArtifactStorage, InMemoryStorage } from "@/adapters/storage/in-memory-storage";
+import {
+  InMemoryArtifactStorage,
+  InMemoryStorage,
+  InMemoryToolResultStore,
+} from "@/adapters/storage/in-memory-storage";
 import { SkillRegistry } from "@/shared/skill-registry";
 import type { AIProvider, StreamTextParams } from "@/ports/ai-provider";
 import type { BrowserExecutor, TabInfo } from "@/ports/browser-executor";
@@ -135,6 +139,7 @@ function createDeps(storage: InMemoryStorage): AppDeps {
     storage,
     sessionStorage: new NoopSessionStorage(),
     artifactStorage: new InMemoryArtifactStorage(),
+    toolResultStore: new InMemoryToolResultStore(),
   };
 }
 

--- a/src/sidepanel/hooks/use-agent.ts
+++ b/src/sidepanel/hooks/use-agent.ts
@@ -4,6 +4,7 @@ import { useStore } from "@/store/index";
 import { isExcludedUrl, getLastKnownUrl } from "@/shared/utils";
 import { runAgentLoop } from "@/orchestration/agent-loop";
 import { getSystemPromptV2 } from "@/features/ai/system-prompt-v2";
+import { getContextBudget } from "@/features/ai/context-budget";
 import {
   getAgentToolDefs,
   createToolExecutorWithSkills,
@@ -148,11 +149,13 @@ export function useAgent() {
         (await skillRegistryRuntimeRef.current.waitForReady()) ??
         skillRegistryRef.current ??
         new SkillRegistry();
+      const budget = getContextBudget(settings.model, settings.maxTokens);
       const { currentTab } = useStore.getState();
       const matchedSkills = currentRegistry.getAvailableSkills(currentTab.url);
       const systemPrompt = getSystemPromptV2({
         includeSkills: matchedSkills.length > 0,
         skills: matchedSkills,
+        includeToolResultStore: budget.useToolResultStore,
       });
 
       runAgentLoop({
@@ -176,6 +179,7 @@ export function useAgent() {
           browserExecutor: deps.browserExecutor,
           authProvider,
           securityMiddleware: securityMiddlewareRef.current,
+          toolResultStore: deps.toolResultStore,
         },
         chatStore: {
           setStreaming: (v) => useStore.getState().setStreaming(v),
@@ -208,13 +212,17 @@ export function useAgent() {
           maxTokens: settings.maxTokens,
         },
         session,
-        tools: getAgentToolDefs({ enableBgFetch: settings.enableBgFetch }),
+        tools: getAgentToolDefs({
+          enableBgFetch: settings.enableBgFetch,
+          enableToolResultStore: budget.useToolResultStore,
+        }),
         systemPrompt,
         autoSaver: autoSaverRef.current,
         toolExecutor: createToolExecutorWithSkills(
           currentRegistry,
           deps.artifactStorage,
           deps.storage,
+          deps.toolResultStore,
         ),
         skillRegistry: currentRegistry,
         credentials,

--- a/src/sidepanel/main.tsx
+++ b/src/sidepanel/main.tsx
@@ -10,6 +10,7 @@ import { CopilotAuth } from "@/adapters/auth/copilot-auth";
 import { ChromeBrowserExecutor } from "@/adapters/chrome/chrome-browser-executor";
 import { ChromeArtifactStorage } from "@/adapters/storage/artifact-storage";
 import { ChromeStorageAdapter } from "@/adapters/storage/chrome-storage";
+import { IndexedDBToolResultStore } from "@/adapters/storage/indexeddb-tool-result-store";
 import { IndexedDBSessionStorage } from "@/adapters/storage/indexeddb-session-storage";
 import { LEGACY_THEME_STORAGE_KEY, THEME_STORAGE_KEY, type ColorScheme } from "@/shared/constants";
 
@@ -38,6 +39,7 @@ function isColorScheme(value: unknown): value is ColorScheme {
   const storage = new ChromeStorageAdapter();
   const sessionStorage = new IndexedDBSessionStorage();
   const artifactStorage = new ChromeArtifactStorage();
+  const toolResultStore = new IndexedDBToolResultStore();
 
   initStore(artifactStorage);
 
@@ -60,6 +62,7 @@ function isColorScheme(value: unknown): value is ColorScheme {
     storage,
     sessionStorage,
     artifactStorage,
+    toolResultStore,
   };
 
   if (import.meta.env.DEV) {


### PR DESCRIPTION
## Summary\n- add IndexedDB-backed ToolResultStore and deterministic result summarization\n- add dynamic get_tool_result tool registration, system prompt guidance, and Layer 3 context management\n- update agent-loop/use-agent wiring plus tests and spike notes for tool result rewriting\n\n## Validation\n- vp check\n- pnpm vitest run src/adapters/storage/__tests__/indexeddb-tool-result-store.test.ts src/features/tools/__tests__/result-summarizer.test.ts src/features/tools/__tests__/get-tool-result.test.ts src/orchestration/__tests__/context-manager.test.ts src/features/ai/__tests__/system-prompt-v2.test.ts src/features/tools/__tests__/integration.test.ts src/sidepanel/hooks/__tests__/use-agent.test.ts src/sidepanel/__tests__/initialize.test.ts src/orchestration/__tests__/agent-loop.test.ts\n- npx tsc --noEmit