### PR TITLE
feat: Wave 4 UI for stored tool results and auto-compact

### DIFF
--- a/src/features/chat/ToolCallBlock.tsx
+++ b/src/features/chat/ToolCallBlock.tsx
@@ -1,5 +1,15 @@
-import { useState } from "react";
-import { Box, Collapse, Code, Paper, Text, UnstyledButton } from "@mantine/core";
+import { useEffect, useState } from "react";
+import {
+  Box,
+  Button,
+  Collapse,
+  Code,
+  Loader,
+  Modal,
+  Paper,
+  Text,
+  UnstyledButton,
+} from "@mantine/core";
 import {
   ChevronDown,
   ChevronUp,
@@ -9,6 +19,9 @@ import {
   Terminal,
 } from "lucide-react";
 import type { ToolCallInfo } from "@/ports/session-types";
+import { useDeps } from "@/shared/deps-context";
+import { useStore } from "@/store";
+import type { ToolResultStorePort } from "@/ports/tool-result-store";
 import { defaultConsoleLogService } from "./services/console-log";
 import { defaultToolRendererRegistry } from "./tool-renderers";
 import { ImageLightbox, ScrollableResult, ToolMessageContainer } from "./tool-renderers/components";
@@ -73,6 +86,28 @@ export async function downloadImageResource(
 }
 
 const RESULT_MAX_LENGTH = 500;
+
+export function getStoredToolResultKey(result?: string): string | null {
+  if (!result) return null;
+  const match = result.match(/(?:^|\n)Stored: tool_result:\/\/([^\n]+)/);
+  return match?.[1]?.trim() || null;
+}
+
+export async function loadStoredToolResult(
+  store: ToolResultStorePort,
+  sessionId: string,
+  key: string,
+): Promise<{ toolName: string; fullResult: string }> {
+  const stored = await store.get(sessionId, key);
+  if (!stored) {
+    throw new Error("保存済みの完全結果が見つかりませんでした。");
+  }
+
+  return {
+    toolName: stored.toolName,
+    fullResult: stored.fullValue,
+  };
+}
 
 function extractImageUrl(result: string): string | null {
   if (result.startsWith("data:image/")) return result;
@@ -144,6 +179,84 @@ function JsonValueNode({ label, value }: { label?: string; value: unknown }) {
         </Box>
       </Collapse>
     </Box>
+  );
+}
+
+function StoredToolResultButton({ result }: { result?: string }) {
+  const { toolResultStore } = useDeps();
+  const activeSessionId = useStore((s) => s.activeSessionId);
+  const key = getStoredToolResultKey(result);
+  const [opened, setOpened] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [fullResult, setFullResult] = useState<string | null>(null);
+  const [toolName, setToolName] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!opened) return;
+    if (!activeSessionId || !key) {
+      setError("完全結果を開くためのセッション情報が見つかりませんでした。");
+      setLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+
+    void loadStoredToolResult(toolResultStore, activeSessionId, key)
+      .then((stored) => {
+        if (cancelled) return;
+        setFullResult(stored.fullResult);
+        setToolName(stored.toolName);
+      })
+      .catch((cause: unknown) => {
+        if (cancelled) return;
+        setError(cause instanceof Error ? cause.message : String(cause));
+        setFullResult(null);
+        setToolName(null);
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [activeSessionId, key, opened, toolResultStore]);
+
+  if (!key) return null;
+
+  return (
+    <>
+      <Button size="compact-xs" variant="subtle" mt={8} onClick={() => setOpened(true)}>
+        完全結果を展開
+      </Button>
+      <Modal
+        opened={opened}
+        onClose={() => setOpened(false)}
+        title={toolName ? `${toolName} の完全結果` : "ツール結果の完全版"}
+        size="lg"
+      >
+        {loading ? (
+          <Box py="md" style={{ display: "flex", justifyContent: "center" }}>
+            <Loader size="sm" />
+          </Box>
+        ) : error ? (
+          <Text size="sm" c="red" style={{ whiteSpace: "pre-wrap" }}>
+            {error}
+          </Text>
+        ) : (
+          <ScrollableResult maxHeight={480}>
+            <Code block style={{ fontSize: 12, whiteSpace: "pre-wrap", wordBreak: "break-word" }}>
+              {fullResult ?? ""}
+            </Code>
+          </ScrollableResult>
+        )}
+      </Modal>
+    </>
   );
 }
 
@@ -232,27 +345,30 @@ export function ToolCallBlock({ tc }: { tc: ToolCallInfo }) {
   const specializedBody = renderSpecializedToolBody(tc);
 
   return (
-    <ToolMessageContainer
-      toolCall={tc}
-      description={renderer ? null : description}
-      summary={summary}
-      icon={getToolIcon(tc.name)}
-      defaultExpanded={tc.name === "repl"}
-    >
-      {renderer ? (
-        specializedBody
-      ) : (
-        <>
-          {argsStr && (
-            <ScrollableResult maxHeight={150}>
-              <Code block style={{ fontSize: 13 }}>
-                {argsStr}
-              </Code>
-            </ScrollableResult>
-          )}
-          {(tc.result || tc.isRunning) && <GenericToolResult toolCall={tc} />}
-        </>
-      )}
-    </ToolMessageContainer>
+    <>
+      <ToolMessageContainer
+        toolCall={tc}
+        description={renderer ? null : description}
+        summary={summary}
+        icon={getToolIcon(tc.name)}
+        defaultExpanded={tc.name === "repl"}
+      >
+        {renderer ? (
+          specializedBody
+        ) : (
+          <>
+            {argsStr && (
+              <ScrollableResult maxHeight={150}>
+                <Code block style={{ fontSize: 13 }}>
+                  {argsStr}
+                </Code>
+              </ScrollableResult>
+            )}
+            {(tc.result || tc.isRunning) && <GenericToolResult toolCall={tc} />}
+          </>
+        )}
+      </ToolMessageContainer>
+      <StoredToolResultButton result={tc.result} />
+    </>
   );
 }

--- a/src/features/chat/__tests__/ToolCallBlock.test.ts
+++ b/src/features/chat/__tests__/ToolCallBlock.test.ts
@@ -3,10 +3,30 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { MantineProvider } from "@mantine/core";
 import { describe, expect, it, vi } from "vitest";
 import type { ToolCallInfo } from "@/ports/session-types";
-import { ToolCallBlock, downloadImageResource, formatArgs } from "../ToolCallBlock";
+import { DepsProvider, type AppDeps } from "@/shared/deps-context";
+import { useStore } from "@/store";
+import {
+  ToolCallBlock,
+  downloadImageResource,
+  formatArgs,
+  getStoredToolResultKey,
+  loadStoredToolResult,
+} from "../ToolCallBlock";
 
-function renderWithMantine(element: ReturnType<typeof createElement>): string {
-  return renderToStaticMarkup(createElement(MantineProvider, null, element));
+const testDeps: AppDeps = {
+  createAIProvider: vi.fn(),
+  authProviders: {},
+  browserExecutor: {} as AppDeps["browserExecutor"],
+  storage: {} as AppDeps["storage"],
+  sessionStorage: {} as AppDeps["sessionStorage"],
+  artifactStorage: {} as AppDeps["artifactStorage"],
+  toolResultStore: {} as AppDeps["toolResultStore"],
+};
+
+function renderWithProviders(element: ReturnType<typeof createElement>): string {
+  return renderToStaticMarkup(
+    createElement(MantineProvider, null, createElement(DepsProvider, { value: testDeps }, element)),
+  );
 }
 
 function createToolCall(overrides: Partial<ToolCallInfo> = {}): ToolCallInfo {
@@ -103,9 +123,49 @@ describe("downloadImageResource", () => {
   });
 });
 
+describe("getStoredToolResultKey", () => {
+  it("Stored 行から tool result key を抽出する", () => {
+    expect(
+      getStoredToolResultKey(
+        '[read_page]\nSummary\nStored: tool_result://tc_abc123\nUse get_tool_result("tc_abc123") for full content.',
+      ),
+    ).toBe("tc_abc123");
+  });
+
+  it("Stored 行がない結果では null を返す", () => {
+    expect(getStoredToolResultKey("plain result")).toBeNull();
+  });
+});
+
+describe("loadStoredToolResult", () => {
+  it("active session と key で完全結果を取得する", async () => {
+    const get = vi.fn().mockResolvedValue({
+      toolName: "read_page",
+      fullValue: "full result body",
+    });
+
+    await expect(
+      loadStoredToolResult({ get } as AppDeps["toolResultStore"], "session-1", "tc_1"),
+    ).resolves.toEqual({
+      toolName: "read_page",
+      fullResult: "full result body",
+    });
+
+    expect(get).toHaveBeenCalledWith("session-1", "tc_1");
+  });
+
+  it("保存済みデータがない場合はエラーにする", async () => {
+    const get = vi.fn().mockResolvedValue(null);
+
+    await expect(
+      loadStoredToolResult({ get } as AppDeps["toolResultStore"], "session-1", "missing"),
+    ).rejects.toThrow("保存済みの完全結果が見つかりませんでした。");
+  });
+});
+
 describe("ToolCallBlock", () => {
   it("specialized repl renderer を使って実行中表示を出す", () => {
-    const markup = renderWithMantine(
+    const markup = renderWithProviders(
       createElement(ToolCallBlock, {
         tc: createToolCall({
           name: "repl",
@@ -120,7 +180,7 @@ describe("ToolCallBlock", () => {
   });
 
   it("未登録ツールは汎用フォールバックで表示する", () => {
-    const markup = renderWithMantine(
+    const markup = renderWithProviders(
       createElement(ToolCallBlock, {
         tc: createToolCall({
           name: "read_page",
@@ -136,5 +196,22 @@ describe("ToolCallBlock", () => {
     expect(markup).toContain("selector");
     expect(markup).toContain("body");
     expect(markup).toContain("plain result");
+  });
+
+  it("stored tool result summary には完全結果を展開ボタンを表示する", () => {
+    useStore.getState().setActiveSessionId("session-1");
+
+    const markup = renderWithProviders(
+      createElement(ToolCallBlock, {
+        tc: createToolCall({
+          name: "read_page",
+          success: true,
+          result:
+            '[read_page]\nSummary\nStored: tool_result://tc_expand\nUse get_tool_result("tc_expand") for full content.',
+        }),
+      }),
+    );
+
+    expect(markup).toContain("完全結果を展開");
   });
 });

--- a/src/features/settings/SettingsPanel.tsx
+++ b/src/features/settings/SettingsPanel.tsx
@@ -316,6 +316,22 @@ export function SettingsPanel() {
 
                 {visibility.showOAuth && <OAuthSection />}
 
+                <div>
+                  <Switch
+                    label="クラウドで自動圧縮を有効にする"
+                    description={
+                      settings.autoCompact
+                        ? "長い会話で構造化要約による自動圧縮を許可します。クラウドプロバイダ利用時は追加の LLM コストが発生します"
+                        : "クラウドプロバイダでは自動圧縮を行いません。必要になったら有効化してください（LLM コストが追加で発生します）"
+                    }
+                    checked={settings.autoCompact}
+                    onChange={(e) => setSettings({ autoCompact: e.currentTarget.checked })}
+                  />
+                  <Text size="xs" c="dimmed" mt="xs">
+                    クラウドプロバイダ利用時は LLM コストが発生します
+                  </Text>
+                </div>
+
                 <SaveButton onClick={handleSave} />
               </Stack>
             </Box>

--- a/src/features/settings/__tests__/persistence.test.ts
+++ b/src/features/settings/__tests__/persistence.test.ts
@@ -34,6 +34,7 @@ describe("persistence", () => {
       enableMcpServer: false,
       enableBgFetch: false,
       enableSecurityMiddleware: true,
+      autoCompact: false,
     };
 
     await saveSettings(storage, data);
@@ -64,6 +65,7 @@ describe("persistence", () => {
       enableMcpServer: false,
       enableBgFetch: false,
       enableSecurityMiddleware: true,
+      autoCompact: false,
     };
     const data2: Settings = {
       provider: "openai",
@@ -85,6 +87,7 @@ describe("persistence", () => {
       enableMcpServer: false,
       enableBgFetch: false,
       enableSecurityMiddleware: true,
+      autoCompact: false,
     };
 
     await saveSettings(storage, data1);
@@ -289,5 +292,40 @@ describe("persistence", () => {
     const result = await loadSettings(storage);
 
     expect(result?.enableSecurityMiddleware).toBe(false);
+  });
+
+  it("autoCompact 未設定の legacy 設定はデフォルトで false に解決する", async () => {
+    const storage = new InMemoryStorage();
+
+    await storage.set("sitesurf_settings", {
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+      apiKey: "sk-test",
+      enableMcpServer: false,
+      enableBgFetch: false,
+      enableSecurityMiddleware: true,
+    });
+
+    const result = await loadSettings(storage);
+
+    expect(result?.autoCompact).toBe(false);
+  });
+
+  it("autoCompact=true は永続化されて復元される", async () => {
+    const storage = new InMemoryStorage();
+
+    await storage.set("sitesurf_settings", {
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+      apiKey: "sk-test",
+      enableMcpServer: false,
+      enableBgFetch: false,
+      enableSecurityMiddleware: true,
+      autoCompact: true,
+    });
+
+    const result = await loadSettings(storage);
+
+    expect(result?.autoCompact).toBe(true);
   });
 });

--- a/src/features/settings/persistence.ts
+++ b/src/features/settings/persistence.ts
@@ -83,6 +83,7 @@ export async function loadSettings(storage: StoragePort): Promise<Settings | nul
     enableMcpServer: raw.enableMcpServer ?? false,
     enableBgFetch: raw.enableBgFetch ?? false,
     enableSecurityMiddleware: raw.enableSecurityMiddleware ?? true,
+    autoCompact: raw.autoCompact ?? false,
   };
 }
 

--- a/src/features/settings/settings-store.ts
+++ b/src/features/settings/settings-store.ts
@@ -29,6 +29,7 @@ export interface Settings {
   enableMcpServer: boolean;
   enableBgFetch: boolean;
   enableSecurityMiddleware: boolean;
+  autoCompact: boolean;
 }
 
 export interface SettingsSlice {
@@ -63,6 +64,7 @@ export const createSettingsSlice: StateCreator<AppStore, [], [], SettingsSlice> 
     enableMcpServer: false,
     enableBgFetch: false,
     enableSecurityMiddleware: true,
+    autoCompact: false,
   },
   setSettings: (partial) =>
     set((s) => {

--- a/src/orchestration/__tests__/agent-loop.test.ts
+++ b/src/orchestration/__tests__/agent-loop.test.ts
@@ -45,6 +45,8 @@ const defaultStoreState = () => ({
   artifacts: [],
   setArtifactPanelOpen: vi.fn(),
   settings: { enableSecurityMiddleware: true },
+  activeSessionSnapshot: null,
+  setActiveSession: vi.fn(),
 });
 
 vi.mock("@/store/index", () => ({
@@ -54,6 +56,8 @@ vi.mock("@/store/index", () => ({
       artifacts: [],
       setArtifactPanelOpen: vi.fn(),
       settings: { enableSecurityMiddleware: true },
+      activeSessionSnapshot: null,
+      setActiveSession: vi.fn(),
     })),
   },
   initStore: vi.fn(),
@@ -332,6 +336,54 @@ describe("runAgentLoop", () => {
         },
       ],
     });
+  });
+
+  it("session summary prompt is not persisted into synced history", async () => {
+    const session = createMockSession({
+      summary: {
+        text: "Previous conversation about web scraping",
+        compressedAt: Date.now(),
+        originalMessageCount: 50,
+      },
+    });
+
+    const params = createParams({ session });
+    await runAgentLoop(params);
+
+    const syncedHistory = vi.mocked(params.chatStore.syncHistory).mock.calls.at(-1)?.[0] ?? [];
+    expect(syncedHistory).not.toContainEqual({
+      role: "user",
+      content: [
+        {
+          type: "text",
+          text: "[過去の会話の要約]\nPrevious conversation about web scraping",
+        },
+      ],
+    });
+  });
+
+  it("先頭以外のユーザーメッセージで summary prefix を含んでも履歴から落とさない", async () => {
+    const prefixedUserMessage = {
+      role: "user" as const,
+      content: [{ type: "text" as const, text: "[過去の会話の要約]\nこれはユーザー入力" }],
+    };
+
+    const params = createParams({
+      session: createMockSession({
+        history: [
+          {
+            role: "assistant",
+            content: [{ type: "text", text: "assistant context" }],
+          },
+          prefixedUserMessage,
+        ],
+      }),
+    });
+
+    await runAgentLoop(params);
+
+    const syncedHistory = vi.mocked(params.chatStore.syncHistory).mock.calls.at(-1)?.[0] ?? [];
+    expect(syncedHistory).toContainEqual(prefixedUserMessage);
   });
 
   it("calls finally cleanup even on error path", async () => {

--- a/src/orchestration/agent-loop.ts
+++ b/src/orchestration/agent-loop.ts
@@ -17,9 +17,11 @@ import { createSecurityMiddleware, type SecurityMiddleware } from "@/features/se
 import { convertNavigationForAPI } from "./navigation-converter";
 import { calculateBackoff, isRetryable, RETRY_CONFIG } from "./retry";
 import { estimateTokens } from "./context-compressor";
+import { compressIfNeeded } from "./context-compressor";
 import { getContextBudget } from "@/features/ai/context-budget";
 import type { ToolResultStorePort } from "@/ports/tool-result-store";
 import { generateVisitedUrlsSection, type VisitedUrlEntry } from "@/features/ai/system-prompt-v2";
+import type { ProviderId } from "@/shared/constants";
 import type { SkillRegistry } from "@/shared/skill-registry";
 import { buildSkillDetectionMessage, isSkillDetectionMessage } from "./skill-detector";
 import { useStore } from "@/store/index";
@@ -39,6 +41,7 @@ import type { GetToolResultValue } from "@/features/tools";
 
 const log = createLogger("agent-loop");
 const defaultSecurityMiddleware = createSecurityMiddleware();
+const SESSION_SUMMARY_PREFIX = "[過去の会話の要約]\n";
 
 export interface AgentLoopDeps {
   createAIProvider: (settings: Settings) => AIProvider;
@@ -87,6 +90,7 @@ export interface Settings {
   oauthToken?: string;
   reasoningLevel?: string;
   maxTokens?: number;
+  autoCompact?: boolean;
 }
 
 export interface AgentLoopParams {
@@ -197,6 +201,34 @@ function isContextOverflowError(error: AppError): boolean {
   );
 }
 
+function isLeadingSessionSummaryMessage(
+  message: AIMessage | undefined,
+  summaryText?: string,
+): boolean {
+  if (!message || !summaryText || message.role !== "user") return false;
+  if (!Array.isArray(message.content) || message.content.length !== 1) return false;
+
+  const [part] = message.content;
+  return part.type === "text" && part.text === `${SESSION_SUMMARY_PREFIX}${summaryText}`;
+}
+
+function stripLeadingSessionSummaryMessage(
+  messages: AIMessage[],
+  summaryText?: string,
+): AIMessage[] {
+  if (!isLeadingSessionSummaryMessage(messages[0], summaryText)) {
+    return messages;
+  }
+  return messages.slice(1);
+}
+
+function toPersistedHistory(messages: AIMessage[], summaryText?: string): AIMessage[] {
+  return stripLeadingSessionSummaryMessage(
+    messages.filter((message) => !isSkillDetectionMessage(message)),
+    summaryText,
+  );
+}
+
 export async function runAgentLoop(params: AgentLoopParams): Promise<void> {
   const {
     deps,
@@ -241,11 +273,20 @@ export async function runAgentLoop(params: AgentLoopParams): Promise<void> {
   // 後の navigate のフラグが意図せずクリアされるのを防ぐ。
   let navFlagTimer: ReturnType<typeof setTimeout> | null = null;
 
+  let currentSession = session;
+  const currentUserMessageCount = chatStore
+    .getMessages()
+    .filter((message) => message.role === "user" || message.role === "navigation").length;
+  const persistedUserMessageCount = session.history.filter(
+    (message) => message.role === "user",
+  ).length;
+  let rebuiltHistoryUserCount = persistedUserMessageCount;
   let messages: AIMessage[] = buildMessagesForAPI(
-    session,
+    currentSession,
     chatStore.getMessages(),
     currentUrl,
     skillRegistry,
+    { historyUserCount: persistedUserMessageCount },
   );
 
   try {
@@ -430,10 +471,11 @@ export async function runAgentLoop(params: AgentLoopParams): Promise<void> {
             if (newUrl && newUrl !== currentUrl) {
               currentUrl = newUrl;
               messages = buildMessagesForAPI(
-                session,
+                currentSession,
                 chatStore.getMessages(),
                 currentUrl,
                 skillRegistry,
+                { historyUserCount: rebuiltHistoryUserCount },
               );
             }
           } catch {
@@ -639,15 +681,39 @@ export async function runAgentLoop(params: AgentLoopParams): Promise<void> {
                 );
                 chatStore.clearLastAssistantMessage();
 
-                while (
-                  messages.length > 4 &&
-                  estimateTokens(messages) > budget.compressionThreshold
-                ) {
-                  const idx = messages.findIndex(
-                    (m, i) => i > 0 && (m.role === "tool" || m.role === "assistant"),
+                const compressed = await compressIfNeeded(
+                  aiProvider,
+                  {
+                    ...currentSession,
+                    history: toPersistedHistory(messages, currentSession.summary?.text),
+                  },
+                  budget,
+                  settings.model,
+                  settings.provider as ProviderId,
+                  { userConfirmed: settings.autoCompact },
+                );
+
+                if (compressed.compressed) {
+                  currentSession = compressed.session;
+                  rebuiltHistoryUserCount = currentUserMessageCount;
+                  messages = buildMessagesForAPI(
+                    currentSession,
+                    chatStore.getMessages(),
+                    currentUrl,
+                    skillRegistry,
+                    { historyUserCount: rebuiltHistoryUserCount },
                   );
-                  if (idx > 0) messages.splice(idx, 1);
-                  else break;
+                } else {
+                  while (
+                    messages.length > 4 &&
+                    estimateTokens(messages) > budget.compressionThreshold
+                  ) {
+                    const idx = messages.findIndex(
+                      (m, i) => i > 0 && (m.role === "tool" || m.role === "assistant"),
+                    );
+                    if (idx > 0) messages.splice(idx, 1);
+                    else break;
+                  }
                 }
 
                 retryCount++;
@@ -694,7 +760,13 @@ export async function runAgentLoop(params: AgentLoopParams): Promise<void> {
     }
   } finally {
     log.info("streamText 終了");
-    chatStore.syncHistory(messages.filter((message) => !isSkillDetectionMessage(message)));
+    if (currentSession.summary) {
+      const { activeSessionSnapshot, setActiveSession } = useStore.getState();
+      if (activeSessionSnapshot?.id === currentSession.id) {
+        setActiveSession({ ...activeSessionSnapshot, summary: currentSession.summary });
+      }
+    }
+    chatStore.syncHistory(toPersistedHistory(messages, currentSession.summary?.text));
     chatStore.setStreaming(false);
     autoSaver.saveImmediately();
   }
@@ -772,15 +844,19 @@ function buildMessagesForAPI(
   chatMessages: ChatMessage[],
   currentUrl: string,
   skillRegistry: SkillRegistry,
+  options: { historyUserCount?: number } = {},
 ): AIMessage[] {
   const messages: AIMessage[] = [];
-  const persistedHistory = session.history.filter((message) => !isSkillDetectionMessage(message));
+  const persistedHistory = stripLeadingSessionSummaryMessage(
+    session.history.filter((message) => !isSkillDetectionMessage(message)),
+    session.summary?.text,
+  );
 
   // 1. Session summary (if exists)
   if (session.summary) {
     messages.push({
       role: "user",
-      content: [{ type: "text", text: `[過去の会話の要約]\n${session.summary.text}` }],
+      content: [{ type: "text", text: `${SESSION_SUMMARY_PREFIX}${session.summary.text}` }],
     });
   }
 
@@ -797,7 +873,8 @@ function buildMessagesForAPI(
   }
 
   // 4. Add new user messages (including navigation messages)
-  const historyUserCount = persistedHistory.filter((m) => m.role === "user").length;
+  const historyUserCount =
+    options.historyUserCount ?? persistedHistory.filter((m) => m.role === "user").length;
   const userMessages = chatMessages.filter((m) => m.role === "user" || m.role === "navigation");
   const newMessages = userMessages.slice(historyUserCount);
 

--- a/src/sidepanel/__tests__/initialize.test.ts
+++ b/src/sidepanel/__tests__/initialize.test.ts
@@ -137,6 +137,7 @@ describe("initializeApp", () => {
       enableMcpServer: false,
       enableBgFetch: false,
       enableSecurityMiddleware: true,
+      autoCompact: false,
     };
     await storage.set("sitesurf_settings", loadedSettings);
 

--- a/src/sidepanel/hooks/use-agent.ts
+++ b/src/sidepanel/hooks/use-agent.ts
@@ -210,6 +210,7 @@ export function useAgent() {
           oauthToken: credentials?.accessToken,
           reasoningLevel: settings.reasoningLevel,
           maxTokens: settings.maxTokens,
+          autoCompact: settings.autoCompact,
         },
         session,
         tools: getAgentToolDefs({

--- a/src/store/__tests__/index.test.ts
+++ b/src/store/__tests__/index.test.ts
@@ -385,6 +385,7 @@ describe("AppStore", () => {
         enableMcpServer: false,
         enableBgFetch: false,
         enableSecurityMiddleware: true,
+        autoCompact: false,
       };
 
       useStore.getState().hydrateSettings(loadedSettings);


### PR DESCRIPTION
## Summary
- add a chat-side expand action for stored `tool_result://` summaries backed by `ToolResultStore`
- persist and expose the `autoCompact` setting with a cloud-cost warning in Settings
- wire autoCompact through agent-loop rebuild paths and keep synthetic summary prompts out of saved history

## Testing
- pnpm vitest run src/orchestration/__tests__/agent-loop.test.ts src/features/chat/__tests__/ToolCallBlock.test.ts src/features/settings/__tests__/persistence.test.ts src/store/__tests__/index.test.ts src/sidepanel/__tests__/initialize.test.ts
- vp check

Closes #38