### PR TITLE
fix(W1-2): implementation-plan 準拠で ContextBudget 計測ログを補完する

### DIFF
--- a/src/features/ai/__tests__/context-budget.test.ts
+++ b/src/features/ai/__tests__/context-budget.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getContextBudget } from "../context-budget";
 import { DEFAULT_MAX_TOKENS } from "@/shared/token-constants";
 
@@ -8,6 +8,10 @@ const MODEL_32K = "gpt-4-32k";
 const MODEL_200K = "claude-sonnet-4-6";
 
 describe("getContextBudget", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("32k model × default maxTokens: outputReserve = DEFAULT_MAX_TOKENS", () => {
     // floor(32768 * 0.5) = 16384 === DEFAULT_MAX_TOKENS → no clamp
     const budget = getContextBudget(MODEL_32K);
@@ -17,10 +21,21 @@ describe("getContextBudget", () => {
   });
 
   it("32k model × maxTokens=32000: clamp occurs, outputReserve = floor(32768*0.5)", () => {
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+
     // requestedOutput=32000 > floor(32768*0.5)=16384 → clamp
     const budget = getContextBudget(MODEL_32K, 32000);
     expect(budget.outputReserve).toBe(16384);
     expect(budget.inputBudget).toBe(32768 - 16384);
+    expect(infoSpy).toHaveBeenCalledWith(
+      "[SiteSurf:context-budget]",
+      "maxTokens clamped",
+      expect.objectContaining({
+        requested: 32000,
+        effective: 16384,
+        windowTokens: 32768,
+      }),
+    );
   });
 
   it("200k model × default: maxToolResultChars = 20000, useToolResultStore = false", () => {

--- a/src/orchestration/__tests__/agent-loop.test.ts
+++ b/src/orchestration/__tests__/agent-loop.test.ts
@@ -16,6 +16,8 @@ import type { ArtifactStoragePort } from "@/ports/artifact-storage";
 import type { ToolResultStorePort } from "@/ports/tool-result-store";
 import { estimateTokens } from "@/shared/token-utils";
 
+let consoleInfoSpy: ReturnType<typeof vi.spyOn>;
+
 const mockArtifactStorage: ArtifactStoragePort & { setSessionId(id: string | null): void } = {
   createOrUpdate: async () => {},
   get: async () => null,
@@ -164,6 +166,7 @@ function createParams(overrides?: Partial<AgentLoopParams>): AgentLoopParams {
 describe("runAgentLoop", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    consoleInfoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
     streamTextCalls = [];
     initStore(mockArtifactStorage);
     setStreamEvents([
@@ -951,6 +954,7 @@ describe("tool execution error", () => {
 describe("context budget integration", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    consoleInfoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
     streamTextCalls = [];
     initStore(mockArtifactStorage);
   });
@@ -1039,6 +1043,15 @@ describe("context budget integration", () => {
     expect(params.chatStore.addSystemMessage).toHaveBeenCalledWith(
       "📝 コンテキストが大きすぎるため、古いメッセージを圧縮して再試行します...",
     );
+    expect(consoleInfoSpy).toHaveBeenCalledWith(
+      "[SiteSurf:agent-loop]",
+      "contextOverflowError",
+      expect.objectContaining({
+        model: "gpt-4",
+        provider: "openai",
+        errorCode: "ai_unknown",
+      }),
+    );
   });
 
   it("autoCompact=true のクラウド設定ではターン開始前に構造化圧縮を実行する", async () => {
@@ -1082,6 +1095,29 @@ describe("context budget integration", () => {
       content: [{ type: "text", text: "[構造化要約]\n## Goal\n圧縮済みの要約" }],
     });
   });
+
+  it("logs currentSessionTurnCount at turn start", async () => {
+    const params = createParams({
+      session: createMockSession({
+        history: [{ role: "user", content: [{ type: "text", text: "old" }] }],
+      }),
+      chatStore: createMockChatStore({
+        getMessages: vi.fn(() => [
+          { id: "u-1", role: "user", content: "new user message", createdAt: Date.now() },
+        ]),
+      }),
+    });
+
+    await runAgentLoop(params);
+
+    expect(consoleInfoSpy).toHaveBeenCalledWith(
+      "[SiteSurf:agent-loop]",
+      "turn start",
+      expect.objectContaining({
+        currentSessionTurnCount: 2,
+      }),
+    );
+  });
 });
 
 describe("trackVisitedUrl", () => {
@@ -1119,6 +1155,25 @@ describe("trackVisitedUrl", () => {
     const warning = trackVisitedUrl(map, "https://example.com", "Example", "navigate");
     expect(warning).toContain("WARNING");
     expect(warning).toContain("6 time(s)");
+  });
+
+  it("logs visitedUrl revisit count when revisiting a URL", () => {
+    trackVisitedUrl(makeMap(), "https://warmup.example", "Warmup", "navigate");
+    consoleInfoSpy.mockClear();
+
+    const map = makeMap();
+    trackVisitedUrl(map, "https://example.com", "Example", "navigate");
+    trackVisitedUrl(map, "https://example.com", "Example", "navigate");
+
+    expect(consoleInfoSpy).toHaveBeenCalledWith(
+      "[SiteSurf:agent-loop]",
+      "visitedUrl revisit count",
+      expect.objectContaining({
+        url: "https://example.com",
+        visitCount: 2,
+        method: "navigate",
+      }),
+    );
   });
 });
 
@@ -1168,6 +1223,7 @@ describe("pruneVisitedUrls", () => {
 describe("visited URLs in system prompt", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    consoleInfoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
     streamTextCalls = [];
     initStore(mockArtifactStorage);
   });

--- a/src/orchestration/__tests__/context-manager.test.ts
+++ b/src/orchestration/__tests__/context-manager.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest";
-import { manageContextMessages } from "../context-manager";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { manageContextMessages, trimMessagesToThreshold } from "../context-manager";
 import { formatRetrievedToolResult } from "@/features/tools/result-summarizer";
 import type { ContextBudget } from "@/features/ai/context-budget";
 import type { AIMessage } from "@/ports/ai-provider";
@@ -15,6 +15,10 @@ const budget: ContextBudget = {
 };
 
 describe("context-manager", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("replaces old get_tool_result full content with the stored summary form", () => {
     const messages: AIMessage[] = [
       {
@@ -59,5 +63,36 @@ describe("context-manager", () => {
     manageContextMessages(messages, budget);
 
     expect((messages[0] as Extract<AIMessage, { role: "tool" }>).result).toContain("FULL CONTENT");
+  });
+
+  it("logs when trimThreshold is reached and reports splicedMessageCount", () => {
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+    const messages: AIMessage[] = [
+      { role: "user", content: [{ type: "text", text: "u".repeat(7000) }] },
+      { role: "assistant", content: [{ type: "text", text: "a".repeat(7000) }] },
+      { role: "tool", toolCallId: "tool-1", toolName: "read_page", result: "t".repeat(7000) },
+      { role: "assistant", content: [{ type: "text", text: "b".repeat(7000) }] },
+      { role: "assistant", content: [{ type: "text", text: "c".repeat(7000) }] },
+    ];
+
+    const trimmed = trimMessagesToThreshold(messages, 20000);
+
+    expect(trimmed).toHaveLength(4);
+    expect(infoSpy).toHaveBeenCalledWith(
+      "[SiteSurf:context-manager]",
+      "trimThreshold reached",
+      expect.objectContaining({
+        estimatedTokens: 35000,
+        trimThreshold: 20000,
+      }),
+    );
+    expect(infoSpy).toHaveBeenCalledWith(
+      "[SiteSurf:context-manager]",
+      "splicedMessageCount",
+      expect.objectContaining({
+        splicedMessageCount: 1,
+        remainingMessagesCount: 4,
+      }),
+    );
   });
 });

--- a/src/orchestration/agent-loop.ts
+++ b/src/orchestration/agent-loop.ts
@@ -145,6 +145,16 @@ export function trackVisitedUrl(
   };
   visitedUrls.set(normalized, entry);
   pruneVisitedUrls(visitedUrls);
+
+  if (entry.visitCount > 1) {
+    log.info("visitedUrl revisit count", {
+      url: normalized,
+      title,
+      method,
+      visitCount: entry.visitCount,
+    });
+  }
+
   if (entry.visitCount >= URL_REVISIT_THRESHOLD) {
     return `\n\n⚠️ WARNING: This URL has already been visited ${entry.visitCount} time(s) in this session. Do NOT navigate to it again. Use the information you already collected from previous visits. If you have enough information, proceed to analysis/response instead of collecting more pages.`;
   }
@@ -280,6 +290,7 @@ export async function runAgentLoop(params: AgentLoopParams): Promise<void> {
   const persistedUserMessageCount = session.history.filter(
     (message) => message.role === "user",
   ).length;
+  const currentSessionTurnCount = persistedUserMessageCount + currentUserMessageCount;
   let rebuiltHistoryUserCount = persistedUserMessageCount;
   let messages: AIMessage[] = buildMessagesForAPI(
     currentSession,
@@ -297,6 +308,7 @@ export async function runAgentLoop(params: AgentLoopParams): Promise<void> {
         turn,
         estimateTokens: estimateTokens(messages),
         messagesCount: messages.length,
+        currentSessionTurnCount,
       });
       let hasToolCall = false;
       let assistantText = "";
@@ -700,6 +712,12 @@ export async function runAgentLoop(params: AgentLoopParams): Promise<void> {
               }
 
               if (isContextOverflowError(event.error)) {
+                log.info("contextOverflowError", {
+                  model: settings.model,
+                  provider: settings.provider,
+                  errorCode: event.error.code,
+                  message: event.error.message,
+                });
                 log.info("コンテキスト超過 — メッセージを圧縮してリトライ");
                 chatStore.addSystemMessage(
                   "📝 コンテキストが大きすぎるため、古いメッセージを圧縮して再試行します...",

--- a/src/orchestration/context-manager.ts
+++ b/src/orchestration/context-manager.ts
@@ -2,10 +2,13 @@ import type { AIMessage, AIProvider } from "@/ports/ai-provider";
 import type { ConversationSummary } from "@/ports/session-types";
 import type { ContextBudget } from "@/features/ai/context-budget";
 import type { ProviderId } from "@/shared/constants";
+import { createLogger } from "@/shared/logger";
 import { estimateTokens } from "@/shared/token-utils";
 import { restoreRetrievedToolResultToSummary } from "@/features/tools/result-summarizer";
 
 import { compressMessagesIfNeeded, stripStructuredSummaryMessage } from "./context-compressor";
+
+const log = createLogger("context-manager");
 
 export interface ContextManagerResult {
   messages: AIMessage[];
@@ -87,14 +90,21 @@ export async function prepareMessagesForTurn(input: {
     message.role === "tool" ? { ...message } : message,
   );
   normalizeContextMessages(normalizedMessages, input.budget);
+  const estimatedTokens = estimateTokens(normalizedMessages);
 
-  if (estimateTokens(normalizedMessages) < input.budget.trimThreshold) {
+  if (estimatedTokens < input.budget.trimThreshold) {
     return {
       messages: normalizedMessages,
       summary: input.sessionSummary,
       compressed: false,
     };
   }
+
+  log.info("trimThreshold reached", {
+    estimatedTokens,
+    trimThreshold: input.budget.trimThreshold,
+    messagesCount: normalizedMessages.length,
+  });
 
   const compressionResult = await compressMessagesIfNeeded(
     input.aiProvider,
@@ -122,21 +132,44 @@ export async function prepareMessagesForTurn(input: {
 
 export function trimMessagesToThreshold(messages: AIMessage[], threshold: number): AIMessage[] {
   const nextMessages = [...messages];
+  const initialEstimatedTokens = estimateTokens(nextMessages);
+
+  if (initialEstimatedTokens > threshold) {
+    log.info("trimThreshold reached", {
+      estimatedTokens: initialEstimatedTokens,
+      trimThreshold: threshold,
+      messagesCount: nextMessages.length,
+    });
+  }
+
+  let splicedMessageCount = 0;
+
   while (nextMessages.length > 4 && estimateTokens(nextMessages) > threshold) {
     const oldest = nextMessages.findIndex(
       (message, index) => index > 0 && (message.role === "tool" || message.role === "assistant"),
     );
     if (oldest > 0) {
       nextMessages.splice(oldest, 1);
+      splicedMessageCount += 1;
       continue;
     }
 
     if (nextMessages[0] && stripStructuredSummaryMessage(nextMessages[0])) {
       nextMessages.shift();
+      splicedMessageCount += 1;
       continue;
     }
 
     break;
+  }
+
+  if (splicedMessageCount > 0) {
+    log.info("splicedMessageCount", {
+      splicedMessageCount,
+      remainingMessagesCount: nextMessages.length,
+      estimatedTokens: estimateTokens(nextMessages),
+      trimThreshold: threshold,
+    });
   }
 
   return nextMessages;


### PR DESCRIPTION
## Summary
- add missing Wave 1 telemetry logs for currentSessionTurnCount, URL revisits, context overflow, and trim/splice events
- keep trimming/context handling behavior intact while surfacing the new log payloads
- add focused Vitest coverage for the new logging conditions

## Test
- npx vitest run src/features/ai/__tests__/context-budget.test.ts src/orchestration/__tests__/context-manager.test.ts src/orchestration/__tests__/agent-loop.test.ts