### PR TITLE
fix: resolve regressions from parallel Wave 1 merges

### DIFF
--- a/src/features/chat/tool-renderers/components.tsx
+++ b/src/features/chat/tool-renderers/components.tsx
@@ -925,6 +925,73 @@ export const extractImageToolRenderer: ToolRenderer = {
   }),
 };
 
+function InspectGenericFallbackView({ toolCall }: ToolRendererContext) {
+  const args = toolCall.args && typeof toolCall.args === "object" ? toolCall.args : {};
+  const argsStr = Object.keys(args).length > 0 ? JSON.stringify(args, null, 2) : null;
+  const resultStr =
+    typeof toolCall.result === "string"
+      ? toolCall.result
+      : toolCall.result !== undefined
+        ? JSON.stringify(toolCall.result, null, 2)
+        : null;
+
+  return (
+    <>
+      {argsStr && (
+        <ScrollableResult maxHeight={150}>
+          <Code block style={{ fontSize: 13 }}>
+            {argsStr}
+          </Code>
+        </ScrollableResult>
+      )}
+      {toolCall.isRunning && !resultStr && (
+        <Group gap="xs" mt="xs">
+          <Loader size={14} />
+          <Text size="sm" c="dimmed">
+            Running {toolCall.name}...
+          </Text>
+        </Group>
+      )}
+      {resultStr && (
+        <ScrollableResult maxHeight={200}>
+          <Code block style={{ fontSize: 13 }}>
+            {resultStr}
+          </Code>
+        </ScrollableResult>
+      )}
+    </>
+  );
+}
+
+function InspectRendererView(context: ToolRendererContext) {
+  const args = context.toolCall.args && typeof context.toolCall.args === "object"
+    ? (context.toolCall.args as { action?: string })
+    : {};
+  if (args.action === "extract_image") {
+    return <ExtractImageRendererView {...context} />;
+  }
+  return <InspectGenericFallbackView {...context} />;
+}
+
+export const inspectToolRenderer: ToolRenderer = {
+  renderExecuting: (context) => <InspectRendererView {...context} />,
+  renderSuccess: (context) => <InspectRendererView {...context} />,
+  renderError: (context) => <InspectRendererView {...context} />,
+  renderSummary: createSummaryRenderer((toolCall) => {
+    const args = toolCall.args && typeof toolCall.args === "object" ? toolCall.args : {};
+    const action = typeof (args as { action?: unknown }).action === "string"
+      ? (args as { action: string }).action
+      : null;
+    if (action === "extract_image") {
+      const selector = typeof (args as { selector?: unknown }).selector === "string"
+        ? (args as { selector: string }).selector
+        : toolCall.name;
+      return <Text size="sm">{selector}</Text>;
+    }
+    return <Text size="sm">{action ?? toolCall.name}</Text>;
+  }),
+};
+
 export const artifactsToolRenderer: ToolRenderer = {
   renderExecuting: (context) => <ArtifactsRendererView {...context} />,
   renderSuccess: (context) => <ArtifactsRendererView {...context} />,

--- a/src/features/chat/tool-renderers/index.ts
+++ b/src/features/chat/tool-renderers/index.ts
@@ -1,13 +1,13 @@
 import { defaultConsoleLogService } from "../services/console-log";
 import { bgFetchToolRenderer } from "./bg-fetch-renderer";
-import { artifactsToolRenderer, extractImageToolRenderer, replToolRenderer } from "./components";
+import { artifactsToolRenderer, inspectToolRenderer, replToolRenderer } from "./components";
 import { ToolRendererRegistry } from "./registry";
 
 export function createDefaultToolRendererRegistry(consoleLogService = defaultConsoleLogService) {
   const registry = new ToolRendererRegistry();
   void consoleLogService;
   registry.register("repl", replToolRenderer);
-  registry.register("inspect", extractImageToolRenderer);
+  registry.register("inspect", inspectToolRenderer);
   registry.register("artifacts", artifactsToolRenderer);
   registry.register("bg_fetch", bgFetchToolRenderer);
   return registry;

--- a/src/features/tools/__tests__/skill.test.ts
+++ b/src/features/tools/__tests__/skill.test.ts
@@ -17,12 +17,10 @@ import {
   type ListSkillDraftsResult,
   type DeleteSkillDraftResult,
   type SkillPatches,
-  type CreateSkillDraftArgs,
 } from "../skill";
 import { SkillRegistry } from "../skills";
 import { InMemoryStorage } from "@/adapters/storage/in-memory-storage";
-import { saveCustomSkills } from "@/shared/test-fixtures/skills";
-import { approveSkillDraft } from "@/shared/test-fixtures/skills";
+import { saveCustomSkills, approveSkillDraft } from "@/shared/test-fixtures/skills";
 import type { Skill } from "@/shared/skill-types";
 import type { StoredSkillDraft } from "@/shared/skill-draft-types";
 import { loadSkillRegistry } from "../skills/skill-loader";


### PR DESCRIPTION
## Summary
- `skill.test.ts` で `CreateSkillDraftArgs` が重複 import されていた (#115 と #116 が同修正を独立して含んでいたため、マージ後に duplicate)
- `inspect` tool の registry 登録を dispatching renderer にして、`action=extract_image` は画像プレビューを維持、`action=pick_element|screenshot` は汎用フォールバックで args/result を表示

## Test plan
- [x] pnpm vitest run (967/967 passing)
- [x] pnpm tsc --noEmit (clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)