### PR TITLE
[計測基盤] Before/After 計測のための context-budget ログ強化

### DIFF
--- a/src/adapters/ai/__tests__/converters.test.ts
+++ b/src/adapters/ai/__tests__/converters.test.ts
@@ -111,12 +111,25 @@ describe("toStreamEvent", () => {
     const event = toStreamEvent({
       type: "finish",
       finishReason: "stop",
-      totalUsage: { promptTokens: 100, completionTokens: 50 },
+      totalUsage: {
+        promptTokens: 100,
+        completionTokens: 50,
+        inputTokenDetails: { cacheReadTokens: 40, cacheWriteTokens: 10 },
+        outputTokenDetails: { reasoningTokens: 12 },
+      },
     });
     expect(event).toEqual({
       type: "finish",
       finishReason: "stop",
-      usage: { promptTokens: 100, completionTokens: 50, totalTokens: 150 },
+      usage: {
+        promptTokens: 100,
+        completionTokens: 50,
+        totalTokens: 150,
+        cachedInputTokens: 40,
+        reasoningTokens: 12,
+        inputTokenDetails: { cacheReadTokens: 40, cacheWriteTokens: 10 },
+        outputTokenDetails: { reasoningTokens: 12 },
+      },
     });
   });
 

--- a/src/adapters/ai/converters.ts
+++ b/src/adapters/ai/converters.ts
@@ -192,6 +192,9 @@ function extractTokenUsage(part: Record<string, unknown>): TokenUsage | undefine
   const totalUsage = part.totalUsage as Record<string, unknown> | undefined;
   if (!totalUsage) return undefined;
 
+  const inputTokenDetails = totalUsage.inputTokenDetails as Record<string, unknown> | undefined;
+  const outputTokenDetails = totalUsage.outputTokenDetails as Record<string, unknown> | undefined;
+
   // 様々な命名規則に対応
   const promptTokens =
     (totalUsage.promptTokens as number | undefined) ??
@@ -207,11 +210,58 @@ function extractTokenUsage(part: Record<string, unknown>): TokenUsage | undefine
     (totalUsage.output_tokens as number | undefined) ??
     0;
 
+  const reasoningTokens =
+    (outputTokenDetails?.reasoningTokens as number | undefined) ??
+    (totalUsage.reasoningTokens as number | undefined);
+
+  const normalizedInputTokenDetails = compactTokenDetails(
+    inputTokenDetails
+      ? {
+          noCacheTokens:
+            (inputTokenDetails.noCacheTokens as number | undefined) ??
+            (inputTokenDetails.no_cache_tokens as number | undefined),
+          cacheReadTokens:
+            (inputTokenDetails.cacheReadTokens as number | undefined) ??
+            (inputTokenDetails.cache_read_tokens as number | undefined),
+          cacheWriteTokens:
+            (inputTokenDetails.cacheWriteTokens as number | undefined) ??
+            (inputTokenDetails.cache_write_tokens as number | undefined),
+        }
+      : undefined,
+  );
+
+  const normalizedOutputTokenDetails = compactTokenDetails(
+    outputTokenDetails
+      ? {
+          textTokens:
+            (outputTokenDetails.textTokens as number | undefined) ??
+            (outputTokenDetails.text_tokens as number | undefined),
+          reasoningTokens,
+        }
+      : undefined,
+  );
+
   return {
     promptTokens,
     completionTokens,
     totalTokens: promptTokens + completionTokens,
+    ...(reasoningTokens !== undefined ? { reasoningTokens } : {}),
+    ...(normalizedInputTokenDetails?.cacheReadTokens !== undefined
+      ? { cachedInputTokens: normalizedInputTokenDetails.cacheReadTokens }
+      : {}),
+    ...(normalizedInputTokenDetails ? { inputTokenDetails: normalizedInputTokenDetails } : {}),
+    ...(normalizedOutputTokenDetails ? { outputTokenDetails: normalizedOutputTokenDetails } : {}),
   };
