### PR TITLE
[Phase 1-B] bg_fetch / read_page の重複ドキュメント解消

### DIFF
--- a/src/features/tools/__tests__/integration.test.ts
+++ b/src/features/tools/__tests__/integration.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   executeReadPage,
   readPageToolDef,
+  bgFetchToolDef,
   createToolExecutorWithSkills,
   ALL_TOOL_DEFS,
   AGENT_TOOL_DEFS,
@@ -147,10 +148,18 @@ describe("2段階抽出ワークフロー", () => {
       expect(new Set(names).size).toBe(names.length);
     });
 
-    it("read_page の description が軽量抽出と簡潔な repl 誘導を含む", () => {
+    it("read_page の description が軽量抽出と1行の repl 誘導のみを含む", () => {
       expect(readPageToolDef.description).toContain("軽量");
-      expect(readPageToolDef.description).toContain("複数ページを跨ぐ場合は `repl` で loop 制御");
+      expect(readPageToolDef.description).toContain("複数ページを跨ぐ場合は `repl` で loop 制御する。");
+      expect(readPageToolDef.description).not.toContain("artifact");
       expect(readPageToolDef.description).not.toContain("```javascript");
+    });
+
+    it("bg_fetch の description が SSOT として詳細な使い分けを保持する", () => {
+      expect(bgFetchToolDef.description).toContain("repl 内 helper の bgFetch() も同じ使い分けに従う");
+      expect(bgFetchToolDef.description).toContain("5URL以上を取得する場合");
+      expect(bgFetchToolDef.description).toContain("createOrUpdateArtifact()");
+      expect(bgFetchToolDef.description).toContain("MAX_TURNS");
     });
 
     it("全ツール定義が parameters.type を持つ", () => {

--- a/src/features/tools/providers/__tests__/fetch-provider.test.ts
+++ b/src/features/tools/providers/__tests__/fetch-provider.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { FetchProvider } from "../fetch-provider";
 import type { ProviderContext } from "@/ports/runtime-provider";
+import { buildBgFetchHelperDescription } from "@/shared/repl-description-sections";
 import type { BgFetchMessage, BgFetchResponse } from "@/shared/message-types";
 import { useStore } from "@/store/index";
 
@@ -41,10 +42,9 @@ describe("FetchProvider", () => {
     expect(code).toContain("action: 'bgFetch'");
   });
 
-  it("getDescription は bgFetch の signature と top-level 参照のみを含む", () => {
+  it("getDescription は repl description と同じ bgFetch helper 説明を再利用する", () => {
     const description = new FetchProvider().getDescription();
-    expect(description).toContain("bgFetch(url, options?)");
-    expect(description).toContain("top-level `bg_fetch` tool description");
+    expect(description).toBe(buildBgFetchHelperDescription());
     expect(description).not.toContain("When to Use");
     expect(description).not.toContain("Do NOT Use For");
     expect(description).not.toContain("Collected ");

--- a/src/features/tools/providers/fetch-provider.ts
+++ b/src/features/tools/providers/fetch-provider.ts
@@ -1,6 +1,7 @@
 import type { RuntimeProvider, SandboxRequest, ProviderContext } from "@/ports/runtime-provider";
 import type { Result, ToolError } from "@/shared/errors";
 import { ok, err } from "@/shared/errors";
+import { buildBgFetchHelperDescription } from "@/shared/repl-description-sections";
 import type { BgFetchMessage, BgFetchResponse } from "@/shared/message-types";
 import { useStore } from "@/store/index";
 
@@ -32,30 +33,7 @@ export class FetchProvider implements RuntimeProvider {
   readonly actions = ["bgFetch"] as const;
 
   getDescription(): string {
-    return `## bgFetch(url, options?)
-
-詳しい使い分けは top-level \`bg_fetch\` tool description を参照。\`enableBgFetch\` トグルも top-level \`bg_fetch\` と共有し、無効時は \`bgFetch\` も使えない。
-
-### Signature
-
-\`\`\`ts
-bgFetch(url: string, options?: {
-  method?: "GET" | "POST" | "PUT" | "PATCH" | "DELETE" | "HEAD" | "OPTIONS",
-  headers?: Record<string, string>,
-  body?: string,
-  responseType?: "text" | "json" | "base64" | "readability",  // default: "text"
-  timeout?: number,                                             // ms, default 30000, max 60000
-}): Promise<{
-  url: string,
-  ok: boolean,
-  status: number,
-  statusText: string,
-  headers: Record<string, string>,
-  body: string | object,
-  redirected?: boolean,
-  redirectUrl?: string,
-}>
-\`\`\``;
+    return buildBgFetchHelperDescription();
   }
 
   getRuntimeCode(): string {

--- a/src/features/tools/read-page.ts
+++ b/src/features/tools/read-page.ts
@@ -6,7 +6,7 @@ import { err } from "@/shared/errors";
 export const readPageToolDef: ToolDefinition = {
   name: "read_page",
   description:
-    "現在のアクティブタブ **1ページのみ** の主要コンテンツを軽量抽出する。タイトル、本文（プレーンテキスト）、メタ情報を返す。\n\n**2ページ以上を順に収集する用途ではこのツールを使わないこと。** ループで呼ぶと毎ページ分の本文が AI コンテキストに積み上がってトークンを浪費する。複数ページを跨ぐ場合は `repl` で loop 制御し、結果は artifact に保存する。\n\nより詳細な抽出が必要な場合も、`repl` の `browserjs()` を使用する。",
+    "現在のアクティブタブ **1ページのみ** の主要コンテンツを軽量抽出する。タイトル、本文（プレーンテキスト）、メタ情報を返す。\n\n**2ページ以上を順に収集する用途ではこのツールを使わないこと。** 複数ページを跨ぐ場合は `repl` で loop 制御する。\n\nより詳細な抽出が必要な場合は `repl` の `browserjs()` を使用する。",
   parameters: {
     type: "object",
     properties: {},

--- a/src/shared/__tests__/repl-description-sections.test.ts
+++ b/src/shared/__tests__/repl-description-sections.test.ts
@@ -11,11 +11,13 @@ describe("assembleReplDescriptionSections", () => {
     expect(out).toContain("Common Patterns");
   });
 
-  it("デフォルト (enableBgFetch 省略) では bgFetch の signature と参照を含む", () => {
+  it("デフォルト (enableBgFetch 省略) では bgFetch の signature と参照のみを含む", () => {
     const out = assembleReplDescriptionSections(["AVAILABLE_FUNCTIONS"]);
     expect(out).toContain("bgFetch(url, options?)");
     expect(out).toContain("詳しい使い分けは top-level `bg_fetch` tool description を参照");
-    expect(out).not.toContain("Fetch an external URL via the background service worker");
+    expect(out).not.toContain("5URL以上を取得する場合");
+    expect(out).not.toContain("MAX_TURNS");
+    expect(out).not.toContain("CORSを回避してあらゆるURLにアクセス可能");
     // sentinel 行は出力に残してはいけない
     expect(out).not.toContain("BG_FETCH_SECTION_START");
     expect(out).not.toContain("BG_FETCH_SECTION_END");

--- a/src/shared/repl-description-sections.ts
+++ b/src/shared/repl-description-sections.ts
@@ -121,6 +121,31 @@ export const COMMON_PATTERNS = [
   "4. If lazy-loaded, scroll first with nativeScroll()",
 ].join("\n");
 
+const BG_FETCH_HELPER_DESCRIPTION_LINES = [
+  "## bgFetch(url, options?)",
+  "",
+  "詳しい使い分けは top-level `bg_fetch` tool description を参照。`enableBgFetch` トグルも top-level `bg_fetch` と共有し、無効時は `bgFetch` も使えない。",
+  "",
+  "### Signature",
+  "```ts",
+  "bgFetch(url: string, options?: {",
+  '  method?: "GET" | "POST" | "PUT" | "PATCH" | "DELETE" | "HEAD" | "OPTIONS",',
+  "  headers?: Record<string, string>,",
+  "  body?: string,",
+  '  responseType?: "text" | "json" | "base64" | "readability",  // default: "text"',
+  "  timeout?: number,  // ms, default 30000, max 60000",
+  "}): Promise<{",
+  "  url: string, ok: boolean, status: number, statusText: string,",
+  "  headers: Record<string, string>, body: string | object,",
+  "  redirected?: boolean, redirectUrl?: string,",
+  "}>",
+  "```",
+];
+
+export function buildBgFetchHelperDescription(): string {
+  return BG_FETCH_HELPER_DESCRIPTION_LINES.join("\n");
+}
+
 export const AVAILABLE_FUNCTIONS = [
   "# Available Functions",
   "",
@@ -276,24 +301,7 @@ export const AVAILABLE_FUNCTIONS = [
   "```",
   "",
   "<!-- BG_FETCH_SECTION_START -->",
-  "## bgFetch(url, options?)",
-  "",
-  "詳しい使い分けは top-level `bg_fetch` tool description を参照。`enableBgFetch` トグルも top-level `bg_fetch` と共有し、無効時は `bgFetch` も使えない。",
-  "",
-  "### Signature",
-  "```ts",
-  "bgFetch(url: string, options?: {",
-  '  method?: "GET" | "POST" | "PUT" | "PATCH" | "DELETE" | "HEAD" | "OPTIONS",',
-  "  headers?: Record<string, string>,",
-  "  body?: string,",
-  '  responseType?: "text" | "json" | "base64" | "readability",  // default: "text"',
-  "  timeout?: number,  // ms, default 30000, max 60000",
-  "}): Promise<{",
-  "  url: string, ok: boolean, status: number, statusText: string,",
-  "  headers: Record<string, string>, body: string | object,",
-  "  redirected?: boolean, redirectUrl?: string,",
-  "}>",
-  "```",
+  ...BG_FETCH_HELPER_DESCRIPTION_LINES,
   "<!-- BG_FETCH_SECTION_END -->",
   "",
   "## Artifact Functions (Data Persistence)",


### PR DESCRIPTION
## Summary\n- dedupe bgFetch helper description by reusing a shared helper description block\n- keep bg_fetch as the SSOT for usage guidance while leaving repl helper text as signature + reference only\n- shorten read_page guidance to a one-line repl loop note and update tests\n\n## Testing\n- pnpm vitest\n