### PR TITLE
feat(extractor): aggregate main containers and expose heading outline in readPage

### DIFF
--- a/src/adapters/chrome/__tests__/chrome-browser-executor.test.ts
+++ b/src/adapters/chrome/__tests__/chrome-browser-executor.test.ts
@@ -111,6 +111,10 @@ describe("ChromeBrowserExecutor", () => {
           description: "A test page",
           text: "Hello",
           method: "article",
+          outline: [
+            { level: 1, text: "Example" },
+            { level: 2, text: "Section A" },
+          ],
         },
       },
     ]);
@@ -120,7 +124,8 @@ describe("ChromeBrowserExecutor", () => {
       ok: true,
       value: {
         text: "Example\n\nHello",
-        simplifiedDom: "[Extraction: article]\nMeta: A test page\nH1: Example",
+        simplifiedDom:
+          "[Extraction: article]\nMeta: A test page\nH1: Example\nOutline:\n- Example\n  - Section A",
       },
     });
     expect(mockExecuteScript).toHaveBeenCalledWith(

--- a/src/adapters/chrome/__tests__/page-extractor.test.ts
+++ b/src/adapters/chrome/__tests__/page-extractor.test.ts
@@ -214,6 +214,124 @@ describe("extractPageContentLightweight", () => {
     expect(result.text).not.toContain("u975eu8868u793au30b3u30f3u30c6u30f3u30c4");
   });
 
+  it("複数の article を集約し method は単一セレクタ名のまま", () => {
+    setupDOM(`
+      <html>
+        <head><title>複数 article</title></head>
+        <body>
+          <article><h2>セクションA</h2><p>Aの本文です。これはテスト用の十分な長さのコンテンツです。テストが正常に動作することを確認するためのテキスト。</p></article>
+          <article><h2>セクションB</h2><p>Bの本文です。これはテスト用の十分な長さのコンテンツです。テストが正常に動作することを確認するためのテキスト。</p></article>
+        </body>
+      </html>
+    `);
+
+    const result = extractPageContentLightweight();
+
+    expect(result.method).toBe("article");
+    expect(result.text).toContain("Aの本文");
+    expect(result.text).toContain("Bの本文");
+  });
+
+  it("article と main の両方にマッチしたら method はカンマ区切り", () => {
+    setupDOM(`
+      <html>
+        <head><title>article + main</title></head>
+        <body>
+          <article><p>記事領域の本文です。これはテスト用の十分な長さのコンテンツです。テストが正常に動作することを確認するため。</p></article>
+          <main><p>メイン領域の本文です。これはテスト用の十分な長さのコンテンツです。テストが正常に動作することを確認するため。</p></main>
+        </body>
+      </html>
+    `);
+
+    const result = extractPageContentLightweight();
+
+    expect(result.method).toBe("article,main");
+    expect(result.text).toContain("記事領域");
+    expect(result.text).toContain("メイン領域");
+  });
+
+  it("ネストした main/article は重複集約しない", () => {
+    setupDOM(`
+      <html>
+        <head><title>ネスト</title></head>
+        <body>
+          <article><p>外側 article の本文です。これはテスト用の十分な長さのコンテンツです。テストが正常に動作することを確認するため。</p><main><p>内側 main の本文</p></main></article>
+        </body>
+      </html>
+    `);
+
+    const result = extractPageContentLightweight();
+
+    expect(result.method).toBe("article");
+    const occurrences = result.text.split("内側 main の本文").length - 1;
+    expect(occurrences).toBe(1);
+  });
+
+  it("outline に h1/h2/h3 を level 付きで抽出する", () => {
+    setupDOM(`
+      <html>
+        <head><title>アウトライン</title></head>
+        <body>
+          <h1>トップ見出し</h1>
+          <article>
+            <h2>セクション1</h2>
+            <h3>サブ1-1</h3>
+            <h2>セクション2</h2>
+            <p>テスト用の十分な長さの本文コンテンツです。テストが正常に動作することを確認するため。</p>
+          </article>
+        </body>
+      </html>
+    `);
+
+    const result = extractPageContentLightweight();
+
+    expect(result.outline).toEqual([
+      { level: 1, text: "トップ見出し" },
+      { level: 2, text: "セクション1" },
+      { level: 3, text: "サブ1-1" },
+      { level: 2, text: "セクション2" },
+    ]);
+  });
+
+  it("outline は nav / aside 配下の見出しを除外する", () => {
+    setupDOM(`
+      <html>
+        <head><title>ナビ除外</title></head>
+        <body>
+          <nav><h2>ナビ見出し</h2></nav>
+          <aside><h3>サイド見出し</h3></aside>
+          <article>
+            <h1>本文見出し</h1>
+            <p>テスト用の十分な長さの本文コンテンツです。テストが正常に動作することを確認するため。</p>
+          </article>
+        </body>
+      </html>
+    `);
+
+    const result = extractPageContentLightweight();
+
+    expect(result.outline.map((o) => o.text)).toEqual(["本文見出し"]);
+  });
+
+  it("outline は最大30件で打ち切る", () => {
+    const headings = Array.from({ length: 40 }, (_, i) => `<h2>見出し${i}</h2>`).join("");
+    setupDOM(`
+      <html>
+        <head><title>多数の見出し</title></head>
+        <body>
+          <article>
+            ${headings}
+            <p>テスト用の十分な長さの本文コンテンツです。テストが正常に動作することを確認するため。</p>
+          </article>
+        </body>
+      </html>
+    `);
+
+    const result = extractPageContentLightweight();
+
+    expect(result.outline.length).toBe(30);
+  });
+
   it("h1 u3092u62bdu51fau3059u308b", () => {
     setupDOM(`
       <html>

--- a/src/adapters/chrome/chrome-browser-executor.ts
+++ b/src/adapters/chrome/chrome-browser-executor.ts
@@ -97,10 +97,16 @@ export class ChromeBrowserExecutor implements BrowserExecutor {
 
       const data = results[0]?.result as LightweightExtraction;
       const text = data.h1 ? `${data.h1}\n\n${data.text}` : data.text;
+      const outlineBlock =
+        data.outline.length > 0
+          ? "Outline:\n" +
+            data.outline.map((o) => `${"  ".repeat(o.level - 1)}- ${o.text}`).join("\n")
+          : "";
       const simplifiedDom = [
         `[Extraction: ${data.method}]`,
         data.description ? `Meta: ${data.description}` : "",
         data.h1 ? `H1: ${data.h1}` : "",
+        outlineBlock,
       ]
         .filter(Boolean)
         .join("\n");

--- a/src/adapters/chrome/page-extractor.ts
+++ b/src/adapters/chrome/page-extractor.ts
@@ -1,8 +1,14 @@
+export interface OutlineItem {
+  level: 1 | 2 | 3;
+  text: string;
+}
+
 export interface LightweightExtraction {
   h1: string;
   description: string;
   text: string;
   method: string;
+  outline: OutlineItem[];
 }
 
 /**
@@ -12,6 +18,7 @@ export interface LightweightExtraction {
  */
 export function extractPageContentLightweight(): LightweightExtraction {
   const MAX_TEXT_LENGTH = 6000;
+  const MAX_OUTLINE_ITEMS = 30;
   const REMOVE_SELECTORS = [
     "script",
     "style",
@@ -26,6 +33,8 @@ export function extractPageContentLightweight(): LightweightExtraction {
     "[role='contentinfo']",
     "[aria-hidden='true']",
   ];
+  const EXCLUDE_HEADING_ANCESTORS =
+    "nav,header,footer,aside,[role='navigation'],[role='banner'],[role='contentinfo'],[aria-hidden='true']";
   const MAIN_SELECTORS = [
     "article",
     "main",
@@ -49,25 +58,48 @@ export function extractPageContentLightweight(): LightweightExtraction {
     return raw.replace(/\s+/g, " ").trim();
   }
 
+  const outline: OutlineItem[] = [];
+  for (const h of document.querySelectorAll("h1,h2,h3")) {
+    if ((h as Element).closest(EXCLUDE_HEADING_ANCESTORS)) continue;
+    const text = cleanText(h.textContent ?? "");
+    if (!text) continue;
+    const level = (h.tagName === "H1" ? 1 : h.tagName === "H2" ? 2 : 3) as 1 | 2 | 3;
+    outline.push({ level, text });
+    if (outline.length >= MAX_OUTLINE_ITEMS) break;
+  }
+
   const h1 = document.querySelector("h1")?.textContent?.trim() ?? "";
   const description =
     document.querySelector('meta[name="description"]')?.getAttribute("content") ?? "";
 
+  const seenElements: Element[] = [];
+  const matchedMethods: string[] = [];
+  const sectionTexts: string[] = [];
+
   for (const selector of MAIN_SELECTORS) {
-    const el = document.querySelector(selector);
-    if (!el) continue;
+    for (const el of document.querySelectorAll(selector)) {
+      if (seenElements.some((s) => s.contains(el) || el.contains(s))) continue;
 
-    const clone = el.cloneNode(true) as Element;
-    removeNoise(clone);
-    const text = cleanText(clone.textContent ?? "");
+      const clone = el.cloneNode(true) as Element;
+      removeNoise(clone);
+      const text = cleanText(clone.textContent ?? "");
 
-    if (text.length < MIN_TEXT_LENGTH) continue;
+      if (text.length < MIN_TEXT_LENGTH) continue;
 
+      seenElements.push(el);
+      if (!matchedMethods.includes(selector)) matchedMethods.push(selector);
+      sectionTexts.push(text);
+    }
+  }
+
+  if (sectionTexts.length > 0) {
+    const joined = sectionTexts.join("\n\n");
     return {
       h1,
       description,
-      text: text.substring(0, MAX_TEXT_LENGTH),
-      method: selector,
+      text: joined.substring(0, MAX_TEXT_LENGTH),
+      method: matchedMethods.join(","),
+      outline,
     };
   }
 
@@ -80,5 +112,6 @@ export function extractPageContentLightweight(): LightweightExtraction {
     description,
     text: bodyText.substring(0, MAX_TEXT_LENGTH),
     method: "body",
+    outline,
   };
 }


### PR DESCRIPTION
## Summary

- `readPage()` が MAIN_SELECTORS の **最初の一致で打ち切り** していたため、`<article>` がヒーロー1つしか無いランディング等で後続セクションを取りこぼしていた問題を改善
- 全マッチを集約し（`contains()` で親子ネスト重複を回避）、`simplifiedDom` に **見出しアウトライン** (h1/h2/h3、nav・header・footer・aside 配下を除外、最大30件) を `Outline:` ブロックとして追加
- `PageContent` port 契約は不変 (`{ text, simplifiedDom }`)。REPL の `readPage()` helper 側の改修不要

## Before / After

**Before** (最初の article 1つだけ):
```
[Extraction: article]
Meta: 為 AI 編程智能体打造的桌面任務管理器
H1: 哪吒三头六臂,并发编程
```

**After** (全セクション＋アウトライン):
```
[Extraction: article,main]
Meta: 為 AI 編程智能体打造的桌面任務管理器
H1: 哪吒三头六臂,并发编程
Outline:
- 哪吒三头六臂,并发编程
  - 特徴
  - ダウンロード
  - FAQ
```

## Test plan

- [x] `page-extractor.test.ts` 既存11件 + 新規6件（複数 article 集約 / article+main 混在 / ネスト重複回避 / outline 抽出 / nav・aside 除外 / 30件上限）全てグリーン
- [x] `chrome-browser-executor.test.ts` の readPageContent モック更新、期待 simplifiedDom に Outline を含めて通過
- [x] `src/adapters/chrome` + `src/features/tools` 計330件グリーン
- [x] `tsc --noEmit` および `vp lint src/adapters/chrome` クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)