+}
+
+function compactTokenDetails<T extends Record<string, number | undefined>>(
+  details: T | undefined,
+): T | undefined {
+  if (!details) return undefined;
+  const compacted = Object.fromEntries(
+    Object.entries(details).filter(([, value]) => value !== undefined),
+  ) as T;
+  return Object.keys(compacted).length > 0 ? compacted : undefined;
 }
 
 function mapFinishReason(reason: unknown): FinishReason {

--- a/src/features/ai/__tests__/context-budget.test.ts
+++ b/src/features/ai/__tests__/context-budget.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { getContextBudget } from "../context-budget";
+import { buildContextBudgetBreakdown, getContextBudget } from "../context-budget";
 import { DEFAULT_MAX_TOKENS } from "@/shared/token-constants";
 
 // gpt-4-32k has contextWindow = 32768
@@ -53,5 +53,49 @@ describe("getContextBudget", () => {
   it("unknown model: defaults to 128000 window", () => {
     const budget = getContextBudget("nonexistent-model-xyz");
     expect(budget.windowTokens).toBe(128_000);
+  });
+
+  it("initializes per-turn token breakdown fields to zero", () => {
+    const budget = getContextBudget(MODEL_32K);
+
+    expect(budget.systemPromptTokens).toBe(0);
+    expect(budget.toolsTokens).toBe(0);
+    expect(budget.historyTokens).toBe(0);
+    expect(budget.toolResultsTokens).toBe(0);
+  });
+});
+
+describe("buildContextBudgetBreakdown", () => {
+  it("separates latest tool results from history tokens", () => {
+    const breakdown = buildContextBudgetBreakdown({
+      systemPrompt: "system prompt",
+      tools: [
+        {
+          name: "read_page",
+          description: "Read the current page",
+          parameters: { type: "object", properties: { depth: { type: "number" } } },
+        },
+      ],
+      messages: [
+        { role: "user", content: [{ type: "text", text: "hello" }] },
+        { role: "assistant", content: [{ type: "text", text: "world" }] },
+        { role: "tool", toolCallId: "tool-old", toolName: "read_page", result: "old result" },
+        { role: "tool", toolCallId: "tool-latest", toolName: "read_page", result: "latest result" },
+      ],
+      latestToolResultIds: new Set(["tool-latest"]),
+    });
+
+    expect(breakdown.systemPromptTokens).toBe("system prompt".length);
+    expect(breakdown.toolsTokens).toBe(
+      JSON.stringify([
+        {
+          name: "read_page",
+          description: "Read the current page",
+          parameters: { type: "object", properties: { depth: { type: "number" } } },
+        },
+      ]).length,
+    );
+    expect(breakdown.historyTokens).toBe("hello".length + "world".length + "old result".length);
+    expect(breakdown.toolResultsTokens).toBe("latest result".length);
   });
 });

--- a/src/features/ai/context-budget.ts
+++ b/src/features/ai/context-budget.ts
@@ -1,8 +1,11 @@
+import type { AIMessage, TokenUsage, ToolDefinition } from "@/ports/ai-provider";
 import { lookupModelContextWindow } from "@/shared/model-utils";
 import { DEFAULT_MAX_TOKENS } from "@/shared/token-constants";
-import { createLogger } from "@/shared/logger";
+import { createLogger, logStructuredInfo } from "@/shared/logger";
+import { estimateTokens } from "@/shared/token-utils";
 
 const log = createLogger("context-budget");
+const CONTEXT_BUDGET_LOG_PREFIX = "[ctx-budget]";
 
 export interface ContextBudget {
   windowTokens: number;
@@ -11,6 +14,10 @@ export interface ContextBudget {
   maxToolResultChars: number;
   compressionThreshold: number;
   trimThreshold: number;
+  systemPromptTokens: number;
+  toolsTokens: number;
+  historyTokens: number;
+  toolResultsTokens: number;
 }
 
 export function getContextBudget(model: string, settingsMaxTokens?: number): ContextBudget {
@@ -44,5 +51,76 @@ export function getContextBudget(model: string, settingsMaxTokens?: number): Con
               : 1_000,
     compressionThreshold: Math.floor(inputBudget * 0.6),
     trimThreshold: Math.floor(inputBudget * 0.85),
+    systemPromptTokens: 0,
+    toolsTokens: 0,
+    historyTokens: 0,
+    toolResultsTokens: 0,
   };
+}
+
+export function buildContextBudgetBreakdown(input: {
+  systemPrompt: string;
+  tools: ToolDefinition[];
+  messages: AIMessage[];
+  latestToolResultIds?: ReadonlySet<string>;
+}): Pick<
+  ContextBudget,
+  "systemPromptTokens" | "toolsTokens" | "historyTokens" | "toolResultsTokens"
+> {
+  const latestToolResultIds = input.latestToolResultIds ?? new Set<string>();
+  const historyMessages: AIMessage[] = [];
+  const latestToolResultMessages: AIMessage[] = [];
+
+  for (const message of input.messages) {
+    if (message.role === "tool" && latestToolResultIds.has(message.toolCallId)) {
+      latestToolResultMessages.push(message);
+      continue;
+    }
+    historyMessages.push(message);
+  }
+
+  return {
+    systemPromptTokens: input.systemPrompt.length,
+    toolsTokens: JSON.stringify(input.tools).length,
+    historyTokens: estimateTokens(historyMessages),
+    toolResultsTokens: estimateTokens(latestToolResultMessages),
+  };
+}
+
+export function logContextBudgetSnapshot(input: {
+  phase: "request" | "finish";
+  model: string;
+  turn: number;
+  budget: ContextBudget;
+  usage?: TokenUsage;
+}): void {
+  const promptCacheReadTokens =
+    input.usage?.inputTokenDetails?.cacheReadTokens ?? input.usage?.cachedInputTokens;
+  const promptCacheWriteTokens = input.usage?.inputTokenDetails?.cacheWriteTokens;
+  const reasoningTokens =
+    input.usage?.outputTokenDetails?.reasoningTokens ?? input.usage?.reasoningTokens;
+  const promptCacheHitRate =
+    input.usage && input.usage.promptTokens > 0 && promptCacheReadTokens !== undefined
+      ? promptCacheReadTokens / input.usage.promptTokens
+      : undefined;
+
+  logStructuredInfo(CONTEXT_BUDGET_LOG_PREFIX, {
+    phase: input.phase,
+    model: input.model,
+    turn: input.turn,
+    windowTokens: input.budget.windowTokens,
+    inputBudget: input.budget.inputBudget,
+    outputReserve: input.budget.outputReserve,
+    systemPromptTokens: input.budget.systemPromptTokens,
+    toolsTokens: input.budget.toolsTokens,
+    historyTokens: input.budget.historyTokens,
+    toolResultsTokens: input.budget.toolResultsTokens,
+    reasoningTokens,
+    promptTokens: input.usage?.promptTokens,
+    completionTokens: input.usage?.completionTokens,
+    totalTokens: input.usage?.totalTokens,
+    promptCacheReadTokens,
+    promptCacheWriteTokens,
+    promptCacheHitRate,
+  });
 }

--- a/src/orchestration/__tests__/agent-loop.test.ts
+++ b/src/orchestration/__tests__/agent-loop.test.ts
@@ -375,7 +375,7 @@ describe("runAgentLoop", () => {
       deps: {
         createAIProvider: () => createMockAIProvider(),
         browserExecutor,
-        },
+      },
     });
     await runAgentLoop(params);
 
