### PR TITLE
feat(tools): extract multiple images in one inspect call

### DIFF
--- a/src/features/chat/tool-renderers/components.tsx
+++ b/src/features/chat/tool-renderers/components.tsx
@@ -183,6 +183,42 @@ interface ParsedExtractImageResult {
   errorText: string | null;
 }
 
+interface ParsedExtractImagesItem {
+  selector: string;
+  imageUrl: string | null;
+  info: ExtractImageInfo;
+  error: string | null;
+}
+
+function parseExtractImagesResult(result?: string): ParsedExtractImagesItem[] | null {
+  if (!result) return null;
+  try {
+    const parsed = JSON.parse(result);
+    if (!parsed || !Array.isArray(parsed.images)) return null;
+    return parsed.images.map((item: unknown): ParsedExtractImagesItem => {
+      const entry = (item ?? {}) as {
+        selector?: string;
+        ok?: boolean;
+        error?: string;
+        image?: { source?: { base64?: string; media_type?: string } };
+        info?: ExtractImageInfo;
+      };
+      let imageUrl: string | null = null;
+      if (entry.image?.source?.base64 && entry.image.source.media_type) {
+        imageUrl = `data:${entry.image.source.media_type};base64,${entry.image.source.base64}`;
+      }
+      return {
+        selector: typeof entry.selector === "string" ? entry.selector : "",
+        imageUrl,
+        info: entry.info && typeof entry.info === "object" ? entry.info : {},
+        error: entry.ok === false && typeof entry.error === "string" ? entry.error : null,
+      };
+    });
+  } catch {
+    return null;
+  }
+}
+
 interface ParsedArtifactResult {
   content?: string;
   isError?: boolean;
@@ -564,8 +600,76 @@ function ReplRendererView({ toolCall, consoleLogService }: ToolRendererContext) 
   );
 }
 
