### PR TITLE
fix(context): strip [構造化要約] leftover from persisted session history

### DIFF
--- a/src/features/settings/SettingsPanel.tsx
+++ b/src/features/settings/SettingsPanel.tsx
@@ -272,7 +272,7 @@ export function SettingsPanel() {
                         ? "ローカルモデルでは必要時に自動圧縮されます。クラウド向け設定は保存のみ行います"
                         : settings.autoCompact
                           ? "長い会話で構造化要約を自動生成します。追加の LLM コストが発生します"
-                          : "デフォルトはOFFです。長期セッションで情報保持を優先したい場合のみ有効にしてください"
+                          : "OFF の間はコンテキスト超過時に古いメッセージを削除します。情報の欠落を避けたい場合は ON を推奨"
                     }
                     checked={settings.autoCompact}
                     onChange={(e) => setSettings({ autoCompact: e.currentTarget.checked })}

--- a/src/orchestration/__tests__/agent-loop.test.ts
+++ b/src/orchestration/__tests__/agent-loop.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import { runAgentLoop, trackVisitedUrl, pruneVisitedUrls } from "../agent-loop";
+import { runAgentLoop, trackVisitedUrl, pruneVisitedUrls, toPersistedHistory } from "../agent-loop";
+import { STRUCTURED_SUMMARY_MESSAGE_PREFIX } from "../context-compressor";
 import type { AgentLoopParams, ChatActions } from "../agent-loop";
 import type { VisitedUrlEntry } from "@/features/ai/system-prompt-v2";
 import type { Session } from "@/ports/session-types";
@@ -1343,5 +1344,66 @@ describe("visited URLs in system prompt", () => {
 
     const firstCall = streamTextCalls[0] as { systemPrompt: string };
     expect(firstCall.systemPrompt).not.toContain("## Current Session: Visited URLs");
+  });
+});
+
+describe("toPersistedHistory", () => {
+  it("圧縮直後に残った [構造化要約] メッセージを先頭から除去する", () => {
+    const messages = [
+      {
+        role: "user" as const,
+        content: [
+          {
+            type: "text" as const,
+            text: `${STRUCTURED_SUMMARY_MESSAGE_PREFIX}\n## Goal\n前回の要約`,
+          },
+        ],
+      },
+      {
+        role: "user" as const,
+        content: [{ type: "text" as const, text: "直近のユーザ発話" }],
+      },
+    ];
+
+    const result = toPersistedHistory(messages);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBe(messages[1]);
+  });
+
+  it("[構造化要約] と [過去の会話の要約] の両方が先頭にある場合も重複せず除去する", () => {
+    const summaryText = "## Goal\nテスト";
+    const messages = [
+      {
+        role: "user" as const,
+        content: [
+          { type: "text" as const, text: `${STRUCTURED_SUMMARY_MESSAGE_PREFIX}\n${summaryText}` },
+        ],
+      },
+      {
+        role: "user" as const,
+        content: [{ type: "text" as const, text: `[過去の会話の要約]\n${summaryText}` }],
+      },
+      {
+        role: "user" as const,
+        content: [{ type: "text" as const, text: "次の発話" }],
+      },
+    ];
+
+    const result = toPersistedHistory(messages, summaryText);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBe(messages[2]);
+  });
+
+  it("要約マーカーのないメッセージ列はそのまま返す", () => {
+    const messages = [
+      { role: "user" as const, content: [{ type: "text" as const, text: "hello" }] },
+      { role: "assistant" as const, content: [{ type: "text" as const, text: "hi" }] },
+    ];
+
+    const result = toPersistedHistory(messages, "ignored");
+
+    expect(result).toEqual(messages);
   });
 });

--- a/src/orchestration/__tests__/context-compressor.test.ts
+++ b/src/orchestration/__tests__/context-compressor.test.ts
@@ -3,6 +3,7 @@ import {
   compressIfNeeded,
   compressMessagesIfNeeded,
   estimateTokens,
+  splitByKeepRecentTokens,
   STRUCTURED_SUMMARY_MESSAGE_PREFIX,
 } from "../context-compressor";
 import type { AIProvider, AIMessage, StreamEvent } from "@/ports/ai-provider";
