### PR TITLE
fix: respect enableBgFetch setting in REPL bgFetch helper

### DIFF
--- a/src/features/tools/providers/__tests__/fetch-provider.test.ts
+++ b/src/features/tools/providers/__tests__/fetch-provider.test.ts
@@ -2,12 +2,19 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { FetchProvider } from "../fetch-provider";
 import type { ProviderContext } from "@/ports/runtime-provider";
 import type { BgFetchMessage, BgFetchResponse } from "@/shared/message-types";
+import { useStore } from "@/store/index";
 
 function makeContext(): ProviderContext {
   return {
     browser: {} as ProviderContext["browser"],
     artifactStorage: {} as ProviderContext["artifactStorage"],
   };
+}
+
+function setEnableBgFetch(enabled: boolean): void {
+  useStore.setState((state) => ({
+    settings: { ...state.settings, enableBgFetch: enabled },
+  }));
 }
 
 function stubSendMessage(response: BgFetchResponse) {
@@ -20,6 +27,7 @@ function stubSendMessage(response: BgFetchResponse) {
 describe("FetchProvider", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    setEnableBgFetch(true);
   });
 
   it("actions に bgFetch を公開する", () => {
@@ -178,5 +186,31 @@ describe("FetchProvider", () => {
     expect(result.ok).toBe(false);
     if (result.ok) return;
     expect(result.error.message).toContain("port closed");
+  });
+
+  it("enableBgFetch=false の時は background に届く前に disabled エラーを返す", async () => {
+    setEnableBgFetch(false);
+    const send = stubSendMessage({
+      success: true,
+      data: {
+        url: "https://example.com",
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        headers: {},
+        body: "should not reach here",
+      },
+    });
+
+    const provider = new FetchProvider();
+    const result = await provider.handleRequest(
+      { id: "req-off", action: "bgFetch", url: "https://example.com" },
+      makeContext(),
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.message).toContain("disabled");
+    expect(send).not.toHaveBeenCalled();
   });
 });

--- a/src/features/tools/providers/fetch-provider.ts
+++ b/src/features/tools/providers/fetch-provider.ts
@@ -2,6 +2,7 @@ import type { RuntimeProvider, SandboxRequest, ProviderContext } from "@/ports/r
 import type { Result, ToolError } from "@/shared/errors";
 import { ok, err } from "@/shared/errors";
 import type { BgFetchMessage, BgFetchResponse } from "@/shared/message-types";
+import { useStore } from "@/store/index";
 
 const DEFAULT_TIMEOUT_MS = 30_000;
 const MAX_TIMEOUT_MS = 60_000;
@@ -124,6 +125,15 @@ async function bgFetch(url, options) {
 
     if (typeof url !== "string" || url.length === 0) {
       return err({ code: "tool_script_error", message: "bgFetch: url is required" });
+    }
+
+    // 設定側の enableBgFetch ゲートを尊重する。top-level bg_fetch と同じ
+    // 判定を通して、REPL 経由の bgFetch が設定の抜け道にならないようにする。
+    if (!useStore.getState().settings.enableBgFetch) {
+      return err({
+        code: "tool_script_error",
+        message: "bgFetch is disabled in settings (enableBgFetch is off)",
+      });
     }
 
     const message: BgFetchMessage = {

--- a/src/shared/repl-description-sections.ts
+++ b/src/shared/repl-description-sections.ts
@@ -361,6 +361,8 @@ export const AVAILABLE_FUNCTIONS = [
   "- 1〜2 URLs whose contents you want to read inline — use top-level `bg_fetch`",
   "- SPA/CSR sites whose content is JS-rendered — use `navigate()` + `browserjs()`",
   "",
+  "Shares the `enableBgFetch` settings toggle with the top-level `bg_fetch` tool; if that tool is disabled by the user, `bgFetch` is also blocked (error: `bgFetch is disabled in settings`).",
+  "",
   "### Signature",
   "```ts",
   "bgFetch(url: string, options?: {",


### PR DESCRIPTION
## Summary

設定 \`enableBgFetch = false\` が REPL 内 \`bgFetch()\` にはゲートされておらず、抜け道になっていた問題を修正。

### 修正前の挙動

| 呼出経路 | 設定 OFF 時 |
|---|---|
| top-level \`bg_fetch\` tool call | ✅ ブロック（"bg_fetch is disabled in settings"） |
| top-level tool 定義 | ✅ AI に tool def を見せない |
| **REPL 内 \`bgFetch()\`** | ❌ **素通り**（FetchProvider.handleRequest が何もチェックしない） |

ユーザが UI でオフにしても AI は \`repl({ code: "await bgFetch(url)" })\` で任意 URL にアクセス可能だった。

### 修正内容

- \`FetchProvider.handleRequest\` で \`useStore.getState().settings.enableBgFetch\` をチェックし、false なら top-level と同じ形式の ToolError を返す（\`chrome.runtime.sendMessage\` を発行する前に止める）
- 回帰テスト追加：\`enableBgFetch=false\` 時にエラーが返り、sendMessage が呼ばれないこと
- \`bgFetch\` の AVAILABLE_FUNCTIONS 節に「top-level \`bg_fetch\` とトグル共有」を明記（AI が無効時の挙動を理解できるように）

## Test plan

- [x] \`npx vitest run\` → 979 passed (+1 regression)
- [x] \`npx tsc --noEmit\` → クリーン
- [ ] 実機で \`enableBgFetch\` を OFF にした状態で REPL 内 \`bgFetch()\` が「disabled in settings」エラーになることを確認

## Related

- #70 bgFetch 導入 PR
- #71 sandboxFetch → bgFetch リネーム PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)