### PR TITLE
fix(W2): ToolResultStore を fail-open 化し session 削除時に完全結果も cleanup する

### DIFF
--- a/src/features/sessions/SessionListModal.tsx
+++ b/src/features/sessions/SessionListModal.tsx
@@ -24,6 +24,7 @@ function useSessionStoreDeps(): SessionStoreDeps {
   const windowId = useStore((s) => s.windowId);
   return {
     sessionStorage: deps.sessionStorage,
+    toolResultStore: deps.toolResultStore,
     acquireLock: async (sessionId: string) => {
       try {
         const r = await port.sendMessage({ type: "acquireLock", sessionId, windowId }, 2000);

--- a/src/features/sessions/SessionTitle.tsx
+++ b/src/features/sessions/SessionTitle.tsx
@@ -37,6 +37,7 @@ export function SessionTitle() {
       const currentWindowId = useStore.getState().windowId;
       const storeDeps: SessionStoreDeps = {
         sessionStorage: deps.sessionStorage,
+        toolResultStore: deps.toolResultStore,
         acquireLock: async (sessionId: string) => {
           try {
             const r = await port.sendMessage(

--- a/src/features/sessions/__tests__/session-store.test.ts
+++ b/src/features/sessions/__tests__/session-store.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi, beforeEach } from "vitest";
 
 import type { SessionStoragePort } from "@/ports/session-storage";
+import type { ToolResultStorePort } from "@/ports/tool-result-store";
 import type { Session, SessionMeta } from "@/ports/session-types";
 
 import type { SessionStoreDeps } from "../types";
@@ -50,9 +51,19 @@ function makeMockStorage(): SessionStoragePort {
   };
 }
 
+function makeMockToolResultStore(): ToolResultStorePort {
+  return {
+    save: vi.fn().mockResolvedValue(undefined),
+    get: vi.fn().mockResolvedValue(null),
+    list: vi.fn().mockResolvedValue([]),
+    deleteSession: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
 function makeDeps(overrides: Partial<SessionStoreDeps> = {}): SessionStoreDeps {
   return {
     sessionStorage: makeMockStorage(),
+    toolResultStore: makeMockToolResultStore(),
     acquireLock: vi.fn().mockResolvedValue({ success: true }),
     releaseLock: vi.fn().mockResolvedValue(undefined),
     getSessionLocks: vi.fn().mockResolvedValue({}),
@@ -71,6 +82,10 @@ function makeStore() {
 }
 
 describe("session-store", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
   describe("loadSessionList", () => {
     it("sessionStorage からメタ一覧を読み込み store に設定する", async () => {
       const metaList = [makeMeta()];
@@ -167,11 +182,27 @@ describe("session-store", () => {
   });
 
   describe("deleteSession", () => {
-    it("セッションを削除して一覧を更新する", async () => {
+    it("セッションを削除してツール結果も cleanup し一覧を更新する", async () => {
       const deps = makeDeps();
       const store = makeStore();
 
       await deleteSession(deps, store, "sess-2", "sess-1");
+
+      expect(deps.sessionStorage.deleteSession).toHaveBeenCalledWith("sess-2");
+      expect(deps.toolResultStore.deleteSession).toHaveBeenCalledWith("sess-2");
+      expect(deps.sessionStorage.listSessions).toHaveBeenCalled();
+    });
+
+    it("ツール結果 cleanup が失敗してもセッション削除は継続する", async () => {
+      const deps = makeDeps({
+        toolResultStore: {
+          ...makeMockToolResultStore(),
+          deleteSession: vi.fn().mockRejectedValue(new Error("IndexedDB offline")),
+        },
+      });
+      const store = makeStore();
+
+      await expect(deleteSession(deps, store, "sess-2", "sess-1")).resolves.toBeUndefined();
 
       expect(deps.sessionStorage.deleteSession).toHaveBeenCalledWith("sess-2");
       expect(deps.sessionStorage.listSessions).toHaveBeenCalled();

--- a/src/features/sessions/session-store.ts
+++ b/src/features/sessions/session-store.ts
@@ -105,6 +105,12 @@ export async function deleteSession(
 
   await deps.sessionStorage.deleteSession(id);
 
+  try {
+    await deps.toolResultStore.deleteSession(id);
+  } catch (error) {
+    log.warn("tool result cleanup failed after session delete; continuing", { id, error });
+  }
+
   const list = await deps.sessionStorage.listSessions();
   store.setSessionList(list);
 }

--- a/src/features/sessions/types.ts
+++ b/src/features/sessions/types.ts
@@ -1,4 +1,5 @@
 import type { SessionStoragePort } from "@/ports/session-storage";
+import type { ToolResultStorePort } from "@/ports/tool-result-store";
 
 export interface SessionLocks {
   [sessionId: string]: number;
@@ -6,6 +7,7 @@ export interface SessionLocks {
 
 export interface SessionStoreDeps {
   sessionStorage: SessionStoragePort;
+  toolResultStore: ToolResultStorePort;
   acquireLock: (sessionId: string) => Promise<{ success: boolean }>;
   releaseLock: (sessionId: string) => Promise<void>;
   getSessionLocks: () => Promise<SessionLocks>;

--- a/src/features/tools/__tests__/get-tool-result.test.ts
+++ b/src/features/tools/__tests__/get-tool-result.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { InMemoryToolResultStore } from "@/adapters/storage/in-memory-storage";
+import type { ToolResultStorePort } from "@/ports/tool-result-store";
 import { executeGetToolResult, getToolResultToolDef } from "../get-tool-result";
 
 describe("get_tool_result", () => {
@@ -22,6 +23,23 @@ describe("get_tool_result", () => {
         toolName: "read_page",
         fullValue: "FULL",
         summary: "SUMMARY",
+      },
+    });
+  });
+
+  it("returns tool error when store lookup throws", async () => {
+    const store: ToolResultStorePort = {
+      save: vi.fn(),
+      get: vi.fn().mockRejectedValue(new Error("IndexedDB offline")),
+      list: vi.fn(),
+      deleteSession: vi.fn(),
+    };
+
+    await expect(executeGetToolResult(store, "session-1", { key: "tc_key" })).resolves.toEqual({
+      ok: false,
+      error: {
+        code: "tool_script_error",
+        message: "Stored tool result could not be loaded for key: tc_key",
       },
     });
   });

--- a/src/features/tools/get-tool-result.ts
+++ b/src/features/tools/get-tool-result.ts
@@ -1,6 +1,9 @@
 import type { ToolDefinition } from "@/ports/ai-provider";
 import type { ToolResultStorePort } from "@/ports/tool-result-store";
 import { err, ok, type Result, type ToolError } from "@/shared/errors";
+import { createLogger } from "@/shared/logger";
+
+const log = createLogger("get-tool-result");
 
 export interface GetToolResultArgs {
   key: string;
@@ -40,18 +43,30 @@ export async function executeGetToolResult(
     return err({ code: "tool_script_error", message: "key is required" });
   }
 
-  const result = await store.get(sessionId, args.key);
-  if (!result) {
+  try {
+    const result = await store.get(sessionId, args.key);
+    if (!result) {
+      return err({
+        code: "tool_script_error",
+        message: `Stored tool result not found for key: ${args.key}`,
+      });
+    }
+
+    return ok({
+      key: result.key,
+      toolName: result.toolName,
+      fullValue: result.fullValue,
+      summary: result.summary,
+    });
+  } catch (error) {
+    log.warn("tool result load failed; returning tool error", {
+      sessionId,
+      key: args.key,
+      error,
+    });
     return err({
       code: "tool_script_error",
-      message: `Stored tool result not found for key: ${args.key}`,
+      message: `Stored tool result could not be loaded for key: ${args.key}`,
     });
   }
-
-  return ok({
-    key: result.key,
-    toolName: result.toolName,
-    fullValue: result.fullValue,
-    summary: result.summary,
-  });
 }

--- a/src/orchestration/__tests__/agent-loop.test.ts
+++ b/src/orchestration/__tests__/agent-loop.test.ts
@@ -275,6 +275,65 @@ describe("runAgentLoop", () => {
     );
   });
 
+  it("falls back to summary-only when tool result store save fails", async () => {
+    setStreamEvents(
+      [
+        { type: "tool-call", id: "tc-store-fail", name: "read_page", args: {} },
+        { type: "finish", finishReason: "tool-calls" },
+      ],
+      [
+        { type: "text-delta", text: "done" },
+        { type: "finish", finishReason: "stop" },
+      ],
+    );
+
+    const save = vi.fn(async () => {
+      throw new Error("IndexedDB quota exceeded");
+    });
+    const syncHistory = vi.fn();
+    const params = createParams({
+      settings: {
+        provider: "openai",
+        model: "gpt-4",
+        apiKey: "sk-test",
+        baseUrl: "",
+        enterpriseDomain: "",
+      },
+      deps: {
+        createAIProvider: () => createMockAIProvider(),
+        browserExecutor: {
+          getActiveTab: vi.fn().mockResolvedValue({ url: "https://example.com", title: "Example" }),
+        } as unknown as BrowserExecutor,
+        toolResultStore: { ...mockToolResultStore, save },
+      },
+      chatStore: createMockChatStore({ syncHistory }),
+      toolExecutor: vi.fn().mockResolvedValue({
+        ok: true,
+        value: { text: "A".repeat(1200), simplifiedDom: "" },
+      }),
+    });
+
+    await expect(runAgentLoop(params)).resolves.toBeUndefined();
+
+    const [messages] = syncHistory.mock.calls.at(-1) ?? [];
+    expect(messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          role: "tool",
+          result: expect.stringContaining("[read_page]"),
+        }),
+      ]),
+    );
+    expect(messages).toEqual(
+      expect.not.arrayContaining([
+        expect.objectContaining({
+          role: "tool",
+          result: expect.stringContaining("Stored: tool_result://"),
+        }),
+      ]),
+    );
+  });
+
   it("repl 実行時は console log callback を渡して realtime log service に反映できる", async () => {
     defaultConsoleLogService.clear("tc-live");
     setStreamEvents([

--- a/src/orchestration/agent-loop.ts
+++ b/src/orchestration/agent-loop.ts
@@ -517,14 +517,24 @@ export async function runAgentLoop(params: AgentLoopParams): Promise<void> {
             shouldStore({ toolName: name, fullResult, summary, isError: !toolResult.ok })
           ) {
             const key = createToolResultKey();
-            await deps.toolResultStore.save(session.id, {
-              key,
-              toolName: name,
-              fullValue: fullResult,
-              summary,
-              turnIndex: turn,
-            });
-            resultForHistory = formatStoredToolResultSummary(name, summary, key);
+            try {
+              await deps.toolResultStore.save(session.id, {
+                key,
+                toolName: name,
+                fullValue: fullResult,
+                summary,
+                turnIndex: turn,
+              });
+              resultForHistory = formatStoredToolResultSummary(name, summary, key);
+            } catch (error) {
+              log.warn("tool result save failed; falling back to summary-only", {
+                sessionId: session.id,
+                toolName: name,
+                key,
+                error,
+              });
+              resultForHistory = formatStoredToolResultSummary(name, summary);
+            }
           } else {
             resultForHistory = formatStoredToolResultSummary(name, summary);
           }

--- a/src/ports/tool-result-store.ts
+++ b/src/ports/tool-result-store.ts
@@ -9,8 +9,17 @@ export interface StoredToolResult {
 }
 
 export interface ToolResultStorePort {
+  /**
+   * Layer 3 optimization only. Callers must fail-open and fall back to summary-only when this rejects.
+   */
   save(sessionId: string, result: Omit<StoredToolResult, "createdAt" | "sessionId">): Promise<void>;
+  /**
+   * Layer 3 optimization only. Callers must convert failures into a tool error instead of breaking the agent loop.
+   */
   get(sessionId: string, key: string): Promise<StoredToolResult | null>;
   list(sessionId: string): Promise<StoredToolResult[]>;
+  /**
+   * Best-effort cleanup. Session deletion should continue even when this rejects.
+   */
   deleteSession(sessionId: string): Promise<void>;
 }

--- a/src/sidepanel/Header.tsx
+++ b/src/sidepanel/Header.tsx
@@ -16,6 +16,7 @@ function useSessionStoreDeps(): SessionStoreDeps {
   const windowId = useStore((s) => s.windowId);
   return {
     sessionStorage: deps.sessionStorage,
+    toolResultStore: deps.toolResultStore,
     acquireLock: async (sessionId: string) => {
       try {
         const result = await port.sendMessage({ type: "acquireLock", sessionId, windowId }, 2000);


### PR DESCRIPTION
## 概要
- ToolResultStore の save/get/deleteSession を Layer 3 の fail-open 方針に合わせて整理
- save 失敗時は summary-only にフォールバックし agent loop を継続
- session 削除時に tool result cleanup を best-effort で実行

## テスト
- pnpm exec vitest run src/features/tools/__tests__/get-tool-result.test.ts src/features/sessions/__tests__/session-store.test.ts src/orchestration/__tests__/agent-loop.test.ts
- vp check