### PR TITLE
fix(tools): inject skill extractors into target page window

### DIFF
--- a/src/features/tools/providers/__tests__/browser-js-provider.test.ts
+++ b/src/features/tools/providers/__tests__/browser-js-provider.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
-import { BrowserJsProvider } from "../browser-js-provider";
+import { BrowserJsProvider, buildSkillInjection } from "../browser-js-provider";
 import type { BrowserExecutor, ScriptResult, TabInfo } from "@/ports/browser-executor";
 import type { ProviderContext } from "@/ports/runtime-provider";
 import type { Result, ToolError } from "@/shared/errors";
+import type { SkillMatch } from "@/shared/skill-types";
 import { ok, err } from "@/shared/errors";
 
 type ExecuteScriptResult = Result<ScriptResult, ToolError>;
@@ -82,5 +83,110 @@ describe("BrowserJsProvider.handleRequest", () => {
     expect(result.ok).toBe(false);
     if (result.ok) return;
     expect(result.error.message).toContain("timeout");
+  });
+
+  it("prepends skill extractor injection so window[skillId][extractorId] is callable", async () => {
+    let receivedCode = "";
+    const browser = makeBrowser(async () => ok({ value: "ok" }));
+    (browser.executeScript as unknown) = vi.fn(async (_tabId: number, code: string) => {
+      receivedCode = code;
+      return ok({ value: "ok" });
+    });
+
+    const skillMatches: SkillMatch[] = [
+      {
+        skill: {
+          id: "x-post-helper",
+          name: "X Post Helper",
+          description: "X投稿フォーム操作",
+          matchers: { hosts: ["x.com"] },
+          version: "1.0.0",
+          extractors: [
+            {
+              id: "check-post-form",
+              name: "Check Post Form",
+              description: "投稿フォーム存在確認",
+              code: "function () { return !!document.querySelector('[data-testid=\"tweetTextarea_0\"]'); }",
+              outputSchema: "boolean",
+            },
+          ],
+        },
+        availableExtractors: [
+          {
+            id: "check-post-form",
+            name: "Check Post Form",
+            description: "投稿フォーム存在確認",
+            code: "function () { return !!document.querySelector('[data-testid=\"tweetTextarea_0\"]'); }",
+            outputSchema: "boolean",
+          },
+        ],
+        confidence: 100,
+      },
+    ];
+
+    const provider = new BrowserJsProvider();
+    await provider.handleRequest(
+      {
+        id: "req-5",
+        action: "browserjs",
+        code: '() => window["x-post-helper"]["check-post-form"]()',
+        args: [],
+      },
+      { ...makeContext(browser), skillMatches },
+    );
+
+    expect(receivedCode).toContain('window["x-post-helper"] = window["x-post-helper"] || {};');
+    expect(receivedCode).toContain('window["x-post-helper"]["check-post-form"] = (function ()');
+  });
+
+  it("does not inject anything when skillMatches is empty or undefined", async () => {
+    let receivedCode = "";
+    const browser = makeBrowser(async () => ok({ value: 1 }));
+    (browser.executeScript as unknown) = vi.fn(async (_tabId: number, code: string) => {
+      receivedCode = code;
+      return ok({ value: 1 });
+    });
+
+    const provider = new BrowserJsProvider();
+    await provider.handleRequest(
+      { id: "req-6", action: "browserjs", code: "() => 1", args: [] },
+      makeContext(browser),
+    );
+
+    expect(receivedCode).not.toContain("window[");
+  });
+});
+
+describe("buildSkillInjection", () => {
+  it("returns empty string when no matches", () => {
+    expect(buildSkillInjection()).toBe("");
+    expect(buildSkillInjection([])).toBe("");
+  });
+
+  it("handles ids with hyphens via bracket notation", () => {
+    const injection = buildSkillInjection([
+      {
+        skill: {
+          id: "x-post-helper",
+          name: "X",
+          description: "x",
+          matchers: { hosts: ["x.com"] },
+          version: "1.0.0",
+          extractors: [],
+        },
+        availableExtractors: [
+          {
+            id: "check-post-form",
+            name: "c",
+            description: "d",
+            code: "function () { return 1; }",
+            outputSchema: "number",
+          },
+        ],
+        confidence: 100,
+      },
+    ]);
+    expect(injection).toContain('window["x-post-helper"]["check-post-form"]');
+    expect(injection).toContain("(function () { return 1; })");
   });
 });

--- a/src/features/tools/providers/browser-js-provider.ts
+++ b/src/features/tools/providers/browser-js-provider.ts
@@ -1,6 +1,26 @@
 import type { RuntimeProvider, SandboxRequest, ProviderContext } from "@/ports/runtime-provider";
 import type { Result, ToolError } from "@/shared/errors";
 import { ok, err } from "@/shared/errors";
