### PR TITLE
fix: consolidate skill draft tools into skill actions

### DIFF
--- a/src/features/tools/__tests__/integration.test.ts
+++ b/src/features/tools/__tests__/integration.test.ts
@@ -162,18 +162,18 @@ describe("2段階抽出ワークフロー", () => {
     it("agent に公開する tool 定義から skill 管理ツールを除外する", () => {
       const names = AGENT_TOOL_DEFS.map((t) => t.name);
 
-      expect(names).toContain("list_skill_drafts");
-      expect(names).toContain("create_skill_draft");
-      expect(names).toContain("update_skill_draft");
-      expect(names).toContain("delete_skill_draft");
-      expect(names).not.toContain("skill");
+      expect(names).toContain("skill");
+      expect(names).not.toContain("list_skill_drafts");
+      expect(names).not.toContain("create_skill_draft");
+      expect(names).not.toContain("update_skill_draft");
+      expect(names).not.toContain("delete_skill_draft");
     });
 
     it("getAgentToolDefs: 引数なしで bg_fetch を除外する", () => {
       const names = getAgentToolDefs().map((t) => t.name);
       expect(names).not.toContain("bg_fetch");
       expect(names).not.toContain("get_tool_result");
-      expect(names).not.toContain("skill");
+      expect(names).toContain("skill");
     });
 
     it("getAgentToolDefs: enableBgFetch=false で bg_fetch を除外する", () => {
@@ -185,37 +185,40 @@ describe("2段階抽出ワークフロー", () => {
       const names = getAgentToolDefs({ enableBgFetch: true }).map((t) => t.name);
       expect(names).toContain("bg_fetch");
       expect(names).not.toContain("get_tool_result");
-      expect(names).not.toContain("skill");
+      expect(names).toContain("skill");
     });
 
   });
 
   describe("draft ツールの dispatch パス", () => {
-    it("list_skill_drafts が executor 経由で実行できる", async () => {
+    it("skill(action=list_drafts) が executor 経由で実行できる", async () => {
       const browser = createMockBrowser();
-      const result = await createToolExecutor("list_skill_drafts", {}, browser);
+      const result = await createToolExecutor("skill", { action: "list_drafts" }, browser);
       expect(result.ok).toBe(true);
       if (!result.ok) return;
       expect(result.value).toHaveProperty("drafts");
     });
 
-    it("create_skill_draft が executor 経由で実行できる", async () => {
+    it("skill(action=create_draft) が executor 経由で実行できる", async () => {
       const browser = createMockBrowser();
       const result = await createToolExecutor(
-        "create_skill_draft",
+        "skill",
         {
-          name: "Integration Draft",
-          description: "Created via executor dispatch",
-          matchers: { hosts: ["example.com"] },
-          extractors: [
-            {
-              id: "getTitle",
-              name: "Get Title",
-              description: "Return the page title",
-              code: "function () { return document.title; }",
-              outputSchema: "string",
-            },
-          ],
+          action: "create_draft",
+          data: {
+            name: "Integration Draft",
+            description: "Created via executor dispatch",
+            matchers: { hosts: ["example.com"] },
+            extractors: [
+              {
+                id: "getTitle",
+                name: "Get Title",
+                description: "Return the page title",
+                code: "function () { return document.title; }",
+                outputSchema: "string",
+              },
+            ],
+          },
         },
         browser,
       );
@@ -224,7 +227,7 @@ describe("2段階抽出ワークフロー", () => {
       expect(result.value).toHaveProperty("draftId");
     });
 
-    it("update_skill_draft が executor 経由で実行できる", async () => {
+    it("skill(action=update_draft) が executor 経由で実行できる", async () => {
       const storage = new InMemoryStorage();
       const registry = new SkillRegistry();
       const browser = createMockBrowser();
@@ -235,20 +238,23 @@ describe("2段階抽出ワークフロー", () => {
       );
 
       const createResult = await executor(
-        "create_skill_draft",
+        "skill",
         {
-          name: "Draft For Update",
-          description: "Will be updated via dispatch",
-          matchers: { hosts: ["example.com"] },
-          extractors: [
-            {
-              id: "getTitle",
-              name: "Get Title",
-              description: "Return the page title",
-              code: "function () { return document.title; }",
-              outputSchema: "string",
-            },
-          ],
+          action: "create_draft",
+          data: {
+            name: "Draft For Update",
+            description: "Will be updated via dispatch",
+            matchers: { hosts: ["example.com"] },
+            extractors: [
+              {
+                id: "getTitle",
+                name: "Get Title",
+                description: "Return the page title",
+                code: "function () { return document.title; }",
+                outputSchema: "string",
+              },
+            ],
+          },
         },
         browser,
       );
@@ -257,8 +263,8 @@ describe("2段階抽出ワークフロー", () => {
       const draftId = (createResult.value as { draftId: string }).draftId;
 
       const updateResult = await executor(
-        "update_skill_draft",
-        { draftId, updates: { description: "Updated via dispatch" } },
+        "skill",
+        { action: "update_draft", id: draftId, updates: { description: "Updated via dispatch" } },
         browser,
       );
       expect(updateResult.ok).toBe(true);
@@ -269,7 +275,7 @@ describe("2段階抽出ワークフロー", () => {
       ).toBe("Updated via dispatch");
     });
 
-    it("delete_skill_draft が executor 経由で実行できる", async () => {
+    it("skill(action=delete_draft) が executor 経由で実行できる", async () => {
       const storage = new InMemoryStorage();
       const registry = new SkillRegistry();
       const browser = createMockBrowser();
@@ -280,20 +286,23 @@ describe("2段階抽出ワークフロー", () => {
       );
 
       const createResult = await executor(
-        "create_skill_draft",
+        "skill",
         {
-          name: "Draft For Delete",
-          description: "Will be deleted via dispatch",
-          matchers: { hosts: ["example.com"] },
-          extractors: [
-            {
-              id: "getTitle",
-              name: "Get Title",
-              description: "Return the page title",
-              code: "function () { return document.title; }",
-              outputSchema: "string",
-            },
-          ],
+          action: "create_draft",
+          data: {
+            name: "Draft For Delete",
+            description: "Will be deleted via dispatch",
+            matchers: { hosts: ["example.com"] },
+            extractors: [
+              {
+                id: "getTitle",
+                name: "Get Title",
+                description: "Return the page title",
+                code: "function () { return document.title; }",
+                outputSchema: "string",
+              },
+            ],
+          },
         },
         browser,
       );
@@ -301,12 +310,16 @@ describe("2段階抽出ワークフロー", () => {
       if (!createResult.ok) return;
       const draftId = (createResult.value as { draftId: string }).draftId;
 
-      const deleteResult = await executor("delete_skill_draft", { draftId }, browser);
+      const deleteResult = await executor(
+        "skill",
+        { action: "delete_draft", id: draftId },
+        browser,
+      );
       expect(deleteResult.ok).toBe(true);
       if (!deleteResult.ok) return;
       expect(deleteResult.value).toEqual({ deleted: true, draftId });
 
-      const listResult = await executor("list_skill_drafts", {}, browser);
+      const listResult = await executor("skill", { action: "list_drafts" }, browser);
       expect(listResult.ok).toBe(true);
       if (!listResult.ok) return;
       expect((listResult.value as { drafts: unknown[] }).drafts).toEqual([]);

--- a/src/features/tools/__tests__/skill.test.ts
+++ b/src/features/tools/__tests__/skill.test.ts
@@ -2,10 +2,6 @@ import { describe, expect, it } from "vitest";
 import {
   executeSkill,
   skillToolDef,
-  listSkillDraftsToolDef,
-  createSkillDraftToolDef,
-  updateSkillDraftToolDef,
-  deleteSkillDraftToolDef,
   executeListSkillDrafts,
   executeCreateSkillDraft,
   executeUpdateSkillDraft,
@@ -19,6 +15,7 @@ import {
   type UpdateSkillDraftResult,
   type ListSkillDraftsResult,
   type DeleteSkillDraftResult,
+  type SkillPatches,
 } from "../skill";
 import { SkillRegistry } from "../skills";
 import { InMemoryStorage } from "@/adapters/storage/in-memory-storage";
@@ -61,30 +58,52 @@ describe("skill tool", () => {
       expect(skillToolDef.description).toContain("update");
       expect(skillToolDef.description).toContain("patch");
       expect(skillToolDef.description).toContain("delete");
+      expect(skillToolDef.description).toContain("list_drafts");
+      expect(skillToolDef.description).toContain("create_draft");
+      expect(skillToolDef.description).toContain("update_draft");
+      expect(skillToolDef.description).toContain("delete_draft");
     });
 
     it("has parameters with action enum", () => {
       const params = skillToolDef.parameters as Record<string, unknown>;
       expect(params.type).toBe("object");
       expect(params.properties).toHaveProperty("action");
+      expect((params.properties as { action: { enum: string[] } }).action.enum).toEqual(
+        expect.arrayContaining([
+          "list",
+          "get",
+          "create",
+          "update",
+          "patch",
+          "delete",
+          "list_drafts",
+          "create_draft",
+          "update_draft",
+          "delete_draft",
+        ]),
+      );
     });
-  });
 
-  describe("create_skill_draft tool definition", () => {
-    it("has the expected tool name", () => {
-      expect(createSkillDraftToolDef.name).toBe("create_skill_draft");
+    it("describes draft persistence through draft actions", () => {
+      expect(skillToolDef.description).toContain("下書き");
+      expect(skillToolDef.description).toContain("create_draft");
+      expect(skillToolDef.description).toContain("custom skill としては保存されません");
     });
 
-    it("describes draft persistence without claiming custom-skill save", () => {
-      expect(createSkillDraftToolDef.description).toContain("下書きとして保存");
-      expect(createSkillDraftToolDef.description).toContain("custom skill としては保存されません");
-    });
+    it("returns a tool error for malformed skill arguments", async () => {
+      const storage = new InMemoryStorage();
+      const registry = new SkillRegistry();
 
-    it("accepts draft creation inputs", () => {
-      const params = createSkillDraftToolDef.parameters as Record<string, unknown>;
-      expect(params.type).toBe("object");
-      expect(params.properties).toHaveProperty("name");
-      expect(params.properties).toHaveProperty("extractors");
+      const result = await executeSkill(
+        storage,
+        registry,
+        undefined,
+        null as unknown as Parameters<typeof executeSkill>[3],
+      );
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.message).toContain("skill arguments must be an object with action");
     });
   });
 
@@ -308,6 +327,22 @@ describe("skill tool", () => {
   });
 
   describe("create action", () => {
+    it("returns a tool error for missing create data", async () => {
+      const storage = new InMemoryStorage();
+      const registry = new SkillRegistry();
+
+      const result = await executeSkill(
+        storage,
+        registry,
+        undefined,
+        { action: "create" } as unknown as Parameters<typeof executeSkill>[3],
+      );
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.message).toContain("create action requires data");
+    });
+
     it("creates a new skill", async () => {
       const storage = new InMemoryStorage();
       const registry = new SkillRegistry();
@@ -549,7 +584,7 @@ describe("skill tool", () => {
     });
   });
 
-  describe("create_skill_draft tool", () => {
+  describe("create_draft action", () => {
     it("creates a draft without persisting it as a custom skill", async () => {
       const storage = new InMemoryStorage();
       const registry = new SkillRegistry();
@@ -757,13 +792,7 @@ describe("skill tool", () => {
     });
   });
 
-  describe("list_skill_drafts tool definition", () => {
-    it("has the expected tool name", () => {
-      expect(listSkillDraftsToolDef.name).toBe("list_skill_drafts");
-    });
-  });
-
-  describe("list_skill_drafts tool", () => {
+  describe("list_drafts action", () => {
     it("returns empty array when no drafts exist", async () => {
       const storage = new InMemoryStorage();
 
@@ -827,18 +856,7 @@ describe("skill tool", () => {
     });
   });
 
-  describe("update_skill_draft tool definition", () => {
-    it("has the expected tool name", () => {
-      expect(updateSkillDraftToolDef.name).toBe("update_skill_draft");
-    });
-
-    it("requires draftId and updates parameters", () => {
-      const params = updateSkillDraftToolDef.parameters as Record<string, unknown>;
-      expect(params.required).toEqual(["draftId", "updates"]);
-    });
-  });
-
-  describe("update_skill_draft tool", () => {
+  describe("update_draft action", () => {
     async function createDraft(storage: InMemoryStorage, registry: SkillRegistry) {
       const result = await executeCreateSkillDraft(storage, registry, {
         name: "Draft To Update",
@@ -990,6 +1008,22 @@ describe("skill tool", () => {
       expect(result.error.message).toContain("updates must be an object");
     });
 
+    it("returns error when update_draft payload is an array", async () => {
+      const storage = new InMemoryStorage();
+      const registry = new SkillRegistry();
+      const draft = await createDraft(storage, registry);
+
+      const result = await executeSkill(storage, registry, undefined, {
+        action: "update_draft",
+        id: draft.draftId,
+        updates: [] as unknown as Partial<CreateSkillDraftArgs>,
+      });
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.message).toContain("update_draft action requires id and updates");
+    });
+
     it("preserves createdAt and sets updatedAt on update", async () => {
       const storage = new InMemoryStorage();
       const registry = new SkillRegistry();
@@ -1136,18 +1170,7 @@ describe("skill tool", () => {
     });
   });
 
-  describe("delete_skill_draft tool definition", () => {
-    it("has the expected tool name", () => {
-      expect(deleteSkillDraftToolDef.name).toBe("delete_skill_draft");
-    });
-
-    it("requires draftId parameter", () => {
-      const params = deleteSkillDraftToolDef.parameters as Record<string, unknown>;
-      expect(params.required).toEqual(["draftId"]);
-    });
-  });
-
-  describe("delete_skill_draft tool", () => {
+  describe("delete_draft action", () => {
     async function createDraft(storage: InMemoryStorage, registry: SkillRegistry) {
       const result = await executeCreateSkillDraft(storage, registry, {
         name: "Draft To Delete",
@@ -1244,12 +1267,43 @@ describe("skill tool", () => {
         ),
       ).resolves.toMatchObject({
         ok: false,
-        error: { message: "delete_skill_draft arguments must be an object" },
+        error: { message: 'skill(action: "delete_draft") arguments must be an object' },
       });
     });
   });
 
   describe("update action", () => {
+    it("returns a tool error for missing update payload", async () => {
+      const storage = new InMemoryStorage();
+      const registry = new SkillRegistry();
+
+      const result = await executeSkill(
+        storage,
+        registry,
+        undefined,
+        { action: "update", id: "test-skill" } as unknown as Parameters<typeof executeSkill>[3],
+      );
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.message).toContain("update action requires id and updates");
+    });
+
+    it("returns a tool error when update payload is an array", async () => {
+      const storage = new InMemoryStorage();
+      const registry = new SkillRegistry();
+
+      const result = await executeSkill(storage, registry, undefined, {
+        action: "update",
+        id: "test-skill",
+        updates: [] as unknown as Partial<Skill>,
+      });
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.message).toContain("update action requires id and updates");
+    });
+
     it("updates skill fields", async () => {
       const storage = new InMemoryStorage();
       const registry = new SkillRegistry();
@@ -1407,6 +1461,42 @@ describe("skill tool", () => {
   });
 
   describe("patch action", () => {
+    it("returns a tool error for missing patch payload", async () => {
+      const storage = new InMemoryStorage();
+      const registry = new SkillRegistry();
+
+      const result = await executeSkill(
+        storage,
+        registry,
+        undefined,
+        { action: "patch", id: "test-skill" } as unknown as Parameters<typeof executeSkill>[3],
+      );
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.message).toContain("patch action requires id and patches");
+    });
+
+    it("returns a tool error when patch payload is an array", async () => {
+      const storage = new InMemoryStorage();
+      const registry = new SkillRegistry();
+
+      const result = await executeSkill(
+        storage,
+        registry,
+        undefined,
+        {
+          action: "patch",
+          id: "test-skill",
+          patches: [] as unknown as SkillPatches,
+        } as unknown as Parameters<typeof executeSkill>[3],
+      );
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.message).toContain("patch action requires id and patches");
+    });
+
     it("patches string fields", async () => {
       const storage = new InMemoryStorage();
       const registry = new SkillRegistry();

--- a/src/features/tools/index.ts
+++ b/src/features/tools/index.ts
@@ -13,15 +13,7 @@ import { screenshotToolDef, executeScreenshot } from "./screenshot";
 import { extractImageToolDef, executeExtractImage } from "./extract-image";
 import {
   skillToolDef,
-  listSkillDraftsToolDef,
-  createSkillDraftToolDef,
-  updateSkillDraftToolDef,
-  deleteSkillDraftToolDef,
   executeSkill,
-  executeListSkillDrafts,
-  executeCreateSkillDraft,
-  executeUpdateSkillDraft,
-  executeDeleteSkillDraft,
   type SkillAction,
   type SkillResult,
   type SkillListResult,
@@ -49,15 +41,7 @@ export { screenshotToolDef, executeScreenshot };
 export { extractImageToolDef, executeExtractImage };
 export {
   skillToolDef,
-  listSkillDraftsToolDef,
-  createSkillDraftToolDef,
-  updateSkillDraftToolDef,
-  deleteSkillDraftToolDef,
   executeSkill,
-  executeListSkillDrafts,
-  executeCreateSkillDraft,
-  executeUpdateSkillDraft,
-  executeDeleteSkillDraft,
 };
 export { bgFetchToolDef, executeBgFetch };
 export { artifactsTool, handleArtifactsTool };
@@ -99,17 +83,11 @@ export const ALL_TOOL_DEFS: ToolDefinition[] = [
   screenshotToolDef,
   extractImageToolDef,
   skillToolDef,
-  listSkillDraftsToolDef,
-  createSkillDraftToolDef,
-  updateSkillDraftToolDef,
-  deleteSkillDraftToolDef,
   artifactsTool,
   bgFetchToolDef,
 ];
 
-export const AGENT_TOOL_DEFS: ToolDefinition[] = ALL_TOOL_DEFS.filter(
-  (tool) => tool.name !== "skill",
-);
+export const AGENT_TOOL_DEFS: ToolDefinition[] = [...ALL_TOOL_DEFS];
 
 export function getAgentToolDefs(options?: { enableBgFetch?: boolean }): ToolDefinition[] {
   const enableBgFetch = options?.enableBgFetch ?? false;
@@ -189,26 +167,6 @@ export function createToolExecutorWithSkills(
       case "skill": {
         const tab = await browser.getActiveTab();
         return executeSkill(storage, skillRegistry, tab.url, args as SkillAction);
-      }
-      case "list_skill_drafts": {
-        return executeListSkillDrafts(storage);
-      }
-      case "create_skill_draft": {
-        return executeCreateSkillDraft(
-          storage,
-          skillRegistry,
-          args as unknown as CreateSkillDraftArgs,
-        );
-      }
-      case "update_skill_draft": {
-        return executeUpdateSkillDraft(
-          storage,
-          skillRegistry,
-          args as unknown as UpdateSkillDraftArgs,
-        );
-      }
-      case "delete_skill_draft": {
-        return executeDeleteSkillDraft(storage, args as unknown as DeleteSkillDraftArgs);
       }
       case "artifacts": {
         const artifactArgs = args as unknown as Parameters<typeof handleArtifactsTool>[0];

--- a/src/features/tools/skill.ts
+++ b/src/features/tools/skill.ts
@@ -25,7 +25,11 @@ export type SkillAction =
   | { action: "create"; data: Skill }
   | { action: "update"; id: string; updates: Partial<Skill> }
   | { action: "patch"; id: string; patches: SkillPatches }
-  | { action: "delete"; id: string };
+  | { action: "delete"; id: string }
+  | { action: "list_drafts" }
+  | { action: "create_draft"; data: CreateSkillDraftArgs }
+  | { action: "update_draft"; id: string; updates: Partial<CreateSkillDraftArgs> }
+  | { action: "delete_draft"; id: string };
 
 export type SkillPatches = {
   [K in keyof Skill]?: {
@@ -133,197 +137,11 @@ export type SkillResult =
   | SkillGetResult
   | SkillCreateResult
   | SkillUpdateResult
-  | SkillDeleteResult;
-
-export const listSkillDraftsToolDef: ToolDefinition = {
-  name: "list_skill_drafts",
-  description: `承認待ちの Skill 下書き一覧を取得するツール。
-
-各下書きの draftId、名前、説明、バリデーション状態などを返します。
-update_skill_draft で下書きを更新する際に draftId を確認するために使用してください。`,
-  parameters: {
-    type: "object",
-    properties: {},
-  },
-};
-
-export const createSkillDraftToolDef: ToolDefinition = {
-  name: "create_skill_draft",
-  description: `チャットから Skill の下書きを作成するツール。
-
-このツールは下書きとして保存されますが、custom skill としては保存されません。
-validation 結果を返し、Settings の下書き一覧で内容を確認したうえで明示承認した時だけ custom skill に反映されます。
-
-## バリデーションルール
-
-### reject になるエラー（必ず回避すること）
-- code 内で **ナビゲーション操作は禁止**: window.location, location.href=, location.assign(), location.replace(), location.reload(), history.pushState(), history.replaceState()
-- code 内で **危険な関数は禁止**: eval(), Function(), new Function(), setTimeout("string"), document.write(), .constructor.constructor(), .submit(), new Image()
-- scope が "site" のとき **matchers.hosts は必須**で1つ以上のホストが必要
-- 各 extractor に **id, name, description, code, outputSchema** はすべて必須
-- **括弧の対応が不一致**（(), [], {} のバランス）
-
-### warning（承認可能だが品質向上のため推奨）
-- description が **10文字未満**だと警告 → 用途がわかる具体的な説明にする
-- outputSchema が "unknown" だと警告 → 返却値の型を具体的に記述する（例: "{ title: string, url: string }"）
-- code に **return 文がない**と警告 → 明示的に return で結果を返す
-- code 内の fetch(), XMLHttpRequest, WebSocket は警告（使用可能だが注意）
-
-### 自動補正
-- code が bare code（return document.title; など）の場合は自動的に function () { ... } でラップされる
-- matchers.hosts は自動的に小文字に正規化される
-- name から id が自動生成される（英数字・ハイフンのスラッグ化）`,
-  parameters: {
-    type: "object",
-    properties: {
-      name: { type: "string", description: "Skill の表示名" },
-      description: { type: "string", description: "Skill の説明" },
-      scope: {
-        type: "string",
-        enum: ["site", "global"],
-        description: "Skill のスコープ。省略時は site。",
-      },
-      matchers: {
-        type: "object",
-        description: "Skill のマッチ条件",
-        properties: {
-          hosts: {
-            type: "array",
-            items: { type: "string" },
-            description: "マッチ対象のホスト名（例: amazon.co.jp）",
-          },
-          paths: {
-            type: "array",
-            items: { type: "string" },
-            description:
-              "マッチ対象のパスパターン（省略可）。* は単一セグメント、** は複数セグメントにマッチ。例: /articles/* は /articles/slug にマッチ、/articles/** は /articles/slug/edit にもマッチ。ワイルドカードなしは前方一致。",
-          },
-          signals: {
-            type: "array",
-            items: { type: "string" },
-            description: "マッチ対象のシグナル（省略可）",
-          },
-        },
-        required: ["hosts"],
-      },
-      extractors: {
-        type: "array",
-        description: "Skill extractor の配列",
-        items: {
-          type: "object",
-          properties: {
-            id: { type: "string", description: "Extractor の識別子（英数字・ハイフン）" },
-            name: { type: "string", description: "Extractor の表示名" },
-            description: { type: "string", description: "Extractor が何を抽出するかの説明" },
-            selector: { type: "string", description: "対象要素の CSS セレクタ（省略可）" },
-            code: {
-              type: "string",
-              description:
-                "抽出ロジックの JavaScript コード。`function () { ... }` 形式が望ましいが、bare code（例: `return document.title;`）でも自動的に function でラップされる。return で結果を返すこと。",
-            },
-            outputSchema: {
-              type: "string",
-              description: "出力の型（例: 'string', 'Array<{title: string, price: string}>'）",
-            },
-          },
-          required: ["id", "name", "description", "code", "outputSchema"],
-        },
-      },
-    },
-    required: ["name", "description", "matchers", "extractors"],
-  },
-};
-
-export const updateSkillDraftToolDef: ToolDefinition = {
-  name: "update_skill_draft",
-  description: `既存の Skill 下書きを更新するツール。
-
-draftId で指定した承認待ちの下書きに対して、部分的な変更を適用します。
-変更後に再度 validation が実行され、結果が返されます。
-指定しなかったフィールドは元の値が維持されます。
-
-- matchers: フィールド単位でマージ（例: hosts のみ指定すると paths は既存値を維持）
-- extractors: 指定時は全置換（既存の extractors は破棄される）
-
-バリデーションルールは create_skill_draft と同一です。`,
-  parameters: {
-    type: "object",
-    properties: {
-      draftId: { type: "string", description: "更新対象の下書き ID" },
-      updates: {
-        type: "object",
-        description: "更新するフィールド（部分更新）",
-        properties: {
-          name: { type: "string", description: "Skill の表示名" },
-          description: { type: "string", description: "Skill の説明" },
-          scope: {
-            type: "string",
-            enum: ["site", "global"],
-            description: "Skill のスコープ",
-          },
-          matchers: {
-            type: "object",
-            description: "Skill のマッチ条件",
-            properties: {
-              hosts: {
-                type: "array",
-                items: { type: "string" },
-                description: "マッチ対象のホスト名",
-              },
-              paths: {
-                type: "array",
-                items: { type: "string" },
-                description:
-                  "マッチ対象のパスパターン。* は単一セグメント、** は複数セグメントにマッチ。",
-              },
-              signals: {
-                type: "array",
-                items: { type: "string" },
-                description: "マッチ対象のシグナル",
-              },
-            },
-          },
-          extractors: {
-            type: "array",
-            description: "Skill extractor の配列（指定時は全置換）",
-            items: {
-              type: "object",
-              properties: {
-                id: { type: "string", description: "Extractor の識別子" },
-                name: { type: "string", description: "Extractor の表示名" },
-                description: { type: "string", description: "Extractor の説明" },
-                selector: { type: "string", description: "CSS セレクタ（省略可）" },
-                code: {
-                  type: "string",
-                  description:
-                    "抽出ロジックの JavaScript コード。bare code でも自動的に function でラップされる。return で結果を返すこと。",
-                },
-                outputSchema: { type: "string", description: "出力の型" },
-              },
-              required: ["id", "name", "description", "code", "outputSchema"],
-            },
-          },
-        },
-      },
-    },
-    required: ["draftId", "updates"],
-  },
-};
-
-export const deleteSkillDraftToolDef: ToolDefinition = {
-  name: "delete_skill_draft",
-  description: `既存の Skill 下書きを破棄するツール。
-
-draftId で指定した承認待ちの下書きを削除します。
-validation が reject の下書きを捨てて作り直したい時にも使用できます。`,
-  parameters: {
-    type: "object",
-    properties: {
-      draftId: { type: "string", description: "削除対象の下書き ID" },
-    },
-    required: ["draftId"],
-  },
-};
+  | SkillDeleteResult
+  | CreateSkillDraftResult
+  | UpdateSkillDraftResult
+  | ListSkillDraftsResult
+  | DeleteSkillDraftResult;
 
 // ============ Tool Definition ============
 
@@ -396,13 +214,84 @@ call skill({
 ### 6. delete - スキル削除
 指定したIDのスキルを削除する。
 
-call skill({ action: "delete", id: "old-skill" })`,
+call skill({ action: "delete", id: "old-skill" })
+
+### 7. list_drafts - 承認待ち下書き一覧
+承認待ちの Skill 下書き一覧を取得する。update_draft / delete_draft に使う下書き ID も返す。
+
+call skill({ action: "list_drafts" })
+
+### 8. create_draft - スキル下書き作成
+チャットから Skill の下書きを作成する。下書きとして保存されるが、custom skill としては保存されません。
+validation 結果を返し、Settings の下書き一覧で内容を確認したうえで明示承認した時だけ custom skill に反映される。
+
+call skill({
+  action: "create_draft",
+  data: {
+    name: "Example Draft Skill",
+    description: "説明文",
+    scope: "site",
+    matchers: { hosts: ["example.com"] },
+    extractors: [{
+      id: "getTitle",
+      name: "タイトル取得",
+      description: "ページタイトルを取得",
+      code: "function () { return document.title; }",
+      outputSchema: "string"
+    }]
+  }
+})
+
+### 9. update_draft - 下書き更新
+指定した下書き ID に部分更新を適用する。matchers はフィールド単位でマージ、extractors は指定時に全置換。
+
+call skill({
+  action: "update_draft",
+  id: "draft-id",
+  updates: { description: "より具体的な説明" }
+})
+
+### 10. delete_draft - 下書き破棄
+指定した下書き ID の承認待ち Skill 下書きを削除する。
+
+call skill({ action: "delete_draft", id: "draft-id" })
+
+## 下書きバリデーション
+
+### reject になるエラー（必ず回避すること）
+- code 内で **ナビゲーション操作は禁止**: window.location, location.href=, location.assign(), location.replace(), location.reload(), history.pushState(), history.replaceState()
+- code 内で **危険な関数は禁止**: eval(), Function(), new Function(), setTimeout("string"), document.write(), .constructor.constructor(), .submit(), new Image()
+- scope が "site" のとき **matchers.hosts は必須**で1つ以上のホストが必要
+- 各 extractor に **id, name, description, code, outputSchema** はすべて必須
+- **括弧の対応が不一致**（(), [], {} のバランス）
+
+### warning（承認可能だが品質向上のため推奨）
+- description が **10文字未満**だと警告 → 用途がわかる具体的な説明にする
+- outputSchema が "unknown" だと警告 → 返却値の型を具体的に記述する（例: "{ title: string, url: string }"）
+- code に **return 文がない**と警告 → 明示的に return で結果を返す
+- code 内の fetch(), XMLHttpRequest, WebSocket は警告（使用可能だが注意）
+
+### 自動補正
+- code が bare code（return document.title; など）の場合は自動的に function () { ... } でラップされる
+- matchers.hosts は自動的に小文字に正規化される
+- name から id が自動生成される（英数字・ハイフンのスラッグ化）`,
   parameters: {
     type: "object",
     properties: {
       action: {
         type: "string",
-        enum: ["list", "get", "create", "update", "patch", "delete"],
+        enum: [
+          "list",
+          "get",
+          "create",
+          "update",
+          "patch",
+          "delete",
+          "list_drafts",
+          "create_draft",
+          "update_draft",
+          "delete_draft",
+        ],
         description: "実行するアクション",
       },
       url: {
@@ -411,7 +300,8 @@ call skill({ action: "delete", id: "old-skill" })`,
       },
       id: {
         type: "string",
-        description: "get/update/patch/deleteアクションで使用。対象スキルのID。",
+        description:
+          "get/update/patch/delete では対象スキル ID、update_draft/delete_draft では対象下書き ID。",
       },
       includeLibraryCode: {
         type: "boolean",
@@ -419,11 +309,11 @@ call skill({ action: "delete", id: "old-skill" })`,
       },
       data: {
         type: "object",
-        description: "createアクションで使用。作成するスキルデータ。",
+        description: "create では作成するスキルデータ、create_draft では作成する下書きデータ。",
       },
       updates: {
         type: "object",
-        description: "updateアクションで使用。更新するフィールド。",
+        description: "update または update_draft で使用。更新するフィールド。",
       },
       patches: {
         type: "object",
@@ -436,25 +326,65 @@ call skill({ action: "delete", id: "old-skill" })`,
 
 // ============ Execute Function ============
 
+function invalidSkillArgs(message: string): Result<never, ToolError> {
+  return err({ code: "tool_script_error", message });
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 export async function executeSkill(
   storage: StoragePort,
   registry: SkillRegistry,
   currentUrl: string | undefined,
   args: SkillAction,
 ): Promise<Result<SkillResult, ToolError>> {
+  if (typeof args !== "object" || args === null || typeof args.action !== "string") {
+    return err({
+      code: "tool_script_error",
+      message: "skill arguments must be an object with action",
+    });
+  }
+
   switch (args.action) {
     case "list":
       return executeList(registry, args.url ?? currentUrl);
     case "get":
       return executeGet(registry, args.id, args.includeLibraryCode ?? false);
     case "create":
-      return executeCreate(storage, registry, args.data);
+      return isPlainObject(args.data)
+        ? executeCreate(storage, registry, args.data as Skill)
+        : invalidSkillArgs("create action requires data");
     case "update":
-      return executeUpdate(storage, registry, args.id, args.updates);
+      return typeof args.id === "string" && isPlainObject(args.updates)
+        ? executeUpdate(storage, registry, args.id, args.updates as Partial<Skill>)
+        : invalidSkillArgs("update action requires id and updates");
     case "patch":
-      return executePatch(storage, registry, args.id, args.patches);
+      return typeof args.id === "string" && isPlainObject(args.patches)
+        ? executePatch(storage, registry, args.id, args.patches as SkillPatches)
+        : invalidSkillArgs("patch action requires id and patches");
     case "delete":
-      return executeDelete(storage, registry, args.id);
+      return typeof args.id === "string"
+        ? executeDelete(storage, registry, args.id)
+        : invalidSkillArgs("delete action requires id");
+    case "list_drafts":
+      return executeListSkillDrafts(storage);
+    case "create_draft":
+      return isPlainObject(args.data)
+        ? executeCreateSkillDraft(storage, registry, args.data as CreateSkillDraftArgs)
+        : invalidSkillArgs("create_draft action requires data");
+    case "update_draft":
+      return typeof args.id === "string" && isPlainObject(args.updates)
+        ? executeUpdateSkillDraft(storage, registry, {
+            draftId: args.id,
+            updates: args.updates as Partial<CreateSkillDraftArgs>,
+          })
+        : invalidSkillArgs("update_draft action requires id and updates");
+    case "delete_draft":
+      return typeof args.id === "string"
+        ? executeDeleteSkillDraft(storage, { draftId: args.id })
+        : invalidSkillArgs("delete_draft action requires id");
     default:
       return err({
         code: "tool_script_error",
@@ -614,7 +544,7 @@ export async function executeDeleteSkillDraft(
   if (typeof args !== "object" || args === null) {
     return err({
       code: "tool_script_error",
-      message: "delete_skill_draft arguments must be an object",
+      message: "skill(action: \"delete_draft\") arguments must be an object",
     });
   }
 
@@ -1100,7 +1030,7 @@ function parseCreateSkillDraftArgs(
   args: CreateSkillDraftArgs,
 ): { ok: true; value: CreateSkillDraftArgs } | { ok: false; error: string } {
   if (typeof args !== "object" || args === null) {
-    return { ok: false, error: "create_skill_draft arguments must be an object" };
+    return { ok: false, error: "skill(action: \"create_draft\") arguments must be an object" };
   }
 
   if (typeof args.name !== "string") {


### PR DESCRIPTION
## Summary
- add draft management actions to the `skill` tool and route them through the existing draft handlers
- remove the four top-level skill draft tool registrations and expose `skill` to agent tool lists
- update tool tests to cover the unified `skill(action: ...)` flow and malformed argument handling

## Testing
- pnpm vitest run src/features/tools

Closes #85
