### PR TITLE
feat(context): default autoCompact=true, keep-recent by tokens

### DIFF
--- a/src/features/settings/__tests__/SettingsPanel.test.ts
+++ b/src/features/settings/__tests__/SettingsPanel.test.ts
@@ -116,6 +116,6 @@ describe("SettingsPanel", () => {
     });
 
     const saved = await loadSettings(storage);
-    expect(saved?.autoCompact).toBe(true);
+    expect(saved?.autoCompact).toBe(false);
   });
 });

--- a/src/features/settings/__tests__/persistence.test.ts
+++ b/src/features/settings/__tests__/persistence.test.ts
@@ -292,7 +292,7 @@ describe("persistence", () => {
     expect(result?.autoCompact).toBe(true);
   });
 
-  it("autoCompact 未設定の legacy 設定はデフォルトで false に解決する", async () => {
+  it("autoCompact 未設定の legacy 設定はデフォルトで true に解決する", async () => {
     const storage = new InMemoryStorage();
 
     await storage.set("sitesurf_settings", {
@@ -304,10 +304,10 @@ describe("persistence", () => {
 
     const result = await loadSettings(storage);
 
-    expect(result?.autoCompact).toBe(false);
+    expect(result?.autoCompact).toBe(true);
   });
 
-  it("autoCompact 未設定の legacy 設定はデフォルトで false に解決する", async () => {
+  it("autoCompact 未設定の legacy 設定はデフォルトで true に解決する (mcp 設定あり)", async () => {
     const storage = new InMemoryStorage();
 
     await storage.set("sitesurf_settings", {
@@ -321,7 +321,7 @@ describe("persistence", () => {
 
     const result = await loadSettings(storage);
 
-    expect(result?.autoCompact).toBe(false);
+    expect(result?.autoCompact).toBe(true);
   });
 
   it("autoCompact=true は永続化されて復元される", async () => {

--- a/src/features/settings/persistence.ts
+++ b/src/features/settings/persistence.ts
@@ -80,7 +80,7 @@ export async function loadSettings(storage: StoragePort): Promise<Settings | nul
     maxTokensByProvider,
     reasoningLevel: reasoningLevelByProvider[provider] ?? raw.reasoningLevel ?? "medium",
     maxTokens: maxTokensByProvider[provider] ?? raw.maxTokens ?? DEFAULT_MAX_TOKENS,
-    autoCompact: raw.autoCompact ?? false,
+    autoCompact: raw.autoCompact ?? true,
     enableBgFetch: raw.enableBgFetch ?? false,
     enableSecurityMiddleware: raw.enableSecurityMiddleware ?? true,
   };

--- a/src/features/settings/settings-store.ts
+++ b/src/features/settings/settings-store.ts
@@ -60,7 +60,7 @@ export const createSettingsSlice: StateCreator<AppStore, [], [], SettingsSlice> 
     maxTokensByProvider: {},
     reasoningLevel: "medium",
     maxTokens: DEFAULT_MAX_TOKENS,
-    autoCompact: false,
+    autoCompact: true,
     enableBgFetch: false,
     enableSecurityMiddleware: true,
   },

--- a/src/orchestration/__tests__/context-compressor.test.ts
+++ b/src/orchestration/__tests__/context-compressor.test.ts
@@ -145,7 +145,8 @@ describe("compressIfNeeded", () => {
     });
     expect(result.compressed).toBe(true);
     expect(result.session.summary?.text).toBe("要約結果");
-    expect(result.session.history).toHaveLength(10);
+    // KEEP_RECENT_TOKENS=20_000 に対し各メッセージが 200k 相当 → 末尾1件のみ保持。
+    expect(result.session.history).toHaveLength(1);
   });
 
   it("ローカルLLMでは自動圧縮する", async () => {
@@ -160,7 +161,7 @@ describe("compressIfNeeded", () => {
     expect(result.session.summary?.text).toBe("ローカル要約");
   });
 
-  it("直近10件のメッセージを保持する", async () => {
+  it("末尾 KEEP_RECENT_TOKENS 分のメッセージを保持する", async () => {
     const provider = createMockAIProvider("要約");
     const history: AIMessage[] = Array.from({ length: 20 }, (_, i) =>
       createUserMessage(`msg-${i}`),
@@ -175,7 +176,8 @@ describe("compressIfNeeded", () => {
 
     const result = await compressIfNeeded(provider, session, budget, "llama3.2", "local");
     expect(result.compressed).toBe(true);
-    expect(result.session.history).toHaveLength(10);
+    // 末尾 5 件の短メッセージ + 10k 相当の long メッセージ 2 件で 20k token を満たす。
+    expect(result.session.history).toHaveLength(7);
   });
 
   it("圧縮対象が空の場合はスキップする", async () => {
@@ -213,7 +215,8 @@ describe("compressIfNeeded", () => {
 
     const result = await compressIfNeeded(provider, session, budget, "llama3.2", "local");
     expect(result.compressed).toBe(true);
-    expect(result.session.summary?.originalMessageCount).toBe(35);
+    // 各メッセージ 10k 相当 × 15 件 → 末尾 2 件を保持、13 件を要約対象に追加する。
+    expect(result.session.summary?.originalMessageCount).toBe(43);
     expect(result.session.summary?.text).toBe("再要約結果");
   });
 
@@ -258,7 +261,8 @@ describe("compressMessagesIfNeeded", () => {
 
     expect(result.compressed).toBe(true);
     expect(result.summary?.text).toBe("## Goal\n要約された目標");
-    expect(result.messages).toHaveLength(11);
+    // 各メッセージ 10k token 相当 × 15 → 末尾 2 件を保持、先頭に要約メッセージで計 3 件。
+    expect(result.messages).toHaveLength(3);
     expect(result.messages[0]).toEqual({
       role: "user",
       content: [

--- a/src/orchestration/context-compressor.ts
+++ b/src/orchestration/context-compressor.ts
@@ -11,9 +11,46 @@ import {
 
 export { estimateTokens } from "@/shared/token-utils";
 
-const KEEP_RECENT = 10;
+const KEEP_RECENT_TOKENS = 20_000;
 const log = createLogger("compressor");
 export const STRUCTURED_SUMMARY_MESSAGE_PREFIX = "[構造化要約]";
+
+/**
+ * 末尾から KEEP_RECENT_TOKENS 相当を保持し、残りを要約対象として切り出す。
+ *
+ * - トークン数ベース（pi-mono と同様）。メッセージ数ベースだと巨大な
+ *   ツール結果 1 件で容易にしきい値を超えるため。
+ * - cut point が tool メッセージに当たった場合は、対応する assistant
+ *   (tool_call) から切れるようにさらに後退する。tool_result は必ず
+ *   直前の assistant と一緒に保持／破棄されなければならない。
+ */
+export function splitByKeepRecentTokens(
+  messages: AIMessage[],
+  keepTokens: number = KEEP_RECENT_TOKENS,
+): { toCompress: AIMessage[]; toKeep: AIMessage[] } {
+  if (messages.length === 0) {
+    return { toCompress: [], toKeep: [] };
+  }
+
+  let cutIndex = messages.length;
+  let keptTokens = 0;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    keptTokens += estimateTokens([messages[i]]);
+    cutIndex = i;
+    if (keptTokens >= keepTokens) {
+      break;
+    }
+  }
+
+  while (cutIndex > 0 && messages[cutIndex].role === "tool") {
+    cutIndex--;
+  }
+
+  return {
+    toCompress: messages.slice(0, cutIndex),
+    toKeep: messages.slice(cutIndex),
+  };
+}
 
 export interface CompressResult {
   session: Session;
@@ -97,8 +134,7 @@ export async function compressMessagesIfNeeded(
 
   const currentSummary = options.existingSummary ?? extractStructuredSummary(messages)?.text;
   const sourceMessages = stripStructuredSummaryMessages(messages);
-  const toCompress = sourceMessages.slice(0, -KEEP_RECENT);
-  const toKeep = sourceMessages.slice(-KEEP_RECENT);
+  const { toCompress, toKeep } = splitByKeepRecentTokens(sourceMessages);
 
   if (toCompress.length === 0) {
     return { messages, compressed: false };


### PR DESCRIPTION
## Summary

類似アプローチと同じ context management の方向へ段階移行する Phase 1。AI が「忘れる」と報告していた直接原因への応急処置。

1. **\`autoCompact\` のデフォルトを \`true\` に**。これまでクラウドプロバイダでは圧縮パスが opt-in ゲートされており、窓が溢れそうになると LLM 要約ではなく古いメッセージの splice（削除）に落ちていた。実機ログでは 1 ターンで 9 メッセージが消失していた。
2. **\`KEEP_RECENT\` をメッセージ数 10 からトークン数 20,000 へ変更**。巨大なツール結果 1 件で容易にしきい値を超えるのを防ぐ。pi-mono の \`keepRecentTokens\` デフォルトと同じ値。tool_call / tool_result のペアを分割しないよう cut point が tool メッセージに当たったら assistant まで後退する。

既に \`autoCompact\` を明示的に \`false\` 保存しているユーザ設定は上書きしない（\`?? false\` → \`?? true\` の変更のみ）。要約プロンプト・要約メッセージ形式・既存 summary のローリング挙動はそのまま。

## Test plan

- [x] \`npx vitest run\` → 987 passed
- [ ] 実機で巨大セッションを作り、\`trimThreshold reached\` 後に \`splicedMessageCount\` ではなく \`コンテキスト圧縮完了\` のログが出ることを確認
- [ ] 大量の bg_fetch を伴うセッションで、圧縮後も AI が直近のタスクを継続できるか確認

## Related

- #29 Context Management v2 トラッキング
- Phase 2 で Wave 2 (\`get_tool_result\` / ToolResultStore) を削除予定
- Phase 3 で要約プロンプトの pi-mono パリティ（Goal/Progress/Decisions）を検討

🤖 Generated with [Claude Code](https://claude.com/claude-code)