@@ -245,6 +246,94 @@ describe("compressIfNeeded", () => {
 
     const result = await compressIfNeeded(provider, session, budget, "llama3.2", "local");
     expect(result.session.messages).toBe(messages);
+  });
+});
+
+describe("splitByKeepRecentTokens", () => {
+  it("空配列で toCompress/toKeep ともに空を返す", () => {
+    const result = splitByKeepRecentTokens([], 100);
+    expect(result.toCompress).toEqual([]);
+    expect(result.toKeep).toEqual([]);
+  });
+
+  it("全てが keepTokens 未満の場合は全てを toKeep として保持する", () => {
+    const messages: AIMessage[] = [createUserMessage("a"), createUserMessage("b")];
+    const result = splitByKeepRecentTokens(messages, 100);
+    expect(result.toCompress).toEqual([]);
+    expect(result.toKeep).toEqual(messages);
+  });
+
+  it("cut point が tool メッセージに当たった場合は直前の assistant(tool-call) まで後退する", () => {
+    const assistantWithCall: AIMessage = {
+      role: "assistant",
+      content: [
+        { type: "text", text: "calling" },
+        { type: "tool-call", id: "tc1", name: "read_page", args: {} },
+      ],
+    };
+    const toolResult: AIMessage = {
+      role: "tool",
+      toolCallId: "tc1",
+      toolName: "read_page",
+      result: "x".repeat(50),
+    };
+    const tailUser = createUserMessage("y".repeat(60));
+    const messages: AIMessage[] = [
+      createUserMessage("u".repeat(200)),
+      assistantWithCall,
+      toolResult,
+      tailUser,
+    ];
+    // tailUser だけでは 100 に届かず、tool を取り込むとそこが cut point になるが、
+    // tool 直前の assistant(tool-call) まで後退して一緒に保持されなければならない。
+    const result = splitByKeepRecentTokens(messages, 100);
+    expect(result.toCompress).toEqual([messages[0]]);
+    expect(result.toKeep).toEqual([assistantWithCall, toolResult, tailUser]);
+  });
+
+  it("並列 tool 実行 (assistant 1 つに対し tool 複数) の pair も分断しない", () => {
+    const assistantWithTwoCalls: AIMessage = {
+      role: "assistant",
+      content: [
+        { type: "tool-call", id: "tc1", name: "navigate", args: {} },
+        { type: "tool-call", id: "tc2", name: "read_page", args: {} },
+      ],
+    };
+    const toolA: AIMessage = {
+      role: "tool",
+      toolCallId: "tc1",
+      toolName: "navigate",
+      result: "a".repeat(30),
+    };
+    const toolB: AIMessage = {
+      role: "tool",
+      toolCallId: "tc2",
+      toolName: "read_page",
+      result: "b".repeat(30),
+    };
+    const messages: AIMessage[] = [createUserMessage("u".repeat(200)), assistantWithTwoCalls, toolA, toolB];
+    const result = splitByKeepRecentTokens(messages, 50);
+    expect(result.toKeep[0]).toBe(assistantWithTwoCalls);
+    expect(result.toKeep).toHaveLength(3);
+  });
+
+  it("画像を含むメッセージは 6000 chars 相当としてトークン計算される", () => {
+    const messageWithImage: AIMessage = {
+      role: "user",
+      content: [
+        { type: "text", text: "hi" },
+        { type: "image", mimeType: "image/png", data: "base64..." },
+      ],
+    };
+    const messages: AIMessage[] = [
+      createUserMessage("u".repeat(1_000)),
+      createUserMessage("v".repeat(1_000)),
+      messageWithImage,
+    ];
+    const result = splitByKeepRecentTokens(messages, 5_000);
+    // 画像 1 枚で ~6000 相当 → tail 1 件で keepTokens を満たす。
+    expect(result.toKeep).toEqual([messageWithImage]);
+    expect(result.toCompress).toHaveLength(2);
   });
 });
 

