### PR TITLE
chore(release): v0.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sitesurf",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "AIと一緒にWebページを操作するChrome拡張機能",
   "license": "MIT",
   "type": "module",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "SiteSurf",
   "description": "AIと一緒にWebページを操作するChrome拡張",
-  "version": "0.1.2",
+  "version": "0.1.4",
   "action": {
     "default_title": "SiteSurfを開く",
     "default_icon": {


### PR DESCRIPTION
## Summary
- `package.json` 0.1.3 → 0.1.4
- `public/manifest.json` 0.1.2 → 0.1.4 (manifest が 1 patch 遅れていたので同期)

タグ `v0.1.4` push で `.github/workflows/release.yml` が dist.zip を作成しリリース生成。

## Test plan
- [x] `pnpm run build` が成功する
- [x] `pnpm tsc --noEmit` がクリーン
- [ ] マージ後に `v0.1.4` タグを push し、Release ワークフロー完走を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)