### PR TITLE
fix(W2-2): ResultSummarizer を設計書の要約フォーマットに揃える

### DIFF
--- a/src/features/tools/__tests__/result-summarizer.test.ts
+++ b/src/features/tools/__tests__/result-summarizer.test.ts
@@ -8,18 +8,58 @@ import {
 } from "../result-summarizer";
 
 describe("result-summarizer", () => {
-  it("summarizes read_page results with url and preview", () => {
+  it("summarizes read_page results with method, url and preview", () => {
     const summary = summarizeToolResult({
       toolName: "read_page",
       args: {},
       fullResult: JSON.stringify({ text: "Welcome to SiteSurf" }),
-      rawValue: { text: "Welcome to SiteSurf\nThis is the body" },
+      rawValue: {
+        text: "Welcome to SiteSurf\nThis is the body",
+        simplifiedDom: "[Extraction: article]",
+      },
       isError: false,
       currentUrl: "https://example.com",
     });
 
     expect(summary).toContain("URL: https://example.com");
+    expect(summary).toContain("method: article");
     expect(summary).toContain("Body preview:");
+  });
+
+  it("summarizes navigate results with status when available", () => {
+    const summary = summarizeToolResult({
+      toolName: "navigate",
+      args: { url: "https://example.com" },
+      fullResult: JSON.stringify({ finalUrl: "https://example.com", status: 200 }),
+      rawValue: { finalUrl: "https://example.com", status: 200 },
+      isError: false,
+    });
+
+    expect(summary).toBe("→ https://example.com (status: 200)");
+  });
+
+  it("keeps navigate summaries stable when status is unavailable", () => {
+    const summary = summarizeToolResult({
+      toolName: "navigate",
+      args: { url: "https://example.com" },
+      fullResult: JSON.stringify({ finalUrl: "https://example.com" }),
+      rawValue: { finalUrl: "https://example.com" },
+      isError: false,
+    });
+
+    expect(summary).toBe("→ https://example.com");
+  });
+
+  it("summarizes artifacts get results with size in bytes", () => {
+    const summary = summarizeToolResult({
+      toolName: "artifacts",
+      args: { command: "get", filename: "notes.txt" },
+      fullResult: "あa",
+      rawValue: "あa",
+      isError: false,
+    });
+
+    expect(summary).toBe("notes.txt (4 bytes)");
   });
 
   it("does not store short results", () => {
@@ -31,6 +71,46 @@ describe("result-summarizer", () => {
         isError: false,
       }),
     ).toBe(false);
+  });
+
+  it("keeps storing long read_page results after adding method to the summary", () => {
+    const fullResult = JSON.stringify({ text: "x".repeat(700) });
+    const summary = summarizeToolResult({
+      toolName: "read_page",
+      args: {},
+      fullResult,
+      rawValue: {
+        text: `Heading\n${"x".repeat(700)}`,
+        simplifiedDom: "[Extraction: article]",
+      },
+      isError: false,
+      currentUrl: "https://example.com",
+    });
+
+    expect(
+      shouldStore({
+        toolName: "read_page",
+        fullResult,
+        summary,
+        isError: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps read_page summaries within 300 characters", () => {
+    const summary = summarizeToolResult({
+      toolName: "read_page",
+      args: {},
+      fullResult: JSON.stringify({ text: "x".repeat(1000) }),
+      rawValue: {
+        text: `Heading\n${"x".repeat(1000)}`,
+        simplifiedDom: "[Extraction: article]",
+      },
+      isError: false,
+      currentUrl: "https://example.com/path",
+    });
+
+    expect(summary.length).toBeLessThanOrEqual(300);
   });
 
   it("does not store when summary and full result are nearly identical", () => {

--- a/src/features/tools/result-summarizer.ts
+++ b/src/features/tools/result-summarizer.ts
@@ -34,9 +34,25 @@ function getString(value: unknown): string | null {
   return typeof value === "string" && value.length > 0 ? value : null;
 }
 
+function getNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function getReadPageMethod(record: Record<string, unknown> | null): string | null {
+  const method = getString(record?.method);
+  if (method) return method;
+
+  const simplifiedDom = getString(record?.simplifiedDom);
+  if (!simplifiedDom) return null;
+
+  const match = simplifiedDom.match(/^\[Extraction: ([^\]]+)\]/);
+  return match?.[1]?.trim() || null;
+}
+
 function summarizeReadPage(input: SummarizeToolResultInput): string {
   const record = getRecord(input.rawValue);
   const text = getString(record?.text) ?? input.fullResult;
+  const method = getReadPageMethod(record);
   const firstLine = text
     .split("\n")
     .map((line) => line.trim())
@@ -45,6 +61,7 @@ function summarizeReadPage(input: SummarizeToolResultInput): string {
   const parts = [
     firstLine ? `H1: ${truncate(firstLine, 80)}` : null,
     input.currentUrl ? `URL: ${input.currentUrl}` : null,
+    method ? `method: ${method}` : null,
     `Body preview: ${previewText(text)}`,
   ].filter(Boolean);
 
@@ -86,14 +103,16 @@ function summarizeRepl(input: SummarizeToolResultInput): string {
 function summarizeNavigate(input: SummarizeToolResultInput): string {
   const record = getRecord(input.rawValue);
   const finalUrl = getString(record?.finalUrl) ?? input.currentUrl ?? "unknown";
-  return `→ ${finalUrl}`;
+  const status = getNumber(record?.status);
+  return status === null ? `→ ${finalUrl}` : `→ ${finalUrl} (status: ${status})`;
 }
 
 function summarizeArtifacts(input: SummarizeToolResultInput): string {
   const command = getString(input.args.command) ?? "unknown";
   const filename = getString(input.args.filename) ?? "unknown";
   if (command === "get") {
-    return `${filename} retrieved`;
+    const sizeBytes = new TextEncoder().encode(input.fullResult).length;
+    return `${filename} (${sizeBytes} bytes)`;
   }
   return `${command}: ${filename}`;
 }


### PR DESCRIPTION
## 概要
- read_page 要約に method を追加
- navigate 要約で status がある場合は含めるように調整
- artifacts.get 要約で UTF-8 byte size を出すように変更
- shouldStore と 300 文字制約の回帰テストを追加

## テスト
- pnpm vitest run src/features/tools/__tests__/navigate.test.ts src/features/tools/__tests__/result-summarizer.test.ts src/orchestration/__tests__/agent-loop.test.ts