@@ -453,7 +453,7 @@ describe("auth refresh on ai_auth_invalid", () => {
         createAIProvider: () => createMockAIProvider(),
         browserExecutor: {} as BrowserExecutor,
         authProvider: mockAuthProvider,
-        },
+      },
       credentials: createMockCredentials(),
       onCredentialsUpdate,
     });
@@ -493,7 +493,7 @@ describe("auth refresh on ai_auth_invalid", () => {
         createAIProvider: () => createMockAIProvider(),
         browserExecutor: {} as BrowserExecutor,
         authProvider: mockAuthProvider,
-        },
+      },
       credentials: createMockCredentials(),
       onCredentialsUpdate,
     });
@@ -524,7 +524,7 @@ describe("auth refresh on ai_auth_invalid", () => {
         createAIProvider: () => createMockAIProvider(),
         browserExecutor: {} as BrowserExecutor,
         authProvider: mockAuthProvider,
-        },
+      },
     });
 
     await runAgentLoop(params);
@@ -824,7 +824,7 @@ describe("tool execution error", () => {
         createAIProvider: () => createMockAIProvider(),
         browserExecutor: {} as BrowserExecutor,
         securityMiddleware: createSecurityMiddleware({ auditLogger }),
-        },
+      },
     });
     vi.mocked(params.toolExecutor).mockResolvedValueOnce({
       ok: true,
@@ -866,7 +866,7 @@ describe("tool execution error", () => {
         createAIProvider: () => createMockAIProvider(),
         browserExecutor: {} as BrowserExecutor,
         securityMiddleware: createSecurityMiddleware({ auditLogger }),
-        },
+      },
     });
     vi.mocked(params.toolExecutor).mockResolvedValueOnce({
       ok: true,
@@ -1060,6 +1060,64 @@ describe("context budget integration", () => {
       }),
     );
   });
