### PR TITLE
fix(W2): preserve full get_tool_result content from Layer 2 truncation

### DIFF
--- a/src/orchestration/__tests__/context-manager.test.ts
+++ b/src/orchestration/__tests__/context-manager.test.ts
@@ -65,6 +65,29 @@ describe("context-manager", () => {
     expect((messages[0] as Extract<AIMessage, { role: "tool" }>).result).toContain("FULL CONTENT");
   });
 
+  it("does not truncate active get_tool_result content larger than maxToolResultChars", () => {
+    const hugeFullValue = "X".repeat(budget.maxToolResultChars * 5);
+    const messages: AIMessage[] = [
+      {
+        role: "tool",
+        toolCallId: "tool-1",
+        toolName: "get_tool_result",
+        result: formatRetrievedToolResult({
+          key: "tc_1",
+          toolName: "read_page",
+          fullValue: hugeFullValue,
+          summary: "Body preview: hello",
+        }),
+      },
+    ];
+
+    manageContextMessages(messages, budget);
+
+    const result = (messages[0] as Extract<AIMessage, { role: "tool" }>).result;
+    expect(result).toContain(hugeFullValue);
+    expect(result).not.toContain("... (truncated)");
+  });
+
   it("logs when trimThreshold is reached and reports splicedMessageCount", () => {
     const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
     const messages: AIMessage[] = [

--- a/src/orchestration/context-manager.ts
+++ b/src/orchestration/context-manager.ts
@@ -47,10 +47,19 @@ function replaceExpiredRetrievedResults(messages: AIMessage[]): void {
   }
 }
 
+const ACTIVE_RETRIEVED_RESULT_PREFIX = "[get_tool_result]\nRestored:";
+
 function normalizeContextMessages(messages: AIMessage[], budget: ContextBudget): void {
   for (let index = 0; index < messages.length; index++) {
     const message = messages[index];
     if (message.role !== "tool" || typeof message.result !== "string") {
+      continue;
+    }
+
+    // 復元中の get_tool_result は maxToolResultChars で切り詰めない。
+    // AI が明示的に全文を求めた直後の 1 ターン限定で渡す想定で、
+    // 次ターン以降は replaceExpiredRetrievedResults が要約形へ戻す。
+    if (message.result.startsWith(ACTIVE_RETRIEVED_RESULT_PREFIX)) {
       continue;
     }
 


### PR DESCRIPTION
## Summary

- `get_tool_result` で復元した完全版が `normalizeContextMessages` の `maxToolResultChars` truncate で即座に削られていた問題を修正
- これにより AI から見ると「`get_tool_result` を呼んでも要約しか返ってこない」状態になっており、Layer 3 の取得機能が実質機能していなかった

## Root cause

`src/orchestration/context-manager.ts:50-64` の `normalizeContextMessages` が全 tool メッセージに対して一律に `truncateToolResult(result, maxToolResultChars)` を適用。

`get_tool_result` の復元結果は `[get_tool_result]\nRestored: ...\nSummary:\n<短>\n---\n<完全版>` 形式で、先頭に Summary セクションが含まれる。32K 窓の `maxToolResultChars=2000` では **完全版の大半が削られ、AI には「Summary + 数百字」しか届かない** → 体感的に「要約しか返ってこない」

## Fix

`[get_tool_result]\nRestored:` で始まるメッセージは truncate から除外。AI が明示的に全文を要求した直後の 1 ターンのみ渡す想定で、次ターン以降は既存の `replaceExpiredRetrievedResults` が要約形へ戻すため、長期的な文脈コストは変わらない。

## Test plan

- [x] `npx vitest run src/orchestration src/features/tools src/features/ai` → 415 passed (+1 regression test)
- [ ] 実機で `read_page` → `get_tool_result` を呼び、次の応答で完全版が参照できることを確認

## Related

- #63 で大窓モデルの完全版保持を修正済み
- 本PRは小窓モデルで `get_tool_result` を使うケース向けの修正

🤖 Generated with [Claude Code](https://claude.com/claude-code)