### PR TITLE
feat(ai): diff skill injection with shownSkillIds (#91)

### DIFF
--- a/src/features/ai/__tests__/prompt-cache.test.ts
+++ b/src/features/ai/__tests__/prompt-cache.test.ts
@@ -15,11 +15,18 @@ describe("createPromptCacheKey", () => {
     expect(firstKey).toBe(secondKey);
   });
 
-  it("returns different key for different options", () => {
+  it("returns different key for different locale options", () => {
+    const firstKey = createPromptCacheKey({ locale: "ja-JP" });
+    const secondKey = createPromptCacheKey({ locale: "en-US" });
+
+    expect(firstKey).not.toBe(secondKey);
+  });
+
+  it("returns same key regardless of includeSkills (skills section is cache-exempt)", () => {
     const firstKey = createPromptCacheKey({ includeSkills: true });
     const secondKey = createPromptCacheKey({ includeSkills: false });
 
-    expect(firstKey).not.toBe(secondKey);
+    expect(firstKey).toBe(secondKey);
   });
 
   it("ignores enableBgFetch because system prompt content no longer varies by that flag", () => {
@@ -29,7 +36,7 @@ describe("createPromptCacheKey", () => {
     expect(enabledKey).toBe(disabledKey);
   });
 
-  it("produces stable key regardless of skill object property order", () => {
+  it("produces same key regardless of skills (skills section is cache-exempt)", () => {
     const makeSkill = (id: string) => ({
       skill: {
         id,
@@ -52,6 +59,7 @@ describe("createPromptCacheKey", () => {
       skills: [makeSkill("b"), makeSkill("a")],
     });
 
+    // Skills are excluded from cache key since skills section is rendered per-turn
     expect(key1).toBe(key2);
   });
 });

--- a/src/features/ai/__tests__/system-prompt-v2.test.ts
+++ b/src/features/ai/__tests__/system-prompt-v2.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from "vitest";
 import { existsSync } from "node:fs";
 import path from "node:path";
-import { getSystemPromptV2, generateVisitedUrlsSection } from "../system-prompt-v2";
+import {
+  getSystemPromptV2,
+  generateVisitedUrlsSection,
+  generateSkillsSectionForLoop,
+  getActiveSkillIds,
+} from "../system-prompt-v2";
 import type { VisitedUrlEntry } from "../system-prompt-v2";
 import type { SkillMatch } from "@/shared/skill-types";
 
@@ -123,13 +128,101 @@ describe("getSystemPromptV2", () => {
 
   it("system prompt は bgFetch の記述を含まない (repl description 側で管理)", () => {
     for (const enableBgFetch of [true, false, undefined]) {
-      const prompt = getSystemPromptV2(
-        enableBgFetch === undefined ? {} : { enableBgFetch },
-      );
+      const prompt = getSystemPromptV2(enableBgFetch === undefined ? {} : { enableBgFetch });
       expect(prompt).not.toContain("bgFetch(url, options?)");
       expect(prompt).not.toContain("BG_FETCH_SECTION_START");
       expect(prompt).not.toContain("BG_FETCH_SECTION_END");
     }
+  });
+});
+
+describe("generateSkillsSectionForLoop / shownSkillIds diff rendering", () => {
+  function makeSkillMatch(id: string, name: string, scope?: "global"): SkillMatch {
+    const extractor = {
+      id: `${id}-ext`,
+      name: "Extractor",
+      description: "Gets data",
+      code: "function() {}",
+      outputSchema: "string",
+    };
+    return {
+      skill: {
+        id,
+        name,
+        description: `${name} description`,
+        matchers: scope ? { hosts: [] } : { hosts: [`${id}.com`] },
+        version: "0.0.0",
+        scope,
+        extractors: [extractor],
+      },
+      availableExtractors: [extractor],
+      confidence: 80,
+    };
+  }
+
+  it("renders full format when shownSkillIds is empty (first turn)", () => {
+    const match = makeSkillMatch("yt", "YouTube");
+    const section = generateSkillsSectionForLoop([match], new Set());
+    expect(section).toContain("**YouTube**");
+    expect(section).toContain("id: yt");
+    expect(section).toContain("yt-ext():");
+    expect(section).toContain("browserjs");
+  });
+
+  it("renders short format for already-seen skills (subsequent turns)", () => {
+    const match = makeSkillMatch("yt", "YouTube");
+    const shownSkillIds = new Set(["yt"]);
+    const section = generateSkillsSectionForLoop([match], shownSkillIds);
+    expect(section).toContain("- YouTube (id: yt):");
+    expect(section).not.toContain("**YouTube**");
+    expect(section).not.toContain("browserjs");
+    expect(section).not.toContain("yt-ext():");
+  });
+
+  it("renders full format for new skill and short format for seen skill", () => {
+    const seen = makeSkillMatch("yt", "YouTube");
+    const newSkill = makeSkillMatch("github", "GitHub");
+    const shownSkillIds = new Set(["yt"]);
+    const section = generateSkillsSectionForLoop([seen, newSkill], shownSkillIds);
+    // YouTube already seen → short
+    expect(section).toContain("- YouTube (id: yt):");
+    expect(section).not.toContain("**YouTube**");
+    // GitHub new → full
+    expect(section).toContain("**GitHub**");
+    expect(section).toContain("github-ext():");
+  });
+
+  it("getActiveSkillIds returns only skills with available extractors", () => {
+    const withExt = makeSkillMatch("yt", "YouTube");
+    const noExt: SkillMatch = {
+      ...withExt,
+      skill: { ...withExt.skill, id: "empty" },
+      availableExtractors: [],
+    };
+    const ids = getActiveSkillIds([withExt, noExt]);
+    expect(ids).toEqual(["yt"]);
+  });
+
+  it("getSystemPromptV2 with shownSkillIds renders short format for seen skill", () => {
+    const match = makeSkillMatch("yt", "YouTube");
+    const prompt = getSystemPromptV2({
+      includeSkills: true,
+      skills: [match],
+      shownSkillIds: new Set(["yt"]),
+    });
+    expect(prompt).toContain("- YouTube (id: yt):");
+    expect(prompt).not.toContain("**YouTube**");
+  });
+
+  it("getSystemPromptV2 with empty shownSkillIds renders full format", () => {
+    const match = makeSkillMatch("yt", "YouTube");
+    const prompt = getSystemPromptV2({
+      includeSkills: true,
+      skills: [match],
+      shownSkillIds: new Set(),
+    });
+    expect(prompt).toContain("**YouTube**");
+    expect(prompt).toContain("browserjs");
   });
 });
 

--- a/src/features/ai/index.ts
+++ b/src/features/ai/index.ts
@@ -1,3 +1,8 @@
 export type { SystemPromptOptions, VisitedUrlEntry } from "./system-prompt-v2";
-export { getSystemPromptV2, generateVisitedUrlsSection } from "./system-prompt-v2";
+export {
+  getSystemPromptV2,
+  generateVisitedUrlsSection,
+  generateSkillsSectionForLoop,
+  getActiveSkillIds,
+} from "./system-prompt-v2";
 export { PromptCache, createPromptCacheKey } from "./prompt-cache";

--- a/src/features/ai/prompt-cache.ts
+++ b/src/features/ai/prompt-cache.ts
@@ -9,23 +9,11 @@ interface CacheEntry {
 }
 
 /**
- * Build a stable, lightweight cache key from prompt options.
- * Uses only scalar flags and skill IDs (not full skill objects).
+ * Build a stable, lightweight cache key for the base (static) sections of the system prompt.
+ * Skills section is excluded from the cache because shownSkillIds changes per turn.
  */
 export function createPromptCacheKey(options: SystemPromptOptions): string {
-  const parts: string[] = [
-    `skills:${options.includeSkills ?? false}`,
-    `locale:${options.locale ?? "default"}`,
-  ];
-
-  if (options.includeSkills && options.skills) {
-    const ids = options.skills.map((m) => m.skill.id).sort();
-    parts.push(`ids:${ids.join(",")}`);
-    const availableIds = options.skills
-      .flatMap((m) => m.availableExtractors.map((e) => e.id))
-      .sort();
-    parts.push(`available:${availableIds.join(",")}`);
-  }
+  const parts: string[] = [`locale:${options.locale ?? "default"}`];
 
   return parts.join("|");
 }

--- a/src/features/ai/system-prompt-v2.ts
+++ b/src/features/ai/system-prompt-v2.ts
@@ -13,6 +13,7 @@ export interface VisitedUrlEntry {
 export interface SystemPromptOptions {
   includeSkills?: boolean;
   skills?: SkillMatch[];
+  shownSkillIds?: ReadonlySet<string>;
   locale?: string;
   visitedUrls?: VisitedUrlEntry[];
   enableBgFetch?: boolean;
@@ -37,7 +38,10 @@ function formatWindowSkillCall(skillId: string, extractorId: string): string {
   return `window${formatPropertyAccess(skillId)}${formatPropertyAccess(extractorId)}()`;
 }
 
-function generateSkillsSection(skills: SkillMatch[]): string {
+function generateSkillsSection(
+  skills: SkillMatch[],
+  shownSkillIds: ReadonlySet<string> = new Set(),
+): string {
   const active = skills.filter((m) => m.availableExtractors.length > 0);
 
   if (active.length === 0) {
@@ -55,7 +59,7 @@ function generateSkillsSection(skills: SkillMatch[]): string {
       "For well-known sites, use optimized extraction patterns:",
       "",
     );
-    sections.push(renderSkillEntries(siteSkills));
+    sections.push(renderSkillEntries(siteSkills, shownSkillIds));
   }
 
   if (globalSkills.length > 0) {
@@ -66,17 +70,29 @@ function generateSkillsSection(skills: SkillMatch[]): string {
       "These skills are available on any page and can be used when their extractor fits the task:",
       "",
     );
-    sections.push(renderSkillEntries(globalSkills));
+    sections.push(renderSkillEntries(globalSkills, shownSkillIds));
   }
 
   return sections.join("\n");
 }
 
-function renderSkillEntries(skills: SkillMatch[]): string {
+function renderSkillEntries(
+  skills: SkillMatch[],
+  shownSkillIds: ReadonlySet<string> = new Set(),
+): string {
   const lines: string[] = [];
 
   for (const match of skills) {
     const { skill, availableExtractors } = match;
+
+    if (shownSkillIds.has(skill.id)) {
+      // Short format for already-seen skills
+      lines.push(`- ${skill.name} (id: ${skill.id}): ${skill.description}`);
+      lines.push("");
+      continue;
+    }
+
+    // Full format for new skills
     const target = skill.scope === "global" ? "any page" : skill.matchers.hosts.join(", ");
     lines.push(`**${skill.name}** (id: ${skill.id}, ${target})`);
     lines.push(skill.description);
@@ -108,20 +124,46 @@ export function generateVisitedUrlsSection(entries: VisitedUrlEntry[]): string {
 }
 
 export function getSystemPromptV2(options: SystemPromptOptions): string {
-  const key = createPromptCacheKey(options);
-  const cached = cache.get(key);
+  // Cache only the static base sections (not skills, which vary by shownSkillIds)
+  const baseKey = createPromptCacheKey(options);
+  const cachedBase = cache.get(baseKey);
 
-  let base: string;
-  if (cached !== null) {
-    base = cached;
-  } else {
-    const baseSections = assembleSections(BASE_SECTIONS);
-    const skillsSection =
-      options.includeSkills && options.skills ? generateSkillsSection(options.skills) : "";
-    base = skillsSection ? `${baseSections}\n\n${skillsSection}` : baseSections;
-    cache.set(key, base);
-  }
+  const baseSections =
+    cachedBase ??
+    (() => {
+      const result = assembleSections(BASE_SECTIONS);
+      cache.set(baseKey, result);
+      return result;
+    })();
+
+  // Skills section is always regenerated (shownSkillIds changes per turn)
+  const skillsSection =
+    options.includeSkills && options.skills
+      ? generateSkillsSection(options.skills, options.shownSkillIds)
+      : "";
+
   const visitedSection = generateVisitedUrlsSection(options.visitedUrls ?? []);
-  const sections = [base, visitedSection].filter((section) => section.length > 0);
+  const sections = [baseSections, skillsSection, visitedSection].filter(
+    (section) => section.length > 0,
+  );
   return sections.join("\n\n");
+}
+
+/**
+ * Extract skill IDs from the active skills that will be sent in the prompt.
+ * Used by agent-loop to track which skills have been shown to the AI.
+ */
+export function getActiveSkillIds(skills: SkillMatch[]): string[] {
+  return skills.filter((m) => m.availableExtractors.length > 0).map((m) => m.skill.id);
+}
+
+/**
+ * Generate skills section string for use inside agent-loop per turn.
+ * Exposed separately so agent-loop can integrate shownSkillIds tracking.
+ */
+export function generateSkillsSectionForLoop(
+  skills: SkillMatch[],
+  shownSkillIds: ReadonlySet<string>,
+): string {
+  return generateSkillsSection(skills, shownSkillIds);
 }

--- a/src/features/chat/chat-store.ts
+++ b/src/features/chat/chat-store.ts
@@ -9,6 +9,7 @@ export interface ChatSlice {
   history: AIMessage[];
   isStreaming: boolean;
   abortController: AbortController | null;
+  shownSkillIds: ReadonlySet<string>;
 
   addUserMessage(content: string, image?: string): void;
   addMessage(msg: Omit<ChatMessage, "id" | "timestamp">): void;
@@ -38,6 +39,8 @@ export interface ChatSlice {
   clearMessages(): void;
   clearHistory(): void;
   clearAll(): void;
+  addShownSkillIds(ids: string[]): void;
+  resetShownSkillIds(): void;
 }
 
 function findLastAssistantIndex(messages: ChatMessage[]): number {
@@ -52,6 +55,7 @@ export const createChatSlice: StateCreator<AppStore, [], [], ChatSlice> = (set, 
   history: [],
   isStreaming: false,
   abortController: null,
+  shownSkillIds: new Set<string>(),
 
   addUserMessage: (content, image) =>
     set((s) => ({
@@ -300,5 +304,14 @@ export const createChatSlice: StateCreator<AppStore, [], [], ChatSlice> = (set, 
 
   clearHistory: () => set({ history: [] }),
 
-  clearAll: () => set({ messages: [], history: [] }),
+  clearAll: () => set({ messages: [], history: [], shownSkillIds: new Set<string>() }),
+
+  addShownSkillIds: (ids) =>
+    set((s) => {
+      const next = new Set<string>(s.shownSkillIds);
+      for (const id of ids) next.add(id);
+      return { shownSkillIds: next };
+    }),
+
+  resetShownSkillIds: () => set({ shownSkillIds: new Set<string>() }),
 });

--- a/src/features/sessions/session-slice.ts
+++ b/src/features/sessions/session-slice.ts
@@ -61,6 +61,7 @@ export const createSessionSlice: StateCreator<AppStore, [], [], SessionSlice> = 
       activeSessionId: session.id,
       messages,
       history: session.history,
+      shownSkillIds: new Set<string>(),
     });
 
     // 3. Close artifact panel

--- a/src/orchestration/agent-loop.ts
+++ b/src/orchestration/agent-loop.ts
@@ -24,9 +24,15 @@ import {
   logContextBudgetSnapshot,
 } from "@/features/ai/context-budget";
 import { buildReplToolDef } from "@/features/tools/repl";
-import { generateVisitedUrlsSection, type VisitedUrlEntry } from "@/features/ai";
+import {
+  generateVisitedUrlsSection,
+  generateSkillsSectionForLoop,
+  getActiveSkillIds,
+  type VisitedUrlEntry,
+} from "@/features/ai";
 import { prepareMessagesForTurn, trimMessagesToThreshold } from "./context-manager";
 import type { SkillRegistry } from "@/shared/skill-registry";
+import type { SkillMatch } from "@/shared/skill-types";
 import { buildSkillDetectionMessage, isSkillDetectionMessage } from "./skill-detector";
 import { useStore } from "@/store/index";
 import type { ProviderId } from "@/shared/constants";
@@ -95,6 +101,7 @@ export interface AgentLoopParams {
   autoSaver: AutoSaver;
   toolExecutor: ToolExecutor;
   skillRegistry: SkillRegistry;
+  skillMatches?: SkillMatch[];
   credentials?: AuthCredentials;
   onCredentialsUpdate?: (creds: AuthCredentials | null) => void;
 }
@@ -104,7 +111,10 @@ export type { ToolExecutor } from "@/ports/tool-executor";
 const MAX_TURNS = 25;
 const MAX_VISITED_URLS = 20;
 
-function shouldIncludeCommonPatternsOnTurn(messages: AIMessage[], lastTurnHadReplError: boolean): boolean {
+function shouldIncludeCommonPatternsOnTurn(
+  messages: AIMessage[],
+  lastTurnHadReplError: boolean,
+): boolean {
   const hasAssistantTurn = messages.some((message) => message.role === "assistant");
   return !hasAssistantTurn || lastTurnHadReplError;
 }
@@ -298,6 +308,7 @@ export async function runAgentLoop(params: AgentLoopParams): Promise<void> {
     autoSaver,
     toolExecutor,
     skillRegistry,
+    skillMatches,
   } = params;
   const securityMiddleware = deps.securityMiddleware ?? defaultSecurityMiddleware;
 
@@ -570,9 +581,16 @@ export async function runAgentLoop(params: AgentLoopParams): Promise<void> {
       };
 
       const visitedSection = generateVisitedUrlsSection([...visitedUrls.values()]);
-      const effectiveSystemPrompt = visitedSection
-        ? `${systemPrompt}\n\n${visitedSection}`
-        : systemPrompt;
+      const currentShownSkillIds = useStore.getState().shownSkillIds;
+      const skillsSection =
+        skillMatches && skillMatches.length > 0
+          ? generateSkillsSectionForLoop(skillMatches, currentShownSkillIds)
+          : "";
+      const activeSkillIds =
+        skillMatches && skillMatches.length > 0 ? getActiveSkillIds(skillMatches) : [];
+      const effectiveSystemPrompt = [systemPrompt, skillsSection, visitedSection]
+        .filter((s) => s.length > 0)
+        .join("\n\n");
 
       while (retryCount <= RETRY_CONFIG.maxRetries) {
         let hasError = false;
@@ -818,6 +836,11 @@ export async function runAgentLoop(params: AgentLoopParams): Promise<void> {
           if (hasError) break;
         }
         if (!hasError) break;
+      }
+
+      // After successful AI response, mark the active skills as shown
+      if (activeSkillIds.length > 0) {
+        useStore.getState().addShownSkillIds(activeSkillIds);
       }
 
       if (!hasToolCall) break;

--- a/src/sidepanel/hooks/use-agent.ts
+++ b/src/sidepanel/hooks/use-agent.ts
@@ -150,9 +150,9 @@ export function useAgent() {
         new SkillRegistry();
       const { currentTab } = useStore.getState();
       const matchedSkills = currentRegistry.getAvailableSkills(currentTab.url);
+      // Build system prompt without skills (skills are injected per-turn in agent-loop
+      // using shownSkillIds for diff-based rendering)
       const systemPrompt = getSystemPromptV2({
-        includeSkills: matchedSkills.length > 0,
-        skills: matchedSkills,
         enableBgFetch: settings.enableBgFetch,
       });
 
@@ -214,6 +214,7 @@ export function useAgent() {
           enableBgFetch: settings.enableBgFetch,
         }),
         systemPrompt,
+        skillMatches: matchedSkills,
         autoSaver: autoSaverRef.current,
         toolExecutor: createToolExecutorWithSkills(
           currentRegistry,


### PR DESCRIPTION
Closes #91

## Summary

- `ChatSlice` に `shownSkillIds: ReadonlySet<string>` を追加し、`addShownSkillIds` / `resetShownSkillIds` アクションを実装
- `generateSkillsSection` が `shownSkillIds` を受け取り、既出スキルを 1 行の short format に縮退させる
- `agent-loop` 内でターンごとに `shownSkillIds` を参照してスキルセクションを差分レンダリングし、AI 応答後に送信済み skill ID を store に登録
- セッション切替 (`loadSession`) および `clearAll` で `shownSkillIds` をリセット
- `createPromptCacheKey` からスキル関連フラグを除外（スキルセクションはキャッシュ対象外に変更）

## Test plan

- [ ] `pnpm vitest run` 全 pass (974 tests)
- [ ] `pnpm tsc --noEmit` クリーン
- [ ] `generateSkillsSectionForLoop` のテスト: 初回ターンは full format、2 ターン目以降は short format
- [ ] 新規スキルは full format、既出スキルは short format の混在レンダリング
- [ ] `getActiveSkillIds` が `availableExtractors` あるスキルのみ返すことを確認

Generated with [Claude Code](https://claude.com/claude-code)