+
+  it("logs [ctx-budget] breakdown and prompt cache metrics", async () => {
+    setStreamEvents([
+      {
+        type: "finish",
+        finishReason: "stop",
+        usage: {
+          promptTokens: 120,
+          completionTokens: 30,
+          totalTokens: 150,
+          reasoningTokens: 9,
+          inputTokenDetails: {
+            cacheReadTokens: 60,
+            cacheWriteTokens: 15,
+          },
+        },
+      },
+    ]);
+
+    const params = createParams({
+      tools: [
+        {
+          name: "read_page",
+          description: "Read the current page",
+          parameters: { type: "object", properties: {} },
+        },
+      ],
+      systemPrompt: "system prompt",
+      chatStore: createMockChatStore({
+        getMessages: vi.fn(() => [
+          {
+            id: "u-1",
+            role: "user" as const,
+            content: "hello world",
+            createdAt: Date.now(),
+            timestamp: Date.now(),
+          },
+        ]),
+      }),
+    });
+
+    await runAgentLoop(params);
+
+    expect(consoleInfoSpy).toHaveBeenCalledWith(
+      "[ctx-budget]",
+      expect.objectContaining({
+        phase: "finish",
+        systemPromptTokens: "system prompt".length,
+        toolsTokens: JSON.stringify(params.tools).length,
+        historyTokens: "hello world".length,
+        toolResultsTokens: 0,
+        reasoningTokens: 9,
+        promptCacheReadTokens: 60,
+        promptCacheWriteTokens: 15,
+        promptCacheHitRate: 0.5,
+      }),
+    );
+  });
 });
 
 describe("trackVisitedUrl", () => {
@@ -1188,7 +1246,7 @@ describe("visited URLs in system prompt", () => {
       deps: {
         createAIProvider: () => createMockAIProvider(),
         browserExecutor,
-        },
+      },
     });
     await runAgentLoop(params);
 

--- a/src/orchestration/__tests__/context-compressor.test.ts
+++ b/src/orchestration/__tests__/context-compressor.test.ts
@@ -58,6 +58,10 @@ function createBudget(overrides: Partial<ContextBudget> = {}): ContextBudget {
     maxToolResultChars: 1_000,
     compressionThreshold: 9_830,
     trimThreshold: 13_926,
+    systemPromptTokens: 0,
+    toolsTokens: 0,
+    historyTokens: 0,
+    toolResultsTokens: 0,
     ...overrides,
   };
 }
