### PR TITLE
chore(release): v0.1.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sitesurf",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "AIと一緒にWebページを操作するChrome拡張機能",
   "license": "MIT",
   "type": "module",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "SiteSurf",
   "description": "AIと一緒にWebページを操作するChrome拡張",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "action": {
     "default_title": "SiteSurfを開く",
     "default_icon": {


### PR DESCRIPTION
## Summary

- package.json と public/manifest.json を 0.1.4 → 0.1.5 に更新
- v0.1.4 以降の主な変更 (#122, #124, #125, #126, #127, #128 など)
  - token 最適化: readPage で heading outline を公開、複数 main containers を集約 (#122)
  - inspect UX 改善: action-aware icon/headline、画像プレビュー、複数画像対応 (#123, #124, #125, #126)
  - prompt: Tool Philosophy に inspect を追加 (#127)
  - skill 実行修正: target page の window に extractor を注入し `browserjs(() => window.skillId.extractorId())` を実際に動作させる (#128)

## Test plan

- [x] package.json / manifest.json の version 更新を確認
- [x] 本ブランチをマージ後、`v0.1.5` タグを push → release.yml が dist.zip 付きで GitHub Release を自動作成

🤖 Generated with [Claude Code](https://claude.com/claude-code)