### PR TITLE
fix: hide bgFetch from REPL prompt when enableBgFetch is disabled

### DIFF
--- a/src/features/tools/index.ts
+++ b/src/features/tools/index.ts
@@ -6,7 +6,7 @@ import { SkillRegistry } from "@/shared/skill-registry";
 import { useStore } from "@/store/index";
 
 import { readPageToolDef, executeReadPage } from "./read-page";
-import { replToolDef, executeRepl, formatSkillsForSandbox } from "./repl";
+import { replToolDef, buildReplToolDef, executeRepl, formatSkillsForSandbox } from "./repl";
 import { navigateToolDef, executeNavigate } from "./navigate";
 import { pickElementToolDef, executePickElement } from "./pick-element";
 import { screenshotToolDef, executeScreenshot } from "./screenshot";
@@ -42,7 +42,7 @@ import { artifactsTool } from "./definitions/artifacts-tool";
 import { handleArtifactsTool } from "./handlers/artifacts-handler";
 
 export { readPageToolDef, executeReadPage };
-export { replToolDef, executeRepl, formatSkillsForSandbox };
+export { replToolDef, buildReplToolDef, executeRepl, formatSkillsForSandbox };
 export { navigateToolDef, executeNavigate };
 export { pickElementToolDef, executePickElement };
 export { screenshotToolDef, executeScreenshot };
