### PR TITLE
refactor: unify IndexedDB versioning for session/tool-result storage

### DIFF
--- a/src/adapters/storage/__tests__/indexeddb-database-schema.test.ts
+++ b/src/adapters/storage/__tests__/indexeddb-database-schema.test.ts
@@ -1,0 +1,132 @@
+import "fake-indexeddb/auto";
+import { describe, expect, it } from "vitest";
+import { IndexedDBSessionStorage } from "../indexeddb-session-storage";
+import { IndexedDBToolResultStore } from "../indexeddb-tool-result-store";
+import type { Session, SessionMeta } from "@/ports/session-types";
+
+function createSession(id: string): Session {
+  return {
+    id,
+    title: `Session ${id}`,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    model: "gpt-4",
+    messages: [],
+    history: [],
+  };
+}
+
+function createMeta(id: string): SessionMeta {
+  return {
+    id,
+    title: `Session ${id}`,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    lastModified: "2026-01-01T00:00:00.000Z",
+    messageCount: 0,
+    modelId: "gpt-4",
+    preview: "",
+  };
+}
+
+function createDbName(suffix: string): string {
+  return `tandemweb-test-${suffix}-${Math.random().toString(36).slice(2)}`;
+}
+
+function createLegacyV1Database(
+  name: string,
+  options: { session?: Session; meta?: SessionMeta } = {},
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(name, 1);
+
+    req.onupgradeneeded = () => {
+      const db = req.result;
+      const sessions = db.createObjectStore("sessions", { keyPath: "id" });
+      const metadata = db.createObjectStore("sessions-metadata", { keyPath: "id" });
+      metadata.createIndex("lastModified", "lastModified");
+
+      if (options.session) {
+        sessions.put(options.session);
+      }
+
+      if (options.meta) {
+        metadata.put(options.meta);
+      }
+    };
+
+    req.onsuccess = () => {
+      req.result.close();
+      resolve();
+    };
+    req.onerror = () => reject(req.error);
+  });
+}
+
+function openDatabase(name: string): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(name);
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+describe("tandemweb indexeddb schema", () => {
+  it("lets session storage open the same database after tool-result storage created it", async () => {
+    const dbName = createDbName("shared");
+    const toolStore = new IndexedDBToolResultStore(dbName);
+
+    await toolStore.save("session-1", {
+      key: "tc_shared",
+      toolName: "read_page",
+      fullValue: "full result",
+      summary: "summary",
+      turnIndex: 0,
+    });
+
+    const sessionStorage = new IndexedDBSessionStorage(dbName);
+
+    await expect(sessionStorage.getLatestSessionId()).resolves.toBeNull();
+  });
+
+  it("upgrades a legacy v1 database with session data without losing records", async () => {
+    const dbName = createDbName("legacy-with-data");
+
+    await createLegacyV1Database(dbName, {
+      session: createSession("legacy-session"),
+      meta: createMeta("legacy-session"),
+    });
+
+    const sessionStorage = new IndexedDBSessionStorage(dbName);
+    const toolStore = new IndexedDBToolResultStore(dbName);
+
+    await expect(sessionStorage.getSession("legacy-session")).resolves.toEqual(
+      createSession("legacy-session"),
+    );
+
+    await toolStore.save("legacy-session", {
+      key: "tc_legacy",
+      toolName: "read_page",
+      fullValue: "full result",
+      summary: "summary",
+      turnIndex: 1,
+    });
+
+    await expect(toolStore.get("legacy-session", "tc_legacy")).resolves.toMatchObject({
+      key: "tc_legacy",
+      sessionId: "legacy-session",
+    });
+  });
+
+  it("upgrades an empty legacy v1 database to include tool-results store on first session open", async () => {
+    const dbName = createDbName("legacy-empty");
+
+    await createLegacyV1Database(dbName);
+
+    const sessionStorage = new IndexedDBSessionStorage(dbName);
+
+    await expect(sessionStorage.getLatestSessionId()).resolves.toBeNull();
+
+    const db = await openDatabase(dbName);
+    expect(Array.from(db.objectStoreNames)).toContain("tool-results");
+    db.close();
+  });
+});