+import type { SkillMatch } from "@/shared/skill-types";
+
+/**
+ * skillMatches から target page の window に extractor を載せるための JS を組み立てる。
+ * 例: `window["youtube"]["getVideoInfo"] = (function () { ... });`
+ * hyphen などを含む id でも壊れないよう bracket notation と JSON.stringify を使う。
+ */
+export function buildSkillInjection(skillMatches?: readonly SkillMatch[]): string {
+  if (!skillMatches || skillMatches.length === 0) return "";
+  const lines: string[] = [];
+  for (const match of skillMatches) {
+    const sid = JSON.stringify(match.skill.id);
+    lines.push(`window[${sid}] = window[${sid}] || {};`);
+    for (const ext of match.availableExtractors) {
+      const eid = JSON.stringify(ext.id);
+      lines.push(`window[${sid}][${eid}] = (${ext.code});`);
+    }
+  }
+  return lines.join("\n");
+}
 
 /**
  * BrowserJsProvider - browserjs() 機能の提供
@@ -88,7 +108,7 @@ function browserjs(fn, ...args) {
     request: SandboxRequest,
     context: ProviderContext,
   ): Promise<Result<unknown, ToolError>> {
-    const { browser, signal } = context;
+    const { browser, signal, skillMatches } = context;
     const { code, args } = request as unknown as { code: string; args: unknown[] };
 
     try {
@@ -98,7 +118,9 @@ function browserjs(fn, ...args) {
       }
 
       const serializedArgs = (args || []).map((a) => JSON.stringify(a)).join(", ");
+      const skillInjection = buildSkillInjection(skillMatches);
       const scriptCode = `(async () => {
+        ${skillInjection}
         const fn = ${code};
         return await fn(${serializedArgs});
       })()`;

--- a/src/features/tools/repl.ts
+++ b/src/features/tools/repl.ts
@@ -266,6 +266,7 @@ async function handleSandboxRequest(
   signal?: AbortSignal,
   onReturnFile?: (name: string) => void,
   onCreateOrUpdateArtifact?: (name: string) => void,
+  skillMatches?: readonly SkillMatch[],
 ): Promise<void> {
   const registry = getProviderRegistry();
   const provider = registry.getProvider(msg.action);
@@ -286,7 +287,7 @@ async function handleSandboxRequest(
   try {
     const result = await provider.handleRequest(
       { ...msg, id: msg.id, action: msg.action },
-      { browser, artifactStorage, signal },
+      { browser, artifactStorage, signal, skillMatches },
     );
 
     if (result.ok) {
@@ -409,6 +410,7 @@ export async function executeRepl(
           signal,
           (name) => returnedFileNames.add(name),
           onArtifactCreated,
+          skillMatches,
         );
         return;
       }

--- a/src/ports/runtime-provider.ts
+++ b/src/ports/runtime-provider.ts
@@ -1,6 +1,7 @@
 import type { BrowserExecutor } from "@/ports/browser-executor";
 import type { ArtifactStoragePort } from "@/ports/artifact-storage";
 import type { Result, ToolError } from "@/shared/errors";
+import type { SkillMatch } from "@/shared/skill-types";
 
 /**
  * RuntimeProviderパターン - 各機能を独立したProviderとして実装
@@ -41,6 +42,9 @@ export interface ProviderContext {
   browser: BrowserExecutor;
   artifactStorage: ArtifactStoragePort;
   signal?: AbortSignal;
+  // browserjs() 実行前に target page の window に skill extractor を注入するために使う。
+  // 現在タブの URL にマッチした skill のみが渡される想定。
+  skillMatches?: readonly SkillMatch[];
 }
 
 /**


### PR DESCRIPTION
## Summary

- system prompt と `[System: Skills available now]` メッセージは `browserjs(() => window.skillId.extractorId())` のパターンを AI に教えていたが、target page の `window` にスキルを注入する処理が存在しなかった。結果 `Cannot read properties of undefined (reading 'xxx')` で常に失敗。
- `BrowserJsProvider.handleRequest` で `scriptCode` 先頭に `window["id"]["extId"] = (extractor.code);` を prepend し、prompt の記述と実装を一致させた。
- `ProviderContext` に `skillMatches` を追加し、`repl.ts` の `handleSandboxRequest` から配線。
- hyphen 含む id (`x-post-helper` など) でも bracket notation + JSON.stringify で安全に注入。

## Test plan

- [x] `browser-js-provider.test.ts` に注入テスト 3 件を追加 (hyphen 対応、空時の非注入、`buildSkillInjection` 単体)
- [x] 全テスト pass (1001 件)
- [x] 編集ファイルの fmt / lint clean
- [ ] 手動検証: x.com 等で自作 skill を定義し、`browserjs(() => window["x-post-helper"]["check-post-form"]())` が動くことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)