@@ -112,8 +112,10 @@ export const AGENT_TOOL_DEFS: ToolDefinition[] = ALL_TOOL_DEFS.filter(
 );
 
 export function getAgentToolDefs(options?: { enableBgFetch?: boolean }): ToolDefinition[] {
-  let defs = AGENT_TOOL_DEFS;
-  if (!options?.enableBgFetch) {
+  const enableBgFetch = options?.enableBgFetch ?? false;
+  const replWithBgFetch = buildReplToolDef({ enableBgFetch });
+  let defs = AGENT_TOOL_DEFS.map((tool) => (tool.name === "repl" ? replWithBgFetch : tool));
+  if (!enableBgFetch) {
     defs = defs.filter((tool) => tool.name !== "bg_fetch");
   }
   return defs;

--- a/src/features/tools/repl.ts
+++ b/src/features/tools/repl.ts
@@ -71,29 +71,59 @@ export function formatSkillsForSandbox(matches: readonly SkillMatch[]): SandboxS
   return result;
 }
 
-export const replToolDef: ToolDefinition = {
-  name: "repl",
-  description: assembleReplDescriptionSections([
-    "TOOL_PHILOSOPHY",
-    "AVAILABLE_FUNCTIONS",
-    "COMMON_PATTERNS",
-  ]),
-  parameters: {
-    type: "object",
-    properties: {
-      title: {
-        type: "string",
-        description: "コードが行うことの簡潔な説明（例: 'ページタイトルを取得'）",
-      },
-      code: {
-        type: "string",
-        description:
-          "実行するJavaScriptコード。browserjs(), navigate(), bgFetch(), skills, Artifact Functions, File Functions, Native Input Functions (nativeClick, nativeDoubleClick, nativeRightClick, nativeHover, nativeFocus, nativeBlur, nativeScroll, nativeSelectText, nativeType, nativePress, nativeKeyDown, nativeKeyUp) が使える。",
+const REPL_PARAMETERS_BASE = {
+  type: "object" as const,
+  properties: {
+    title: {
+      type: "string" as const,
+      description: "コードが行うことの簡潔な説明（例: 'ページタイトルを取得'）",
+    },
+    code: {
+      type: "string" as const,
+      description: "",
+    },
+  },
+  required: ["code"] as const,
+};
+
+function codeDescription(enableBgFetch: boolean): string {
+  const fns = [
+    "browserjs()",
+    "navigate()",
+    ...(enableBgFetch ? ["bgFetch()"] : []),
+    "skills",
+    "Artifact Functions",
+    "File Functions",
+    "Native Input Functions (nativeClick, nativeDoubleClick, nativeRightClick, nativeHover, nativeFocus, nativeBlur, nativeScroll, nativeSelectText, nativeType, nativePress, nativeKeyDown, nativeKeyUp)",
+  ];
+  return `実行するJavaScriptコード。${fns.join(", ")} が使える。`;
+}
+
+export function buildReplToolDef(options: { enableBgFetch?: boolean } = {}): ToolDefinition {
+  const enableBgFetch = options.enableBgFetch ?? true;
+  return {
+    name: "repl",
+    description: assembleReplDescriptionSections(
+      ["TOOL_PHILOSOPHY", "AVAILABLE_FUNCTIONS", "COMMON_PATTERNS"],
+      { enableBgFetch },
+    ),
+    parameters: {
+      ...REPL_PARAMETERS_BASE,
+      properties: {
+        ...REPL_PARAMETERS_BASE.properties,
+        code: {
+          ...REPL_PARAMETERS_BASE.properties.code,
+          description: codeDescription(enableBgFetch),
+        },
       },
     },
-    required: ["code"],
-  },
-};
+  };
+}
+
+// 静的なデフォルト（bgFetch あり）。テストや ALL_TOOL_DEFS に載せる用。
+// 実行時は use-agent.ts 経由で buildReplToolDef({ enableBgFetch }) を使うので、
+// 設定が OFF の時は AI には bgFetch が見えない description が渡る。
+export const replToolDef: ToolDefinition = buildReplToolDef({ enableBgFetch: true });
 
 export interface UsedSkillInfo {
   skillId: string;

--- a/src/shared/__tests__/repl-description-sections.test.ts
+++ b/src/shared/__tests__/repl-description-sections.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { assembleReplDescriptionSections } from "../repl-description-sections";
+
+describe("assembleReplDescriptionSections", () => {
+  it("デフォルト (enableBgFetch 省略) では bgFetch セクションを含む", () => {
+    const out = assembleReplDescriptionSections(["AVAILABLE_FUNCTIONS"]);
+    expect(out).toContain("bgFetch(url, options?)");
+    expect(out).toContain("Multi-URL fetch");
+    // sentinel 行は出力に残してはいけない
+    expect(out).not.toContain("BG_FETCH_SECTION_START");
+    expect(out).not.toContain("BG_FETCH_SECTION_END");
+  });
+
+  it("enableBgFetch=true でも同様に bgFetch セクションを含む", () => {
+    const out = assembleReplDescriptionSections(["AVAILABLE_FUNCTIONS"], {
+      enableBgFetch: true,
+    });
+    expect(out).toContain("bgFetch(url, options?)");
+    expect(out).not.toContain("BG_FETCH_SECTION_START");
+  });
+
+  it("enableBgFetch=false の時は bgFetch 関連を全削除する", () => {
+    const out = assembleReplDescriptionSections(
+      ["AVAILABLE_FUNCTIONS", "COMMON_PATTERNS"],
+      { enableBgFetch: false },
+    );
+    expect(out).not.toContain("bgFetch");
+    expect(out).not.toContain("Multi-URL fetch");
+    expect(out).not.toContain("Multi-URL Fetch");
+    // 無関係なセクションは残っている
+    expect(out).toContain("REPL Persistence Model");
+    expect(out).toContain("navigate(url)");
+    expect(out).toContain("Multi-page Scraping");
+  });
+
+  it("sentinel マーカは enableBgFetch の値に関係なく絶対に残さない", () => {
+    for (const flag of [undefined, true, false]) {
+      const options = flag === undefined ? undefined : { enableBgFetch: flag };
+      const out = assembleReplDescriptionSections(
+        ["AVAILABLE_FUNCTIONS", "COMMON_PATTERNS"],
+        options,
+      );
+      expect(out).not.toMatch(/BG_FETCH_SECTION_(START|END)/);
+    }
+  });
+});

--- a/src/shared/repl-description-sections.ts
+++ b/src/shared/repl-description-sections.ts
@@ -92,6 +92,7 @@ export const COMMON_PATTERNS = [
   "await createOrUpdateArtifact('items.json', allItems);",
   "```",
   "",
+  "<!-- BG_FETCH_SECTION_START -->",
   "## Multi-URL Fetch (static / server-rendered pages, JSON APIs)",
   "",
   "**Prefer this over top-level `bg_fetch` when you have 5+ URLs.** Results never hit the AI context — they go straight to an artifact, saving tokens and turns.",
@@ -111,6 +112,7 @@ export const COMMON_PATTERNS = [
   "await createOrUpdateArtifact('docs.json', contents);",
   "return `Collected ${Object.keys(contents).length} pages`;",
   "```",
+  "<!-- BG_FETCH_SECTION_END -->",
   "",
   "**Data storage rule:** `createOrUpdateArtifact` for structured JSON data (name with `.json` extension). `returnFile` for user-facing files (HTML, CSV, Markdown, images).",
   "",
@@ -340,7 +342,9 @@ export const AVAILABLE_FUNCTIONS = [
   "### Do NOT Use For",
   "- Single page interactions (use native functions)",
   "- Inside browserjs() (closures don't work)",
+  "<!-- BG_FETCH_SECTION_START -->",
   "- Multi-URL fetching of static / server-rendered pages — use `bgFetch` instead",
+  "<!-- BG_FETCH_SECTION_END -->",
   "",
   "```javascript",
   "// ✅ Navigate and extract",
@@ -348,6 +352,7 @@ export const AVAILABLE_FUNCTIONS = [
   "const title = await browserjs(() => document.title);",
   "```",
   "",
+  "<!-- BG_FETCH_SECTION_START -->",
   "## bgFetch(url, options?) — Multi-URL fetch that bypasses the AI context",
   "",
   "Fetch an external URL via the background service worker. CORS-free, does not touch the active tab, and — unlike top-level `bg_fetch` — results never hit the AI conversation history, so you can save them straight into an artifact.",
@@ -392,6 +397,7 @@ export const AVAILABLE_FUNCTIONS = [
   "await createOrUpdateArtifact('docs.json', contents);",
   "return `Collected ${Object.keys(contents).length} pages`;",
   "```",
+  "<!-- BG_FETCH_SECTION_END -->",
   "",
   "## Artifact Functions (Data Persistence)",
   "",
@@ -481,6 +487,22 @@ const SECTIONS: Record<ReplDescriptionSectionKey, string> = {
   AVAILABLE_FUNCTIONS,
 };
 
-export function assembleReplDescriptionSections(keys: ReplDescriptionSectionKey[]): string {
-  return keys.map((key) => SECTIONS[key]).join("\n\n");
+// bgFetch 関連の部分は <!-- BG_FETCH_SECTION_START --> / <!-- BG_FETCH_SECTION_END -->
+// で囲んである。enableBgFetch=false の時はマーカごと中身を削除し、AI から
+// bgFetch の存在を隠す。true の時はマーカ行だけ取り除いて中身を残す。
+const BG_FETCH_SECTION_RE = /^<!-- BG_FETCH_SECTION_START -->\n([\s\S]*?)^<!-- BG_FETCH_SECTION_END -->\n?/gm;
+
+function stripBgFetchSections(text: string, enableBgFetch: boolean): string {
+  if (enableBgFetch) {
+    return text.replace(BG_FETCH_SECTION_RE, (_match, body: string) => body);
+  }
+  return text.replace(BG_FETCH_SECTION_RE, "");
+}
+
+export function assembleReplDescriptionSections(
+  keys: ReplDescriptionSectionKey[],
+  options: { enableBgFetch?: boolean } = {},
+): string {
+  const joined = keys.map((key) => SECTIONS[key]).join("\n\n");
+  return stripBgFetchSections(joined, options.enableBgFetch ?? true);
 }


### PR DESCRIPTION
## Summary

#72 で実行時ゲートを入れても AI が毎ターン \`bgFetch\` を試行 → エラー → ターン浪費 のループが止まらない実機問題への追加対応。

根本原因：REPL tool description (\`AVAILABLE_FUNCTIONS\` / \`COMMON_PATTERNS\`) は設定に関係なく常に \`bgFetch\` を「多URL取得の推奨手段」として提示していた。AI はそれを見て試す → ゲートで弾かれる、の繰り返し。

本 PR では **設定 OFF 時に AI からそもそも \`bgFetch\` の存在を隠す**。

## Implementation

- \`repl-description-sections.ts\` の bgFetch 関連箇所を \`<!-- BG_FETCH_SECTION_START -->\` / \`<!-- BG_FETCH_SECTION_END -->\` の sentinel コメントで囲む（対象: \`bgFetch\` 関数本体節、\`Multi-URL Fetch\` の COMMON_PATTERNS、\`navigate\` の Do NOT Use For の 1 行）
- \`assembleReplDescriptionSections\` に \`{ enableBgFetch }\` オプションを追加：
  - \`true\`：sentinel 行だけ取り除き中身を残す
  - \`false\`：sentinel もろとも中身を削除
  - どちらでも sentinel 文字列が最終 prompt に漏れないことを保証
- 新規 \`buildReplToolDef({ enableBgFetch })\` を \`repl.ts\` に追加。\`code\` パラメータの description も動的に（\`bgFetch()\` の記載を条件付きに）
- \`getAgentToolDefs\` は turn ごとに \`buildReplToolDef\` を呼んで repl tool def を差し替える
- 静的な \`replToolDef\` export は後方互換用に残し、デフォルト \`enableBgFetch: true\`（既存テスト保護）
- 新テスト 4 件で検証

## Test plan

- [x] \`npx vitest run\` → 983 passed (+4)
- [x] \`npx tsc --noEmit\` → クリーン
- [ ] 実機で設定 OFF → AI が bgFetch を呼ばなくなることを確認
- [ ] 実機で設定 ON → 従来通り bgFetch が使えることを確認

## Related

- #72 実行時ゲート
- #71 \`sandboxFetch\` → \`bgFetch\` リネーム
- #70 初期実装

🤖 Generated with [Claude Code](https://claude.com/claude-code)