### PR TITLE
fix(ai): align context-budget logs with token estimates

### DIFF
--- a/src/features/ai/__tests__/context-budget.test.ts
+++ b/src/features/ai/__tests__/context-budget.test.ts
@@ -85,17 +85,21 @@ describe("buildContextBudgetBreakdown", () => {
       latestToolResultIds: new Set(["tool-latest"]),
     });
 
-    expect(breakdown.systemPromptTokens).toBe("system prompt".length);
+    expect(breakdown.systemPromptTokens).toBe(Math.ceil("system prompt".length / 4));
     expect(breakdown.toolsTokens).toBe(
-      JSON.stringify([
-        {
-          name: "read_page",
-          description: "Read the current page",
-          parameters: { type: "object", properties: { depth: { type: "number" } } },
-        },
-      ]).length,
+      Math.ceil(
+        JSON.stringify([
+          {
+            name: "read_page",
+            description: "Read the current page",
+            parameters: { type: "object", properties: { depth: { type: "number" } } },
+          },
+        ]).length / 4,
+      ),
     );
-    expect(breakdown.historyTokens).toBe("hello".length + "world".length + "old result".length);
-    expect(breakdown.toolResultsTokens).toBe("latest result".length);
+    expect(breakdown.historyTokens).toBe(
+      Math.ceil(("hello".length + "world".length + "old result".length) / 4),
+    );
+    expect(breakdown.toolResultsTokens).toBe(Math.ceil("latest result".length / 4));
   });
 });

--- a/src/features/ai/context-budget.ts
+++ b/src/features/ai/context-budget.ts
@@ -6,6 +6,23 @@ import { estimateTokens } from "@/shared/token-utils";
 
 const log = createLogger("context-budget");
 const CONTEXT_BUDGET_LOG_PREFIX = "[ctx-budget]";
+const APPROX_CHARS_PER_TOKEN = 4;
+
+function toApproxTokens(charCount: number): number {
+  return Math.ceil(charCount / APPROX_CHARS_PER_TOKEN);
+}
+
+function estimateTextTokens(text: string): number {
+  return toApproxTokens(text.length);
+}
+
+function estimateSerializedTokens(value: unknown): number {
+  return estimateTextTokens(JSON.stringify(value));
+}
+
+function estimateMessageTokens(messages: AIMessage[]): number {
+  return toApproxTokens(estimateTokens(messages));
+}
 
 export interface ContextBudget {
   windowTokens: number;
@@ -80,10 +97,10 @@ export function buildContextBudgetBreakdown(input: {
   }
 
   return {
-    systemPromptTokens: input.systemPrompt.length,
-    toolsTokens: JSON.stringify(input.tools).length,
-    historyTokens: estimateTokens(historyMessages),
-    toolResultsTokens: estimateTokens(latestToolResultMessages),
+    systemPromptTokens: estimateTextTokens(input.systemPrompt),
+    toolsTokens: estimateSerializedTokens(input.tools),
+    historyTokens: estimateMessageTokens(historyMessages),
+    toolResultsTokens: estimateMessageTokens(latestToolResultMessages),
   };
 }
 

--- a/src/orchestration/__tests__/agent-loop.test.ts
+++ b/src/orchestration/__tests__/agent-loop.test.ts
@@ -1108,9 +1108,9 @@ describe("context budget integration", () => {
       "[ctx-budget]",
       expect.objectContaining({
         phase: "finish",
-        systemPromptTokens: "system prompt".length,
-        toolsTokens: JSON.stringify(params.tools).length,
-        historyTokens: "hello world".length,
+        systemPromptTokens: Math.ceil("system prompt".length / 4),
+        toolsTokens: Math.ceil(JSON.stringify(params.tools).length / 4),
+        historyTokens: Math.ceil("hello world".length / 4),
         toolResultsTokens: 0,
         reasoningTokens: 9,
         promptCacheReadTokens: 60,


### PR DESCRIPTION
## Summary
- convert context-budget breakdown fields to approximate token counts using a 4 chars/token heuristic
- keep existing prompt-cache and reasoning metrics logging intact
- update tests to assert token-estimate values instead of raw character counts

## Testing
- pnpm vitest

Closes #84