--- a/src/adapters/storage/indexeddb-database.ts
+++ b/src/adapters/storage/indexeddb-database.ts
@@ -1,0 +1,68 @@
+const DEFAULT_DB_NAME = "tandemweb";
+const CURRENT_DB_VERSION = 2;
+const SESSIONS_STORE = "sessions";
+const METADATA_STORE = "sessions-metadata";
+const TOOL_RESULTS_STORE = "tool-results";
+const LAST_MODIFIED_INDEX = "lastModified";
+const TOOL_RESULTS_SESSION_INDEX = "sessionId";
+const TOOL_RESULTS_SESSION_CREATED_INDEX = "sessionId_createdAt";
+
+export {
+  CURRENT_DB_VERSION,
+  DEFAULT_DB_NAME,
+  LAST_MODIFIED_INDEX,
+  METADATA_STORE,
+  SESSIONS_STORE,
+  TOOL_RESULTS_SESSION_CREATED_INDEX,
+  TOOL_RESULTS_SESSION_INDEX,
+  TOOL_RESULTS_STORE,
+};
+
+export function upgradeTandemwebDatabase(db: IDBDatabase, oldVersion: number): void {
+  if (oldVersion < 1) {
+    if (!db.objectStoreNames.contains(SESSIONS_STORE)) {
+      db.createObjectStore(SESSIONS_STORE, { keyPath: "id" });
+    }
+
+    if (!db.objectStoreNames.contains(METADATA_STORE)) {
+      const metadataStore = db.createObjectStore(METADATA_STORE, { keyPath: "id" });
+      metadataStore.createIndex(LAST_MODIFIED_INDEX, LAST_MODIFIED_INDEX);
+    }
+  }
+
+  if (oldVersion < 2 && !db.objectStoreNames.contains(TOOL_RESULTS_STORE)) {
+    const toolResultsStore = db.createObjectStore(TOOL_RESULTS_STORE, { keyPath: "key" });
+    toolResultsStore.createIndex(TOOL_RESULTS_SESSION_INDEX, "sessionId", { unique: false });
+    toolResultsStore.createIndex(TOOL_RESULTS_SESSION_CREATED_INDEX, ["sessionId", "createdAt"], {
+      unique: false,
+    });
+  }
+}
+
+export function openTandemwebDatabase(options?: {
+  dbName?: string;
+  onSuccess?: (db: IDBDatabase) => void;
+  onError?: (error: unknown) => void;
+}): Promise<IDBDatabase> {
+  const dbName = options?.dbName ?? DEFAULT_DB_NAME;
+
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(dbName, CURRENT_DB_VERSION);
+
+    req.onupgradeneeded = (event) => {
+      upgradeTandemwebDatabase(req.result, event.oldVersion);
+    };
+
+    req.onsuccess = () => {
+      const db = req.result;
+      options?.onSuccess?.(db);
+      resolve(db);
+    };
+
+    req.onerror = () => {
+      const error = req.error;
+      options?.onError?.(error);
+      reject(error);
+    };
+  });
+}

--- a/src/adapters/storage/indexeddb-session-storage.ts
+++ b/src/adapters/storage/indexeddb-session-storage.ts
@@ -1,38 +1,31 @@
 import type { SessionStoragePort } from "@/ports/session-storage";
 import type { Session, SessionMeta } from "@/ports/session-types";
 import { createLogger } from "@/shared/logger";
+import {
+  DEFAULT_DB_NAME,
+  LAST_MODIFIED_INDEX,
+  METADATA_STORE,
+  SESSIONS_STORE,
+  openTandemwebDatabase,
+} from "./indexeddb-database";
 
 const log = createLogger("indexeddb-storage");
