### PR TITLE
fix(prompt): close bgFetch leak in system prompt when disabled

### DIFF
--- a/src/features/ai/__tests__/system-prompt-v2.test.ts
+++ b/src/features/ai/__tests__/system-prompt-v2.test.ts
@@ -106,6 +106,32 @@ describe("getSystemPromptV2", () => {
     expect(prompt).toContain("CRITICAL");
   });
 
+
+  it("enableBgFetch=false の時は system prompt から bgFetch の記述を全削除する", () => {
+    const prompt = getSystemPromptV2({ enableBgFetch: false });
+    // AVAILABLE_FUNCTIONS / COMMON_PATTERNS 経由で system prompt に漏れていた
+    // bgFetch 関連記述が残っていないこと
+    expect(prompt).not.toContain("bgFetch(url, options?)");
+    expect(prompt).not.toContain("Multi-URL fetch that bypasses");
+    expect(prompt).not.toContain("Multi-URL Fetch (static");
+    // sentinel も絶対に残さない
+    expect(prompt).not.toContain("BG_FETCH_SECTION_START");
+    expect(prompt).not.toContain("BG_FETCH_SECTION_END");
+  });
+
+  it("enableBgFetch=true の時は system prompt に bgFetch 記述が含まれる", () => {
+    const prompt = getSystemPromptV2({ enableBgFetch: true });
+    expect(prompt).toContain("bgFetch(url, options?)");
+    // sentinel は常に剥がす
+    expect(prompt).not.toContain("BG_FETCH_SECTION_START");
+  });
+
+  it("enableBgFetch オプション省略時 (未設定) は true 相当として扱う", () => {
+    const prompt = getSystemPromptV2({});
+    // legacy 呼び出しで bgFetch が見えることに依存しているテストを壊さない
+    expect(prompt).toContain("bgFetch(url, options?)");
+    expect(prompt).not.toContain("BG_FETCH_SECTION_START");
+  });
 });
 
 describe("generateVisitedUrlsSection", () => {

--- a/src/features/ai/prompt-cache.ts
+++ b/src/features/ai/prompt-cache.ts
@@ -16,6 +16,7 @@ export function createPromptCacheKey(options: SystemPromptOptions): string {
   const parts: string[] = [
     `skills:${options.includeSkills ?? false}`,
     `locale:${options.locale ?? "default"}`,
+    `bgFetch:${options.enableBgFetch ?? true}`,
   ];
 
   if (options.includeSkills && options.skills) {

--- a/src/features/ai/sections/core-identity.ts
+++ b/src/features/ai/sections/core-identity.ts
@@ -9,5 +9,5 @@ export const CORE_IDENTITY = [
   'Tone: Professional, concise, pragmatic. Use "I" when referring to yourself.',
   "Explain things in plain language unless the user shows technical expertise.",
   "",
-  "Tool results from recent turns (read_page, repl return values, bg_fetch, ...) remain fully visible in your conversation history; older turns may be replaced with a structured summary. Do NOT re-execute tools merely to re-verify data you can still see at full length — trust your history for unsummarized turns.",
+  "Tool results from recent turns (read_page, navigate, repl return values, ...) remain fully visible in your conversation history; older turns may be replaced with a structured summary. Do NOT re-execute tools merely to re-verify data you can still see at full length — trust your history for unsummarized turns.",
 ].join("\n");

--- a/src/features/ai/system-prompt-v2.ts
+++ b/src/features/ai/system-prompt-v2.ts
@@ -1,6 +1,7 @@
 import type { SkillMatch } from "@/shared/skill-types";
 import { assembleSections, type SectionKey } from "./sections";
 import { PromptCache, createPromptCacheKey } from "./prompt-cache";
+import { stripBgFetchSections } from "@/shared/repl-description-sections";
 
 export interface VisitedUrlEntry {
   url: string;
@@ -15,6 +16,7 @@ export interface SystemPromptOptions {
   skills?: SkillMatch[];
   locale?: string;
   visitedUrls?: VisitedUrlEntry[];
+  enableBgFetch?: boolean;
 }
 
 const cache = new PromptCache();
@@ -110,7 +112,11 @@ export function getSystemPromptV2(options: SystemPromptOptions): string {
   if (cached !== null) {
     base = cached;
   } else {
-    const baseSections = assembleSections(BASE_SECTIONS);
+    // BASE_SECTIONS の中には <!-- BG_FETCH_SECTION_* --> マーカで囲まれた
+    // bgFetch 関連の記述があるので、設定に応じて剥がす。true でもマーカは
+    // 必ず取り除くので、sentinel が AI に漏れることはない。
+    const rawBaseSections = assembleSections(BASE_SECTIONS);
+    const baseSections = stripBgFetchSections(rawBaseSections, options.enableBgFetch ?? true);
     const skillsSection =
       options.includeSkills && options.skills ? generateSkillsSection(options.skills) : "";
     base = skillsSection ? `${baseSections}\n\n${skillsSection}` : baseSections;

--- a/src/shared/repl-description-sections.ts
+++ b/src/shared/repl-description-sections.ts
@@ -490,9 +490,12 @@ const SECTIONS: Record<ReplDescriptionSectionKey, string> = {
 // bgFetch 関連の部分は <!-- BG_FETCH_SECTION_START --> / <!-- BG_FETCH_SECTION_END -->
 // で囲んである。enableBgFetch=false の時はマーカごと中身を削除し、AI から
 // bgFetch の存在を隠す。true の時はマーカ行だけ取り除いて中身を残す。
+//
+// 同じマーカは system-prompt-v2 経由の prompt でも使われるため、本ヘルパは
+// 両パスから再利用する。どちらの値でも sentinel 文字列自体は必ず取り除く。
 const BG_FETCH_SECTION_RE = /^<!-- BG_FETCH_SECTION_START -->\n([\s\S]*?)^<!-- BG_FETCH_SECTION_END -->\n?/gm;
 
-function stripBgFetchSections(text: string, enableBgFetch: boolean): string {
+export function stripBgFetchSections(text: string, enableBgFetch: boolean): string {
   if (enableBgFetch) {
     return text.replace(BG_FETCH_SECTION_RE, (_match, body: string) => body);
   }

--- a/src/sidepanel/hooks/use-agent.ts
+++ b/src/sidepanel/hooks/use-agent.ts
@@ -153,6 +153,7 @@ export function useAgent() {
       const systemPrompt = getSystemPromptV2({
         includeSkills: matchedSkills.length > 0,
         skills: matchedSkills,
+        enableBgFetch: settings.enableBgFetch,
       });
 
       runAgentLoop({


### PR DESCRIPTION
## 原因

PR #73 で REPL tool description から bgFetch セクションを条件付き除去するようにしましたが、**system prompt 側に並行経路**があり、そちらは未修正でした。

\`src/features/ai/sections/available-functions.ts\` が \`AVAILABLE_FUNCTIONS\` を生 re-export しており、それが \`system-prompt-v2.ts\` の \`BASE_SECTIONS\` 経由で system prompt に注入されていた。\`assembleSections\` は生文字列を join するだけで sentinel を剥がさないため、\`enableBgFetch=false\` でも system prompt に bgFetch 記述 12 箇所が残っていた。

dump 検証：

\`\`\`
[enableBgFetch=false] system prompt: 12 matches  ← 設定 OFF なのに残存
[enableBgFetch=true]  system prompt: 12 matches
\`\`\`

これが「拡張再インストール後も AI が bgFetch を使う」の直接原因。新規セッションでも system prompt に描かれている bgFetch 記述を見て「これが使えるツールだ」と判断していた。

## 修正後

\`\`\`
[enableBgFetch=false] system prompt: 0 matches  ← 完全消去
[enableBgFetch=true]  system prompt: 11 matches (core-identity 例文から bg_fetch を除いた分 -1)
\`\`\`

## 実装

- \`repl-description-sections.ts\`: \`stripBgFetchSections\` を export（両 prompt パスで再利用可能に）
- \`system-prompt-v2.ts\`: \`SystemPromptOptions.enableBgFetch\` を追加し、assemble 後に \`stripBgFetchSections\` を通す
- \`prompt-cache.ts\`: cache key に \`bgFetch:<bool>\` を追加（cache 混線防止）
- \`use-agent.ts\`: \`settings.enableBgFetch\` を \`getSystemPromptV2\` に渡す
- \`core-identity.ts\`: trust-your-history 例文の \`bg_fetch\` を削除（例示として誤解を招くため）

## Test plan

- [x] \`npx vitest run\` → 986 passed (+3)
- [x] \`npx tsc --noEmit\` → クリーン
- [x] dump で system prompt の bgFetch mentions 12 → 0 を確認
- [ ] 実機: \`enableBgFetch=false\` で拡張リロード → 新規セッション → AI が bgFetch を呼ばないこと

## Related

- #73 REPL tool description 側の対応（同じ sentinel を使用）
- #72 実行時ゲート
- #70 / #71 初期導入 + rename

🤖 Generated with [Claude Code](https://claude.com/claude-code)