### PR TITLE
fix(chat): auto-collapse tool message when it completes

### DIFF
--- a/src/features/chat/tool-renderers/components.tsx
+++ b/src/features/chat/tool-renderers/components.tsx
@@ -79,9 +79,18 @@ export function ToolMessageContainer({
     toolCall.isRunning || (defaultExpanded === true && !isComplete),
   );
 
+  // 実行中は自動展開 → 完了した瞬間に自動で畳む。ユーザが完了後に手動で
+  // 展開した状態は、次の running → complete 遷移まで維持する。
+  const wasRunningRef = useRef(toolCall.isRunning);
   useEffect(() => {
     if (toolCall.isRunning) {
       setExpanded(true);
+      wasRunningRef.current = true;
+      return;
+    }
+    if (wasRunningRef.current) {
+      setExpanded(false);
+      wasRunningRef.current = false;
     }
   }, [toolCall.isRunning]);
 


### PR DESCRIPTION
## Problem

チャット中で tool call (repl / read_page / navigate 等) が完了後も展開したまま残り続けてチャットが非常に見づらい。

\`ToolMessageContainer\` (src/features/chat/tool-renderers/components.tsx) の useEffect は「実行中 → 展開 (\`setExpanded(true)\`)」の片道だけ扱っていて、完了時に折りたたむ transition がなかった。一度展開された card は最後までそのまま。

## Fix

running → complete の transition を ref で捕捉して自動折りたたみ：

\`\`\`tsx
const wasRunningRef = useRef(toolCall.isRunning);
useEffect(() => {
  if (toolCall.isRunning) {
    setExpanded(true);
    wasRunningRef.current = true;
    return;
  }
  if (wasRunningRef.current) {
    setExpanded(false);
    wasRunningRef.current = false;
  }
}, [toolCall.isRunning]);
\`\`\`

- 完了後にユーザが手動展開した状態は、次の実行サイクルまで維持
- 初期 mount で既に完了済みの case (再ロード等) は元通り collapsed

## Behavior

| Before | After |
|---|---|
| running 中: 展開 ✓ | 変わらず |
| 完了時: **展開のまま** ✗ | 自動折りたたみ ✓ |
| 完了後手動展開: ユーザ操作後も保持 | 変わらず |

## Test plan

- [x] \`npx vitest run\` → 984 passed
- [x] \`npx tsc --noEmit\` → クリーン
- [ ] 実機で repl / read_page / navigate 実行 → 完了で自動的に折りたたまれる
- [ ] 折りたたまれた card を手動クリック → 展開する
- [ ] 再度クリック → 折りたたまれる

🤖 Generated with [Claude Code](https://claude.com/claude-code)