@@ -310,7 +314,12 @@ describe("splitByKeepRecentTokens", () => {
       toolName: "read_page",
       result: "b".repeat(30),
     };
-    const messages: AIMessage[] = [createUserMessage("u".repeat(200)), assistantWithTwoCalls, toolA, toolB];
+    const messages: AIMessage[] = [
+      createUserMessage("u".repeat(200)),
+      assistantWithTwoCalls,
+      toolA,
+      toolB,
+    ];
     const result = splitByKeepRecentTokens(messages, 50);
     expect(result.toKeep[0]).toBe(assistantWithTwoCalls);
     expect(result.toKeep).toHaveLength(3);

--- a/src/orchestration/__tests__/context-manager.test.ts
+++ b/src/orchestration/__tests__/context-manager.test.ts
@@ -10,6 +10,10 @@ const budget: ContextBudget = {
   maxToolResultChars: 1000,
   compressionThreshold: 15000,
   trimThreshold: 20000,
+  systemPromptTokens: 0,
+  toolsTokens: 0,
+  historyTokens: 0,
+  toolResultsTokens: 0,
 };
 
 describe("context-manager", () => {
@@ -27,7 +31,9 @@ describe("context-manager", () => {
 
     const result = (messages[0] as Extract<AIMessage, { role: "tool" }>).result as string;
     expect(result).toContain("... (truncated)");
-    expect(result.length).toBeLessThanOrEqual(budget.maxToolResultChars + "\n... (truncated)".length);
+    expect(result.length).toBeLessThanOrEqual(
+      budget.maxToolResultChars + "\n... (truncated)".length,
+    );
   });
 
   it("maxToolResultChars 未満の tool メッセージは改変しない", () => {
@@ -53,7 +59,9 @@ describe("context-manager", () => {
 
     manageContextMessages(messages, budget);
 
-    expect((messages[0] as Extract<AIMessage, { role: "tool" }>).result).toBe("[screenshot captured]");
+    expect((messages[0] as Extract<AIMessage, { role: "tool" }>).result).toBe(
+      "[screenshot captured]",
+    );
   });
 
   it("logs when trimThreshold is reached and reports splicedMessageCount", () => {

--- a/src/orchestration/agent-loop.ts
+++ b/src/orchestration/agent-loop.ts
@@ -18,7 +18,11 @@ import { convertNavigationForAPI } from "./navigation-converter";
 import { calculateBackoff, isRetryable, RETRY_CONFIG } from "./retry";
 import { estimateTokens } from "./context-compressor";
 import { compressIfNeeded, stripStructuredSummaryMessage } from "./context-compressor";
-import { getContextBudget } from "@/features/ai/context-budget";
+import {
+  buildContextBudgetBreakdown,
+  getContextBudget,
+  logContextBudgetSnapshot,
+} from "@/features/ai/context-budget";
 import { generateVisitedUrlsSection, type VisitedUrlEntry } from "@/features/ai/system-prompt-v2";
 import { prepareMessagesForTurn, trimMessagesToThreshold } from "./context-manager";
 import type { SkillRegistry } from "@/shared/skill-registry";
@@ -309,6 +313,7 @@ export async function runAgentLoop(params: AgentLoopParams): Promise<void> {
   let navFlagTimer: ReturnType<typeof setTimeout> | null = null;
 
   let currentSession = session;
+  let latestTurnToolResultIds = new Set<string>();
   const currentUserMessageCount = chatStore
     .getMessages()
     .filter((message) => message.role === "user" || message.role === "navigation").length;
@@ -574,6 +579,21 @@ export async function runAgentLoop(params: AgentLoopParams): Promise<void> {
             });
           }
         }
+        const turnBudget = {
+          ...budget,
+          ...buildContextBudgetBreakdown({
+            systemPrompt: effectiveSystemPrompt,
+            tools,
+            messages,
+            latestToolResultIds: latestTurnToolResultIds,
+          }),
+        };
+        logContextBudgetSnapshot({
+          phase: "request",
+          model: settings.model,
+          turn,
+          budget: turnBudget,
+        });
         chatStore.startNewAssistantMessage();
 
         for await (const event of aiProvider.streamText({
@@ -645,6 +665,13 @@ export async function runAgentLoop(params: AgentLoopParams): Promise<void> {
               if (event.usage) {
                 chatStore.setLastMessageUsage(event.usage);
               }
+              logContextBudgetSnapshot({
+                phase: "finish",
+                model: settings.model,
+                turn,
+                budget: turnBudget,
+                usage: event.usage,
+              });
 
               const assistantContent: AssistantContent[] = [];
               if (assistantText) {
@@ -665,6 +692,9 @@ export async function runAgentLoop(params: AgentLoopParams): Promise<void> {
               for (const tr of pendingToolResults) {
                 messages.push({ role: "tool", ...tr });
               }
+              latestTurnToolResultIds = new Set(
+                pendingToolResults.map((toolResult) => toolResult.toolCallId),
+              );
               pendingToolCalls.length = 0;
               pendingToolResults.length = 0;
               break;

--- a/src/ports/ai-provider.ts
+++ b/src/ports/ai-provider.ts
@@ -114,4 +114,15 @@ export interface TokenUsage {
   promptTokens: number;
   completionTokens: number;
   totalTokens: number;
+  reasoningTokens?: number;
+  cachedInputTokens?: number;
+  inputTokenDetails?: {
+    noCacheTokens?: number;
+    cacheReadTokens?: number;
+    cacheWriteTokens?: number;
+  };
+  outputTokenDetails?: {
+    textTokens?: number;
+    reasoningTokens?: number;
+  };
 }

--- a/src/shared/logger.ts
+++ b/src/shared/logger.ts
@@ -7,6 +7,10 @@ export interface Logger {
   error(message: string, error?: unknown): void;
 }
 
+export function logStructuredInfo(prefix: string, data?: unknown): void {
+  console.info(prefix, data ?? "");
+}
+
 export function createLogger(module: string): Logger {
   const prefix = `[SiteSurf:${module}]`;
   return {


### PR DESCRIPTION
## 概要
- `ContextBudget` に system prompt / tools / history / latest tool results の内訳を追加
- `finish` usage から reasoning / prompt cache read-write を抽出して `[ctx-budget]` で構造化ログ出力
- context-budget / converter / agent-loop のテストを更新

## テスト
- `pnpm vitest`
- `vp check src/shared/logger.ts src/ports/ai-provider.ts src/adapters/ai/converters.ts src/features/ai/context-budget.ts src/features/ai/__tests__/context-budget.test.ts src/adapters/ai/__tests__/converters.test.ts src/orchestration/agent-loop.ts src/orchestration/__tests__/agent-loop.test.ts src/orchestration/__tests__/context-compressor.test.ts src/orchestration/__tests__/context-manager.test.ts`
