### PR TITLE
fix(W2): keep full tool results on large-window models

### DIFF
--- a/src/orchestration/agent-loop.ts
+++ b/src/orchestration/agent-loop.ts
@@ -547,8 +547,10 @@ export async function runAgentLoop(params: AgentLoopParams): Promise<void> {
               });
               resultForHistory = formatStoredToolResultSummary(name, summary);
             }
-          } else {
+          } else if (budget.useToolResultStore) {
             resultForHistory = formatStoredToolResultSummary(name, summary);
+          } else {
+            resultForHistory = fullResult;
           }
         }
 


### PR DESCRIPTION
## Summary

- 大窓モデル (`inputBudget >= 80k`、`useToolResultStore=false`) でツール結果の完全版が履歴から失われていた問題を修正
- これまで全モデルで 300 字の要約に潰され、大窓モデルには `get_tool_result` での復元手段も無かったため、AI が毎ターン `read_page` / `bg_fetch` の本文を忘れていた
- Layer 3 の設計意図通り「小窓のみ summarize+store、大窓は fullResult 保持」に揃える

## Root cause

`agent-loop.ts:507-552` の `else` 分岐が `useToolResultStore` の真偽を問わず `formatStoredToolResultSummary(name, summary)` を書き戻していた。大窓では `shouldStore` で分岐する前にまず `useToolResultStore` を見るべきだった。

## Behavior matrix

| 条件 | 履歴に残るもの |
|---|---|
| 小窓 & `shouldStore=true` | 要約+key (IndexedDB保存) |
| 小窓 & save 失敗 | 要約のみ (fail-open) |
| 小窓 & `shouldStore=false` | 要約のみ |
| **大窓** | **完全版** (Layer 2 の `maxToolResultChars` で truncate) |

## Test plan

- [x] `npx vitest run src/orchestration src/features/tools src/features/ai` → 414 passed
- [ ] 実機で大窓モデル (Claude Sonnet 等) で `read_page` 後のターンでも本文が参照されることを確認
- [ ] 小窓モデル (gpt-4 8k) の挙動に回帰が無いこと (要約+key が残る)

🤖 Generated with [Claude Code](https://claude.com/claude-code)