### PR TITLE
fix(browserjs): unwrap ScriptResult so AI receives raw user return

### DIFF
--- a/src/features/tools/providers/__tests__/browser-js-provider.test.ts
+++ b/src/features/tools/providers/__tests__/browser-js-provider.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from "vitest";
+import { BrowserJsProvider } from "../browser-js-provider";
+import type { BrowserExecutor, ScriptResult, TabInfo } from "@/ports/browser-executor";
+import type { ProviderContext } from "@/ports/runtime-provider";
+import type { Result, ToolError } from "@/shared/errors";
+import { ok, err } from "@/shared/errors";
+
+type ExecuteScriptResult = Result<ScriptResult, ToolError>;
+
+function makeBrowser(
+  executeScriptImpl: () => Promise<ExecuteScriptResult>,
+  tab: Partial<TabInfo> = {},
+): BrowserExecutor {
+  return {
+    getActiveTab: vi.fn(async () => ({ id: 1, url: "https://example.com", title: "", ...tab })),
+    executeScript: executeScriptImpl,
+  } as unknown as BrowserExecutor;
+}
+
+function makeContext(browser: BrowserExecutor): ProviderContext {
+  return { browser, artifactStorage: {} as ProviderContext["artifactStorage"] };
+}
+
+describe("BrowserJsProvider.handleRequest", () => {
+  it("unwraps ScriptResult so the sandbox receives the raw user return (not {value: ...})", async () => {
+    const browser = makeBrowser(async () => ok({ value: { title: "Hello", count: 3 } }));
+
+    const provider = new BrowserJsProvider();
+    const result = await provider.handleRequest(
+      { id: "req-1", action: "browserjs", code: "() => ({ title: 'Hello', count: 3 })", args: [] },
+      makeContext(browser),
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    // ユーザの関数が返した object がそのまま見える（.value ラップされない）
+    expect(result.value).toEqual({ title: "Hello", count: 3 });
+  });
+
+  it("unwraps primitives", async () => {
+    const browser = makeBrowser(async () => ok({ value: 42 }));
+
+    const provider = new BrowserJsProvider();
+    const result = await provider.handleRequest(
+      { id: "req-2", action: "browserjs", code: "() => 42", args: [] },
+      makeContext(browser),
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value).toBe(42);
+  });
+
+  it("returns err when the tab has no id", async () => {
+    const browser = {
+      getActiveTab: vi.fn(async () => ({ id: null, url: "", title: "" })),
+      executeScript: vi.fn(),
+    } as unknown as BrowserExecutor;
+
+    const provider = new BrowserJsProvider();
+    const result = await provider.handleRequest(
+      { id: "req-3", action: "browserjs", code: "() => 1", args: [] },
+      makeContext(browser),
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe("tool_tab_not_found");
+  });
+
+  it("propagates executeScript errors", async () => {
+    const browser = makeBrowser(async () =>
+      err({ code: "tool_script_error", message: "Script timeout" }),
+    );
+
+    const provider = new BrowserJsProvider();
+    const result = await provider.handleRequest(
+      { id: "req-4", action: "browserjs", code: "() => { while(1); }", args: [] },
+      makeContext(browser),
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.message).toContain("timeout");
+  });
+});

--- a/src/features/tools/providers/browser-js-provider.ts
+++ b/src/features/tools/providers/browser-js-provider.ts
@@ -108,7 +108,13 @@ function browserjs(fn, ...args) {
         return err(result.error);
       }
 
-      return ok(result.value);
+      // browser.executeScript は `Result<ScriptResult, ToolError>` を返し、
+      // ScriptResult は `{ value: unknown }` でユーザの戻り値を内部ラップする。
+      // ここでさらに ok(result.value) としてしまうと、sandbox 側で
+      // `await browserjs(() => ({ foo: 1 }))` の結果が `{ value: { foo: 1 } }`
+      // となり、AI が `.value.foo` / `.foo` の使い分けに迷う。unwrap して
+      // ユーザの直接戻り値だけを渡す。
+      return ok(result.value.value);
     } catch (e: unknown) {
       return err({
         code: "tool_script_error",


### PR DESCRIPTION
## Summary

AI から「\`browserjs()\` の戻り値が \`data.value\` にラップされていたりされていなかったり\」という指摘。コード追跡したところ **常に二重ラップ** されていて、AI はたまたま user が \`.value\` を付けて動いたケースを「ラップあり」、user が直接プロパティアクセスして undefined を返したケースを「ラップなし」と誤解していた、というのが真相。

### 二重ラップの構造

1. \`chrome.scripting.executeScript\` の injected 関数が \`{ ok: true, value: result }\` を作る
2. \`normalizeScriptResponse\` がそれを \`Result<ScriptResult, ToolError>\` (=\`Result<{value: unknown}, ...>\`) に変換
3. \`BrowserJsProvider.handleRequest\` が \`ok(result.value)\` を返す → ここで \`result.value\` は ScriptResult = \`{value: userReturn}\`
4. sandbox 側 \`msg.value = {value: userReturn}\` を resolve → \`await browserjs()\` は \`{value: userReturn}\`

### 修正

\`ok(result.value.value)\` に変更して ScriptResult の \`.value\` を unwrap。以降 AI は \`await browserjs(() => ({foo: 1}))\` で直接 \`{foo: 1}\` を受け取る。

## Test plan

- [x] \`npx vitest run\` → 988 passed (+4 新規)
- [x] \`npx tsc --noEmit\` → クリーン
- [ ] 実機で \`const data = await browserjs(() => ({ title: 'x' }))\` → \`data.title === 'x'\` になる
- [ ] 数値やプリミティブも同様に unwrap される

## Related

- AI からのフィードバック (browserjs 戻り値の不一致)

🤖 Generated with [Claude Code](https://claude.com/claude-code)