-
-const DB_NAME = "tandemweb";
-const DB_VERSION = 1;
-const SESSIONS_STORE = "sessions";
-const METADATA_STORE = "sessions-metadata";
 
 export class IndexedDBSessionStorage implements SessionStoragePort {
   private db: IDBDatabase | null = null;
 
+  constructor(private readonly dbName = DEFAULT_DB_NAME) {}
+
   private async getDB(): Promise<IDBDatabase> {
     if (this.db) return this.db;
-    return new Promise((resolve, reject) => {
-      const req = indexedDB.open(DB_NAME, DB_VERSION);
-      req.onupgradeneeded = () => {
-        const db = req.result;
-        if (!db.objectStoreNames.contains(SESSIONS_STORE))
-          db.createObjectStore(SESSIONS_STORE, { keyPath: "id" });
-        if (!db.objectStoreNames.contains(METADATA_STORE)) {
-          const meta = db.createObjectStore(METADATA_STORE, { keyPath: "id" });
-          meta.createIndex("lastModified", "lastModified");
-        }
-      };
-      req.onsuccess = () => {
-        this.db = req.result;
-        resolve(this.db);
-      };
-      req.onerror = () => {
-        log.error("IndexedDB open エラー", req.error);
-        reject(req.error);
-      };
+    return openTandemwebDatabase({
+      dbName: this.dbName,
+      onSuccess: (db) => {
+        this.db = db;
+      },
+      onError: (error) => {
+        log.error("IndexedDB open エラー", error);
+      },
     });
   }
 
@@ -40,7 +33,7 @@ export class IndexedDBSessionStorage implements SessionStoragePort {
     const db = await this.getDB();
     return new Promise((resolve, reject) => {
       const tx = db.transaction(METADATA_STORE, "readonly");
-      const index = tx.objectStore(METADATA_STORE).index("lastModified");
+      const index = tx.objectStore(METADATA_STORE).index(LAST_MODIFIED_INDEX);
       const req = index.openCursor(null, "prev");
       const results: SessionMeta[] = [];
       req.onsuccess = () => {

--- a/src/adapters/storage/indexeddb-tool-result-store.ts
+++ b/src/adapters/storage/indexeddb-tool-result-store.ts
@@ -1,51 +1,30 @@
 import type { StoredToolResult, ToolResultStorePort } from "@/ports/tool-result-store";
 import { createLogger } from "@/shared/logger";
+import {
+  DEFAULT_DB_NAME,
+  TOOL_RESULTS_SESSION_CREATED_INDEX,
+  TOOL_RESULTS_SESSION_INDEX,
+  TOOL_RESULTS_STORE,
+  openTandemwebDatabase,
+} from "./indexeddb-database";
 
 const log = createLogger("indexeddb-tool-result-store");
-
-const DB_NAME = "tandemweb";
-const DB_VERSION = 2;
-const STORE_NAME = "tool-results";
-const SESSION_INDEX = "sessionId";
-const SESSION_CREATED_INDEX = "sessionId_createdAt";
 
 export class IndexedDBToolResultStore implements ToolResultStorePort {
   private db: IDBDatabase | null = null;
 
+  constructor(private readonly dbName = DEFAULT_DB_NAME) {}
+
   private async getDB(): Promise<IDBDatabase> {
     if (this.db) return this.db;
-
-    return new Promise((resolve, reject) => {
-      const req = indexedDB.open(DB_NAME, DB_VERSION);
-
-      req.onupgradeneeded = () => {
-        const db = req.result;
-
-        if (!db.objectStoreNames.contains("sessions")) {
-          db.createObjectStore("sessions", { keyPath: "id" });
-        }
-
-        if (!db.objectStoreNames.contains("sessions-metadata")) {
-          const meta = db.createObjectStore("sessions-metadata", { keyPath: "id" });
-          meta.createIndex("lastModified", "lastModified");
-        }
-
-        if (!db.objectStoreNames.contains(STORE_NAME)) {
-          const store = db.createObjectStore(STORE_NAME, { keyPath: "key" });
-          store.createIndex(SESSION_INDEX, "sessionId", { unique: false });
-          store.createIndex(SESSION_CREATED_INDEX, ["sessionId", "createdAt"], { unique: false });
-        }
-      };
-
-      req.onsuccess = () => {
-        this.db = req.result;
-        resolve(this.db);
-      };
-
-      req.onerror = () => {
-        log.error("IndexedDB open error", req.error);
-        reject(req.error);
-      };
+    return openTandemwebDatabase({
+      dbName: this.dbName,
+      onSuccess: (db) => {
+        this.db = db;
+      },
+      onError: (error) => {
+        log.error("IndexedDB open error", error);
+      },
     });
   }
 
@@ -61,8 +40,8 @@ export class IndexedDBToolResultStore implements ToolResultStorePort {
     };
 
     return new Promise((resolve, reject) => {
-      const tx = db.transaction(STORE_NAME, "readwrite");
-      tx.objectStore(STORE_NAME).put(record);
+      const tx = db.transaction(TOOL_RESULTS_STORE, "readwrite");
+      tx.objectStore(TOOL_RESULTS_STORE).put(record);
       tx.oncomplete = () => resolve();
       tx.onerror = () => {
         log.error("save tool result error", tx.error);
@@ -75,7 +54,10 @@ export class IndexedDBToolResultStore implements ToolResultStorePort {
     const db = await this.getDB();
 
     return new Promise((resolve, reject) => {
-      const req = db.transaction(STORE_NAME, "readonly").objectStore(STORE_NAME).get(key);
+      const req = db
+        .transaction(TOOL_RESULTS_STORE, "readonly")
+        .objectStore(TOOL_RESULTS_STORE)
+        .get(key);
       req.onsuccess = () => {
         const value = (req.result as StoredToolResult | undefined) ?? null;
         if (value?.sessionId !== sessionId) {
@@ -92,8 +74,8 @@ export class IndexedDBToolResultStore implements ToolResultStorePort {
     const db = await this.getDB();
 
     return new Promise((resolve, reject) => {
-      const tx = db.transaction(STORE_NAME, "readonly");
-      const index = tx.objectStore(STORE_NAME).index(SESSION_CREATED_INDEX);
+      const tx = db.transaction(TOOL_RESULTS_STORE, "readonly");
+      const index = tx.objectStore(TOOL_RESULTS_STORE).index(TOOL_RESULTS_SESSION_CREATED_INDEX);
       const range = IDBKeyRange.bound([sessionId, 0], [sessionId, Number.MAX_SAFE_INTEGER]);
       const req = index.openCursor(range, "prev");
       const results: StoredToolResult[] = [];
@@ -115,14 +97,14 @@ export class IndexedDBToolResultStore implements ToolResultStorePort {
     const db = await this.getDB();
 
     return new Promise((resolve, reject) => {
-      const tx = db.transaction(STORE_NAME, "readwrite");
-      const index = tx.objectStore(STORE_NAME).index(SESSION_INDEX);
+      const tx = db.transaction(TOOL_RESULTS_STORE, "readwrite");
+      const index = tx.objectStore(TOOL_RESULTS_STORE).index(TOOL_RESULTS_SESSION_INDEX);
       const req = index.openKeyCursor(IDBKeyRange.only(sessionId));
 
       req.onsuccess = () => {
         const cursor = req.result;
         if (cursor) {
-          tx.objectStore(STORE_NAME).delete(cursor.primaryKey);
+          tx.objectStore(TOOL_RESULTS_STORE).delete(cursor.primaryKey);
           cursor.continue();
         }
       };


### PR DESCRIPTION
## Summary\n- extract tandemweb IndexedDB schema/version management into a shared helper\n- make both session and tool-result adapters open the same DB version and reuse the same upgrade path\n- add regression tests for fresh opens and legacy v1 upgrade paths\n\n## Testing\n- npx vitest run src/adapters/storage/__tests__/indexeddb-session-storage.test.ts src/adapters/storage/__tests__/indexeddb-tool-result-store.test.ts src/adapters/storage/__tests__/indexeddb-database-schema.test.ts\n- vp check\n\nCloses #53