+function ExtractImagesGridView({ items }: { items: ParsedExtractImagesItem[] }) {
+  const successCount = items.filter((i) => i.imageUrl).length;
+  const failureCount = items.length - successCount;
+
+  return (
+    <Box mt="xs">
+      <Paper
+        p="sm"
+        radius="md"
+        mb="xs"
+        style={{
+          background: "var(--mantine-color-green-light)",
+          border: "1px solid var(--mantine-color-green-light)",
+        }}
+      >
+        <Group gap="sm">
+          <ImageIcon size={20} color="var(--mantine-color-green-6)" />
+          <Text size="sm" fw={600}>
+            {successCount} image{successCount === 1 ? "" : "s"} extracted
+            {failureCount > 0 ? ` · ${failureCount} failed` : ""}
+          </Text>
+        </Group>
+      </Paper>
+
+      <Box
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(auto-fill, minmax(160px, 1fr))",
+          gap: 8,
+        }}
+      >
+        {items.map((item, idx) => (
+          <Paper
+            key={`${item.selector}-${idx}`}
+            withBorder
+            radius="md"
+            p={4}
+            style={{ overflow: "hidden" }}
+          >
+            {item.imageUrl ? (
+              <ImageLightbox src={item.imageUrl} alt={item.selector || `image ${idx + 1}`} />
+            ) : (
+              <Box p="xs" style={{ background: "var(--mantine-color-red-light-hover)" }}>
+                <Group gap={4} align="flex-start" wrap="nowrap">
+                  <XCircle size={14} color="var(--mantine-color-red-5)" />
+                  <Text size="xs" c="red" lineClamp={3}>
+                    {item.error ?? "failed"}
+                  </Text>
+                </Group>
+              </Box>
+            )}
+            <Text
+              size="xs"
+              c="dimmed"
+              mt={4}
+              lineClamp={1}
+              style={{ fontFamily: "monospace", padding: "0 4px 2px" }}
+              title={item.selector}
+            >
+              {item.selector}
+            </Text>
+          </Paper>
+        ))}
+      </Box>
+    </Box>
+  );
+}
+
 function ExtractImageRendererView({ toolCall }: ToolRendererContext) {
-  const { imageUrl, info, errorText } = parseExtractImageResult(toolCall.result);
+  // Hooks must be called before any early returns.
   const [downloadError, setDownloadError] = useState<string | null>(null);
   const [isDownloading, setIsDownloading] = useState(false);
 
@@ -574,6 +678,17 @@ function ExtractImageRendererView({ toolCall }: ToolRendererContext) {
     typeof (args as { action?: unknown }).action === "string"
       ? ((args as { action: string }).action as "screenshot" | "extract_image" | string)
       : null;
+
+  // action=extract_image で result が {images:[...]} 形式のときは複数画像ビューに委譲する。
+  if (action === "extract_image" && !toolCall.isRunning) {
+    const multi = parseExtractImagesResult(toolCall.result);
+    if (multi && multi.length > 0) {
+      return <ExtractImagesGridView items={multi} />;
+    }
+  }
+
+  const { imageUrl, info, errorText } = parseExtractImageResult(toolCall.result);
+
   const isScreenshot = action === "screenshot";
   const runningLabel = isScreenshot ? "Capturing screenshot..." : "Extracting image...";
   const failureLabel = isScreenshot ? "Failed to capture screenshot" : "Failed to extract image";

--- a/src/features/tools/index.ts
+++ b/src/features/tools/index.ts
@@ -129,6 +129,7 @@ export function createToolExecutorWithSkills(
           action: "pick_element" | "screenshot" | "extract_image";
           message?: string;
           selector?: string;
+          selectors?: string[];
           maxWidth?: number;
         });
       case "bg_fetch": {

--- a/src/features/tools/inspect.ts
+++ b/src/features/tools/inspect.ts
@@ -2,9 +2,14 @@ import type { ToolDefinition } from "@/ports/ai-provider";
 import type { BrowserExecutor, ElementInfo } from "@/ports/browser-executor";
 import type { BrowserError, Result, ToolError } from "@/shared/errors";
 import { err, ok } from "@/shared/errors";
-import { executeExtractImage, type ExtractImageResult } from "@/shared/extract-image-core";
+import {
+  executeExtractImage,
+  executeExtractImages,
+  type ExtractImageResult,
+  type ExtractImagesResult,
+} from "@/shared/extract-image-core";
 
-export type { ExtractImageResult };
+export type { ExtractImageResult, ExtractImagesResult };
 
 export interface ScreenshotResult {
   dataUrl: string;
@@ -15,7 +20,7 @@ export const inspectToolDef: ToolDefinition = {
   description: `Inspect the current page visually or interactively. Choose an action:
 - pick_element: Ask the user to click an element to select it. Returns CSS selector, tag, text, and attributes.
 - screenshot: Capture a screenshot of the visible viewport. Use to check the page's visual state.
-- extract_image: Extract an image from the page (img, canvas, video, background-image). Returns image data.`,
+- extract_image: Extract one or more images from the page (img, canvas, video, background-image). Pass \`selector\` for a single image or \`selectors\` for multiple in one call.`,
   parameters: {
     type: "object",
     properties: {
@@ -32,7 +37,13 @@ export const inspectToolDef: ToolDefinition = {
       selector: {
         type: "string",
         description:
-          "(extract_image only) CSS selector for the image element (e.g. 'img.hero', '#logo', 'canvas#main', 'video').",
+          "(extract_image only) CSS selector for a single image element (e.g. 'img.hero', '#logo', 'canvas#main', 'video'). Use `selectors` instead to extract multiple images in one call.",
+      },
+      selectors: {
+        type: "array",
+        items: { type: "string" },
+        description:
+          "(extract_image only) Multiple CSS selectors to extract in a single call. Prefer this over several separate inspect calls when you need two or more images.",
       },
       maxWidth: {
         type: "number",
@@ -51,9 +62,15 @@ export async function executeInspect(
     action: "pick_element" | "screenshot" | "extract_image";
     message?: string;
     selector?: string;
+    selectors?: string[];
     maxWidth?: number;
   },
-): Promise<Result<ElementInfo | null | ScreenshotResult | ExtractImageResult, ToolError | BrowserError>> {
+): Promise<
+  Result<
+    ElementInfo | null | ScreenshotResult | ExtractImageResult | ExtractImagesResult,
+    ToolError | BrowserError
+  >
+> {
   switch (args.action) {
     case "pick_element": {
       const tab = await browser.getActiveTab();
@@ -67,16 +84,21 @@ export async function executeInspect(
       return ok({ dataUrl });
     }
     case "extract_image": {
+      const maxWidth = typeof args.maxWidth === "number" ? args.maxWidth : undefined;
+      const hasPlural = Array.isArray(args.selectors) && args.selectors.length > 0;
+      if (hasPlural) {
+        return executeExtractImages(browser, { selectors: args.selectors!, maxWidth });
+      }
       if (typeof args.selector !== "string") {
         return {
           ok: false as const,
-          error: { code: "tool_script_error", message: "selector is required for extract_image" },
+          error: {
+            code: "tool_script_error",
+            message: "selector or selectors is required for extract_image",
+          },
         };
       }
-      return executeExtractImage(browser, {
-        selector: args.selector,
-        maxWidth: typeof args.maxWidth === "number" ? args.maxWidth : undefined,
-      });
+      return executeExtractImage(browser, { selector: args.selector, maxWidth });
     }
     default: {
       const exhaustive: never = args.action;

--- a/src/shared/extract-image-core.ts
+++ b/src/shared/extract-image-core.ts
@@ -49,6 +49,35 @@ export async function executeExtractImage(
   return extractElementImage(browser, args.selector, maxWidth);
 }
 
+export type ExtractImagesItem =
+  | ({ ok: true; selector: string } & ExtractImageResult)
+  | { ok: false; selector: string; error: string };
+
+export interface ExtractImagesResult {
+  images: ExtractImagesItem[];
+}
+
+/**
+ * 複数セレクタの画像を 1 回のツール呼び出しで順に抽出する。個別の失敗は
+ * items に `{ok: false, error}` として残し、全体としては成功を返す。
+ */
+export async function executeExtractImages(
+  browser: BrowserExecutor,
+  args: { selectors: string[]; maxWidth?: number },
+): Promise<Result<ExtractImagesResult, ToolError>> {
+  const maxWidth = args.maxWidth ?? 800;
+  const items: ExtractImagesItem[] = [];
+  for (const selector of args.selectors) {
+    const r = await extractElementImage(browser, selector, maxWidth);
+    if (r.ok) {
+      items.push({ ok: true, selector, ...r.value });
+    } else {
+      items.push({ ok: false, selector, error: r.error.message });
+    }
+  }
+  return ok({ images: items });
+}
+
 async function extractElementImage(
   browser: BrowserExecutor,
   selector: string,


### PR DESCRIPTION
## Summary
- `inspect(action=extract_image)` が `selectors: string[]` を受け付けるように拡張
- 複数セレクタを 1 回のツール呼び出しで並列抽出 (実装は逐次だが AI 側は 1 turn で済む)
- 結果は `{ images: [{ selector, ok, image, info } | { selector, ok: false, error }] }`
- サイドパネル UI はグリッド表示 (selector ラベル付き) で、失敗要素のみ赤アイコンで区別
- `selector: string` 単独指定時は旧 `{ image, info }` 形状を維持 (後方互換)

## Motivation
v0.1.4 以前は複数画像を扱えた、とユーザーからの指摘。実装上 v0.1.4 時点でも `selector: string` 単発のみだったが、ユーザー体験として AI が 1 ターンで複数画像を一括取得できる設計にした方が自然なので明示的にサポートした。

## Test plan
- [x] pnpm vitest run (997/997)
- [x] pnpm tsc --noEmit クリーン
- [ ] 手動: 「このページの画像 3 つ抽出して」で `selectors` 経由の call になり、グリッドで表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)