### PR TITLE
diag(W2): log get_tool_result lifecycle

### DIFF
--- a/src/orchestration/agent-loop.ts
+++ b/src/orchestration/agent-loop.ts
@@ -506,7 +506,16 @@ export async function runAgentLoop(params: AgentLoopParams): Promise<void> {
 
         let resultForHistory = fullResult;
         if (name === "get_tool_result" && toolResult.ok) {
-          resultForHistory = formatRetrievedToolResult(toolResult.value as GetToolResultValue);
+          const retrieved = toolResult.value as GetToolResultValue;
+          resultForHistory = formatRetrievedToolResult(retrieved);
+          log.info("[diag:get_tool_result] retrieved from store", {
+            key: retrieved.key,
+            originalTool: retrieved.toolName,
+            fullValueChars: retrieved.fullValue.length,
+            summaryChars: retrieved.summary.length,
+            historyMessageChars: resultForHistory.length,
+            turn,
+          });
         } else {
           const summary = summarizeToolResult({
             toolName: name,
@@ -536,6 +545,13 @@ export async function runAgentLoop(params: AgentLoopParams): Promise<void> {
                 fullValue: fullResult,
                 summary,
                 turnIndex: turn,
+              });
+              log.info("[diag:tool_result_store] saved", {
+                key,
+                toolName: name,
+                fullValueChars: fullResult.length,
+                summaryChars: summary.length,
+                turn,
               });
               resultForHistory = formatStoredToolResultSummary(name, summary, key);
             } catch (error) {

--- a/src/orchestration/context-manager.ts
+++ b/src/orchestration/context-manager.ts
@@ -42,7 +42,18 @@ function replaceExpiredRetrievedResults(messages: AIMessage[]): void {
       .slice(index + 1)
       .some((candidate) => candidate.role !== "tool");
     if (hasLaterMessage) {
+      log.info("[diag:get_tool_result] expiring retrieved content → summary form", {
+        index,
+        beforeChars: message.result.length,
+        afterChars: restored.length,
+        reason: "laterNonToolMessageExists",
+      });
       message.result = restored;
+    } else {
+      log.info("[diag:get_tool_result] preserving active retrieved content", {
+        index,
+        chars: message.result.length,
+      });
     }
   }
 }
@@ -60,13 +71,26 @@ function normalizeContextMessages(messages: AIMessage[], budget: ContextBudget):
     // AI が明示的に全文を求めた直後の 1 ターン限定で渡す想定で、
     // 次ターン以降は replaceExpiredRetrievedResults が要約形へ戻す。
     if (message.result.startsWith(ACTIVE_RETRIEVED_RESULT_PREFIX)) {
+      log.info("[diag:get_tool_result] bypass truncate (active)", {
+        index,
+        chars: message.result.length,
+        maxToolResultChars: budget.maxToolResultChars,
+      });
       continue;
     }
 
-    messages[index] = {
-      ...message,
-      result: truncateToolResult(message.result, budget.maxToolResultChars),
-    };
+    const before = message.result.length;
+    const truncated = truncateToolResult(message.result, budget.maxToolResultChars);
+    if (before !== truncated.length) {
+      log.info("[diag:tool_result_truncate] applied", {
+        index,
+        toolName: message.toolName,
+        beforeChars: before,
+        afterChars: truncated.length,
+        maxToolResultChars: budget.maxToolResultChars,
+      });
+    }
+    messages[index] = { ...message, result: truncated };
   }
 
   replaceExpiredRetrievedResults(messages);


### PR DESCRIPTION
## Summary

AI が「\`get_tool_result\` で取得しても要約しか返ってこない」と報告しているため、ツール結果ストアの各段階で info ログを追加し、どこで完全版が失われるか（または失われていないか）を特定する。

## Log points

| ポイント | 場所 | 出力 |
|---|---|---|
| 保存時 | \`agent-loop.ts\` \`shouldStore\` 分岐 | \`key / toolName / fullValueChars / summaryChars / turn\` |
| 取得時 | \`agent-loop.ts\` \`get_tool_result\` 分岐 | \`key / originalTool / fullValueChars / summaryChars / historyMessageChars / turn\` |
| truncate 抑止時 | \`context-manager.ts\` normalize | \`index / chars / maxToolResultChars\` |
| truncate 適用時 | 同上 | \`toolName / beforeChars / afterChars / maxToolResultChars\` |
| 期限切れで要約へ戻す時 | \`context-manager.ts\` replaceExpired | \`index / beforeChars / afterChars / reason\` |
| アクティブ保持時 | 同上 | \`index / chars\` |

すべて \`[diag:...]\` プレフィックス付き。問題が解消したらこのコミットを revert するだけで一括削除可能。

## 期待するシグナル

- \`fullValueChars ≈ summaryChars\` → 保存されたデータ自体が要約と変わらない (result-summarizer の問題)
- bypass ログが出ない → 拡張機能が古い JS を実行している (リロード不足)
- truncate applied ログ (on retrieved message) → フィックス漏れの箇所あり
- expiring ログが想定より早く出る → 設計の見直しが必要

## Test plan

- [x] \`npx vitest run src/orchestration src/features/tools\` → 386 passed
- [ ] 実機 DevTools console で [diag:...] ログを観察し原因特定

🤖 Generated with [Claude Code](https://claude.com/claude-code)