### PR TITLE
refactor: drop URL-revisit warning and surfacing system message

### DIFF
--- a/src/orchestration/__tests__/agent-loop.test.ts
+++ b/src/orchestration/__tests__/agent-loop.test.ts
@@ -1083,22 +1083,6 @@ describe("trackVisitedUrl", () => {
     expect(map.get("https://example.com")?.visitCount).toBe(2);
   });
 
-  it("returns null for first visits below threshold", () => {
-    const map = makeMap();
-    const result = trackVisitedUrl(map, "https://example.com", "Example", "navigate");
-    expect(result).toBeNull();
-  });
-
-  it("returns warning string at revisit threshold", () => {
-    const map = makeMap();
-    for (let i = 0; i < 5; i++) {
-      trackVisitedUrl(map, "https://example.com", "Example", "navigate");
-    }
-    const warning = trackVisitedUrl(map, "https://example.com", "Example", "navigate");
-    expect(warning).toContain("WARNING");
-    expect(warning).toContain("6 time(s)");
-  });
-
   it("logs visitedUrl revisit count when revisiting a URL", () => {
     trackVisitedUrl(makeMap(), "https://warmup.example", "Warmup", "navigate");
     consoleInfoSpy.mockClear();

--- a/src/orchestration/agent-loop.ts
+++ b/src/orchestration/agent-loop.ts
@@ -100,7 +100,6 @@ export interface AgentLoopParams {
 export type { ToolExecutor } from "@/ports/tool-executor";
 
 const MAX_TURNS = 25;
-const URL_REVISIT_THRESHOLD = 6;
 const MAX_VISITED_URLS = 20;
 
 /** 末尾スラッシュを除去してURLを正規化する */
@@ -117,13 +116,20 @@ function extractHostname(url: string): string {
   }
 }
 
-/** 訪問済みURLの再訪問警告メッセージを生成する（再訪問でなければ null） */
+/**
+ * 訪問済み URL をトラッキングする。system prompt の "Current Session: Visited URLs"
+ * セクションに反映されるほか、重複ログの抑制にも使う。
+ *
+ * 以前は `visitCount >= URL_REVISIT_THRESHOLD` で警告を返却していたが、
+ * 同一 URL を正当に何度も参照するワークフロー（ドキュメント参照、状態確認等）
+ * があるため撤廃。必要なら AI は履歴から前回の取得結果を直接参照できる。
+ */
 export function trackVisitedUrl(
   visitedUrls: Map<string, VisitedUrlEntry>,
   url: string,
   title: string,
   method: VisitedUrlEntry["lastMethod"],
-): string | null {
+): void {
   const normalized = normalizeUrl(url);
   const existing = visitedUrls.get(normalized);
   const entry: VisitedUrlEntry = {
@@ -144,11 +150,6 @@ export function trackVisitedUrl(
       visitCount: entry.visitCount,
     });
   }
-
-  if (entry.visitCount >= URL_REVISIT_THRESHOLD) {
-    return `\n\n⚠️ WARNING: This URL has already been visited ${entry.visitCount} time(s) in this session. Do NOT navigate to it again. Use the information you already collected from previous visits. If you have enough information, proceed to analysis/response instead of collecting more pages.`;
-  }
-  return null;
 }
 
 /** MAX_VISITED_URLS を超えたとき、訪問回数が少なく古いエントリを削除する */
@@ -464,17 +465,11 @@ export async function runAgentLoop(params: AgentLoopParams): Promise<void> {
 
         // --- ツール別ポスト処理: 訪問追跡・SPA検出・スキル再構築 ---
 
-        let loopWarningEmitted = false;
-
         if (name === "navigate" && toolResult.ok) {
           const navResult = toolResult.value as { finalUrl?: string; title?: string };
           if (navResult.finalUrl) {
             const title = navResult.title || extractHostname(navResult.finalUrl);
-            const warning = trackVisitedUrl(visitedUrls, navResult.finalUrl, title, "navigate");
-            if (warning) {
-              fullResult += warning;
-              loopWarningEmitted = true;
-            }
+            trackVisitedUrl(visitedUrls, navResult.finalUrl, title, "navigate");
           }
         }
 
@@ -498,11 +493,7 @@ export async function runAgentLoop(params: AgentLoopParams): Promise<void> {
             // navigate ツール直接呼び出しは上で追跡済みなのでここでは repl のみ。
             if (name === "repl" && newUrl) {
               const title = tab.title || extractHostname(newUrl);
-              const warning = trackVisitedUrl(visitedUrls, newUrl, title, "navigate");
-              if (warning) {
-                fullResult += warning;
-                loopWarningEmitted = true;
-              }
+              trackVisitedUrl(visitedUrls, newUrl, title, "navigate");
             }
             if (newUrl && newUrl !== currentUrl) {
               currentUrl = newUrl;
@@ -517,13 +508,6 @@ export async function runAgentLoop(params: AgentLoopParams): Promise<void> {
           } catch {
             // Ignore error
           }
-        }
-
-        // ループ警告が出た場合、ユーザーにもシステムメッセージで通知
-        if (loopWarningEmitted) {
-          chatStore.addSystemMessage(
-            "⚠️ 同じページへの繰り返しアクセスを検出しました。AIに収集を終えて分析に移るよう指示しています。",
-          );
         }
 
         chatStore.updateToolCallResult(id, toolResult);


### PR DESCRIPTION
## Summary

\`URL_REVISIT_THRESHOLD = 6\` の AI 向け警告と、ユーザ側の「⚠️ 同じページへの繰り返しアクセス検出」system message を全撤廃。

## 背景

この警告は Wave 1 時代（AI がツール結果を数ターンで忘れる問題がピークだった頃）の band-aid。Phase 1/2 で根本原因側（auto-compact・完全版履歴保持）を直したため、警告の存在意義は下がった。

一方で、同一 URL を正当に複数回参照するワークフロー（ドキュメント参照、状態確認、ダッシュボード操作等）では毎回警告が発火してノイズになり、AI の動きも妨げる。

## Changes

- \`trackVisitedUrl\` の戻り値を \`string | null\` → \`void\` に。訪問カウントと prune は残すので system prompt の "Current Session: Visited URLs" セクションは不変。
- \`URL_REVISIT_THRESHOLD\` 定数削除
- \`loopWarningEmitted\` フラグと \`chatStore.addSystemMessage\` ディスパッチを削除
- 警告閾値系テスト 2 件を削除（訪問カウント / 正規化 / ログ系テストは残す）

## 暴走対策は MAX_TURNS が残る

\`MAX_TURNS = 25\` は引き続き AI の無限ループを最終キャップ。per-URL ヒューリスティックより構造的な上限で守る方向に寄せた。

## Test plan

- [x] \`npx vitest run\` → 984 passed (-2 警告閾値テスト削除)
- [x] \`npx tsc --noEmit\` → クリーン
- [ ] 実機で同一 URL を繰り返し navigate しても警告メッセージが出ないこと
- [ ] "Current Session: Visited URLs" セクションが引き続き機能すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)