--- a/src/orchestration/agent-loop.ts
+++ b/src/orchestration/agent-loop.ts
@@ -17,7 +17,7 @@ import { createSecurityMiddleware, type SecurityMiddleware } from "@/features/se
 import { convertNavigationForAPI } from "./navigation-converter";
 import { calculateBackoff, isRetryable, RETRY_CONFIG } from "./retry";
 import { estimateTokens } from "./context-compressor";
-import { compressIfNeeded } from "./context-compressor";
+import { compressIfNeeded, stripStructuredSummaryMessage } from "./context-compressor";
 import { getContextBudget } from "@/features/ai/context-budget";
 import type { ToolResultStorePort } from "@/ports/tool-result-store";
 import { generateVisitedUrlsSection, type VisitedUrlEntry } from "@/features/ai/system-prompt-v2";
@@ -232,11 +232,20 @@ function stripLeadingSessionSummaryMessage(
   return messages.slice(1);
 }
 
-function toPersistedHistory(messages: AIMessage[], summaryText?: string): AIMessage[] {
-  return stripLeadingSessionSummaryMessage(
-    messages.filter((message) => !isSkillDetectionMessage(message)),
-    summaryText,
-  );
+// 構造化要約メッセージ（[構造化要約]\n...）は圧縮直後の in-memory messages 先頭に
+// 残るが、セッション永続化の履歴には session.summary として別途保持するため
+// 重複送信・残骸蓄積を避けるために先頭から外しておく。
+function stripLeadingStructuredSummary(messages: AIMessage[]): AIMessage[] {
+  if (stripStructuredSummaryMessage(messages[0]) === undefined) {
+    return messages;
+  }
+  return messages.slice(1);
+}
+
+export function toPersistedHistory(messages: AIMessage[], summaryText?: string): AIMessage[] {
+  const withoutSkillMessages = messages.filter((message) => !isSkillDetectionMessage(message));
+  const withoutStructuredSummary = stripLeadingStructuredSummary(withoutSkillMessages);
+  return stripLeadingSessionSummaryMessage(withoutStructuredSummary, summaryText);
 }
 
 export async function runAgentLoop(params: AgentLoopParams): Promise<void> {


### PR DESCRIPTION
## Summary

#66 レビューで oracle が指摘した実バグの修正。圧縮実行時に in-memory messages[0] に入る \`[構造化要約]\` マーカーが、\`toPersistedHistory\` → \`session.history\` へ素通りし、次ターン以降に \`[過去の会話の要約]\` と重複して API へ送られていた。#66 以前は opt-in だったため症状レア、#66 後はクラウド既定で毎圧縮で発火するため併せて修正。

## Changes

- \`src/orchestration/agent-loop.ts\`: \`toPersistedHistory\` に \`[構造化要約]\` 先頭 strip を追加。\`stripLeadingStructuredSummary\` を新設し、\`toPersistedHistory\` は export に変更してテスト可能に。
- \`src/features/settings/SettingsPanel.tsx\`: 「デフォルトはOFFです」文言を修正（#66 で default true に変更済みのため stale）。
- テスト追加：
  - \`toPersistedHistory\` 3 件（[構造化要約] 除去、両プレフィックス混在、要約なし）
  - \`splitByKeepRecentTokens\` 4 件（空、全て keep 範囲内、tool 境界 back-up、並列 tool-call、画像 6000 chars 相当）

## Test plan

- [x] \`npx vitest run\` → 995 passed（#66 の 987 + 新規 8）
- [x] oracle 指摘の回帰テストでバグ再現 → 修正で解消を確認
- [ ] 実機 DevTools で長セッション後、\`session.history[0]\` が \`[構造化要約]\` を含まないこと

## Related

- #66 feat(context): default autoCompact=true, keep-recent by tokens
- 後続：Phase 2 (get_tool_result / ToolResultStore 削除)

🤖 Generated with [Claude Code](https://claude.com/claude-code)