### PR TITLE
fix: autoCompact 設定の型定義・永続化・SettingsPanel UI を整理する

### DIFF
--- a/src/features/settings/SettingsPanel.tsx
+++ b/src/features/settings/SettingsPanel.tsx
@@ -277,6 +277,11 @@ export function SettingsPanel() {
                     checked={settings.autoCompact}
                     onChange={(e) => setSettings({ autoCompact: e.currentTarget.checked })}
                   />
+                  {settings.provider !== "local" && settings.provider !== "ollama" && (
+                    <Text size="xs" c="dimmed" mt="xs">
+                      クラウドプロバイダ利用時は LLM コストが発生します
+                    </Text>
+                  )}
                 </div>
 
                 {visibility.showApiKey && (
@@ -330,22 +335,6 @@ export function SettingsPanel() {
                 )}
 
                 {visibility.showOAuth && <OAuthSection />}
-
-                <div>
-                  <Switch
-                    label="クラウドで自動圧縮を有効にする"
-                    description={
-                      settings.autoCompact
-                        ? "長い会話で構造化要約による自動圧縮を許可します。クラウドプロバイダ利用時は追加の LLM コストが発生します"
-                        : "クラウドプロバイダでは自動圧縮を行いません。必要になったら有効化してください（LLM コストが追加で発生します）"
-                    }
-                    checked={settings.autoCompact}
-                    onChange={(e) => setSettings({ autoCompact: e.currentTarget.checked })}
-                  />
-                  <Text size="xs" c="dimmed" mt="xs">
-                    クラウドプロバイダ利用時は LLM コストが発生します
-                  </Text>
-                </div>
 
                 <SaveButton onClick={handleSave} />
               </Stack>

--- a/src/features/settings/__tests__/SettingsPanel.test.ts
+++ b/src/features/settings/__tests__/SettingsPanel.test.ts
@@ -1,0 +1,121 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { MantineProvider } from "@mantine/core";
+import { notifications } from "@mantine/notifications";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { InMemoryStorage } from "@/adapters/storage/in-memory-storage";
+import { DepsProvider, type AppDeps } from "@/shared/deps-context";
+import { initStore, useStore } from "@/store";
+import { loadSettings } from "../persistence";
+import { SettingsPanel } from "../SettingsPanel";
+
+const mockArtifactStorage = {
+  createOrUpdate: async () => {},
+  get: async () => null,
+  list: async () => [],
+  delete: async () => {},
+  saveFile: async () => {},
+  getFile: async () => null,
+  listFiles: async () => [],
+  deleteFile: async () => {},
+  clearAll: async () => {},
+  setSessionId: () => {},
+};
+
+function createDeps(storage: InMemoryStorage): AppDeps {
+  return {
+    createAIProvider: vi.fn(),
+    authProviders: {},
+    browserExecutor: {} as AppDeps["browserExecutor"],
+    storage,
+    sessionStorage: {} as AppDeps["sessionStorage"],
+    artifactStorage: mockArtifactStorage,
+    toolResultStore: {} as AppDeps["toolResultStore"],
+  };
+}
+
+describe("SettingsPanel", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let storage: InMemoryStorage;
+
+  beforeEach(() => {
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    vi.spyOn(notifications, "show").mockImplementation(() => "notification-id");
+    vi.stubGlobal(
+      "matchMedia",
+      vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    );
+
+    storage = new InMemoryStorage();
+    initStore(mockArtifactStorage);
+    useStore.setState(useStore.getInitialState());
+    useStore.getState().setSettingsOpen(true);
+
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.restoreAllMocks();
+  });
+
+  async function renderPanel() {
+    await act(async () => {
+      root.render(
+        createElement(
+          MantineProvider,
+          null,
+          createElement(DepsProvider, { value: createDeps(storage) }, createElement(SettingsPanel)),
+        ),
+      );
+    });
+  }
+
+  it("autoCompact トグルを 1 つだけ表示する", async () => {
+    await renderPanel();
+
+    expect(document.body.textContent?.match(/クラウドで自動圧縮を有効にする/g) ?? []).toHaveLength(
+      1,
+    );
+  });
+
+  it("autoCompact を保存すると永続化される", async () => {
+    await renderPanel();
+
+    const checkbox = document.body.querySelector<HTMLInputElement>('input[type="checkbox"]');
+    expect(checkbox).not.toBeNull();
+
+    await act(async () => {
+      checkbox?.click();
+    });
+
+    const saveButton = Array.from(document.body.querySelectorAll("button")).find(
+      (button) => button.textContent?.trim() === "保存",
+    );
+    expect(saveButton).toBeDefined();
+
+    await act(async () => {
+      saveButton?.click();
+    });
+
+    const saved = await loadSettings(storage);
+    expect(saved?.autoCompact).toBe(true);
+  });
+});

--- a/src/features/settings/settings-store.ts
+++ b/src/features/settings/settings-store.ts
@@ -29,7 +29,6 @@ export interface Settings {
   autoCompact: boolean;
   enableBgFetch: boolean;
   enableSecurityMiddleware: boolean;
-  autoCompact: boolean;
 }
 
 export interface SettingsSlice {


### PR DESCRIPTION
## 概要
- `Settings` 型から `autoCompact` の重複定義を削除
- `SettingsPanel` の autoCompact トグルを 1 箇所に整理し、補足文を一本化
- `SettingsPanel` の直接テストを追加し、保存後の `autoCompact` 永続化を確認

## テスト
- `vp check`
- `pnpm exec vitest run src/features/settings/__tests__/SettingsPanel.test.ts src/features/settings/__tests__/persistence.test.ts src/store/__tests__/index.test.ts --environment jsdom`

Closes #52
