### PR TITLE
feat(tools): clean up artifacts-handler on new Port + add unit tests [ADR-007 3/7]

### DIFF
--- a/src/features/tools/handlers/__tests__/artifacts-handler.test.ts
+++ b/src/features/tools/handlers/__tests__/artifacts-handler.test.ts
@@ -1,0 +1,302 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { InMemoryArtifactStorage } from "@/adapters/storage/in-memory-storage";
+import type { ArtifactEntry } from "@/shared/artifact-types";
+import { handleArtifactsTool } from "../artifacts-handler";
+
+function makeSlice() {
+  const state = {
+    artifacts: [] as ArtifactEntry[],
+    selectedArtifact: null as string | null,
+    panelOpen: false,
+  };
+  return {
+    state,
+    slice: {
+      get artifacts() {
+        return state.artifacts;
+      },
+      get selectedArtifact() {
+        return state.selectedArtifact;
+      },
+      setArtifacts: (v: ArtifactEntry[]) => {
+        state.artifacts = v;
+      },
+      selectArtifact: (name: string | null) => {
+        state.selectedArtifact = name;
+      },
+      setArtifactPanelOpen: (open: boolean) => {
+        state.panelOpen = open;
+      },
+    },
+  };
+}
+
+describe("handleArtifactsTool", () => {
+  let storage: InMemoryArtifactStorage;
+  let harness: ReturnType<typeof makeSlice>;
+
+  beforeEach(() => {
+    storage = new InMemoryArtifactStorage();
+    harness = makeSlice();
+  });
+
+  describe("create", () => {
+    it("saves .json files as kind:json", async () => {
+      const result = await handleArtifactsTool(
+        { command: "create", filename: "data.json", content: '{"foo":1}' },
+        storage,
+        harness.slice,
+      );
+
+      expect(result.isError).toBeFalsy();
+      const stored = await storage.get("data.json");
+      expect(stored).toEqual({ kind: "json", data: { foo: 1 } });
+    });
+
+    it("saves non-json files as kind:file with correct mimeType", async () => {
+      await handleArtifactsTool(
+        { command: "create", filename: "page.html", content: "<!doctype html>" },
+        storage,
+        harness.slice,
+      );
+
+      const stored = await storage.get("page.html");
+      expect(stored?.kind).toBe("file");
+      if (stored?.kind !== "file") return;
+      expect(stored.mimeType).toBe("text/html");
+      expect(new TextDecoder().decode(stored.bytes)).toBe("<!doctype html>");
+    });
+
+    it("auto-opens panel for html files", async () => {
+      await handleArtifactsTool(
+        { command: "create", filename: "x.html", content: "<p/>" },
+        storage,
+        harness.slice,
+      );
+      expect(harness.state.panelOpen).toBe(true);
+    });
+
+    it("does not auto-open panel for json", async () => {
+      await handleArtifactsTool(
+        { command: "create", filename: "x.json", content: "{}" },
+        storage,
+        harness.slice,
+      );
+      expect(harness.state.panelOpen).toBe(false);
+    });
+
+    it("rejects duplicate create", async () => {
+      await handleArtifactsTool(
+        { command: "create", filename: "x.txt", content: "a" },
+        storage,
+        harness.slice,
+      );
+      const second = await handleArtifactsTool(
+        { command: "create", filename: "x.txt", content: "b" },
+        storage,
+        harness.slice,
+      );
+      expect(second.isError).toBe(true);
+      expect(second.content).toContain("already exists");
+    });
+
+    it("returns actionable error for invalid JSON", async () => {
+      const result = await handleArtifactsTool(
+        { command: "create", filename: "bad.json", content: "{not valid}" },
+        storage,
+        harness.slice,
+      );
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("Invalid JSON content");
+    });
+
+    it("does not fail for unknown extensions", async () => {
+      const result = await handleArtifactsTool(
+        { command: "create", filename: "note.xyz", content: "hello" },
+        storage,
+        harness.slice,
+      );
+      expect(result.isError).toBeFalsy();
+      const stored = await storage.get("note.xyz");
+      expect(stored?.kind).toBe("file");
+      if (stored?.kind !== "file") return;
+      expect(stored.mimeType).toBe("application/octet-stream");
+    });
+  });
+
+  describe("rewrite", () => {
+    it("replaces file content", async () => {
+      await handleArtifactsTool(
+        { command: "create", filename: "x.txt", content: "old" },
+        storage,
+        harness.slice,
+      );
+      const result = await handleArtifactsTool(
+        { command: "rewrite", filename: "x.txt", content: "new" },
+        storage,
+        harness.slice,
+      );
+      expect(result.isError).toBeFalsy();
+      const stored = await storage.get("x.txt");
+      if (stored?.kind !== "file") throw new Error("expected file");
+      expect(new TextDecoder().decode(stored.bytes)).toBe("new");
+    });
+
+    it("errors when file is missing", async () => {
+      const result = await handleArtifactsTool(
+        { command: "rewrite", filename: "missing.txt", content: "x" },
+        storage,
+        harness.slice,
+      );
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("not found");
+    });
+  });
+
+  describe("update (find/replace)", () => {
+    it("replaces substring in text file", async () => {
+      await handleArtifactsTool(
+        { command: "create", filename: "doc.txt", content: "hello world" },
+        storage,
+        harness.slice,
+      );
+      const result = await handleArtifactsTool(
+        { command: "update", filename: "doc.txt", old_str: "world", new_str: "there" },
+        storage,
+        harness.slice,
+      );
+      expect(result.isError).toBeFalsy();
+      const stored = await storage.get("doc.txt");
+      if (stored?.kind !== "file") throw new Error("expected file");
+      expect(new TextDecoder().decode(stored.bytes)).toBe("hello there");
+    });
+
+    it("surfaces full content when old_str not found", async () => {
+      await handleArtifactsTool(
+        { command: "create", filename: "doc.txt", content: "hello world" },
+        storage,
+        harness.slice,
+      );
+      const result = await handleArtifactsTool(
+        { command: "update", filename: "doc.txt", old_str: "foo", new_str: "bar" },
+        storage,
+        harness.slice,
+      );
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("hello world");
+    });
+
+    it("round-trips JSON via string replacement", async () => {
+      await handleArtifactsTool(
+        { command: "create", filename: "cfg.json", content: '{"key":"old"}' },
+        storage,
+        harness.slice,
+      );
+      const result = await handleArtifactsTool(
+        { command: "update", filename: "cfg.json", old_str: '"old"', new_str: '"new"' },
+        storage,
+        harness.slice,
+      );
+      expect(result.isError).toBeFalsy();
+      const stored = await storage.get("cfg.json");
+      expect(stored).toEqual({ kind: "json", data: { key: "new" } });
+    });
+  });
+
+  describe("get", () => {
+    it("returns pretty-printed JSON", async () => {
+      await handleArtifactsTool(
+        { command: "create", filename: "x.json", content: '{"a":1}' },
+        storage,
+        harness.slice,
+      );
+      const result = await handleArtifactsTool(
+        { command: "get", filename: "x.json" },
+        storage,
+        harness.slice,
+      );
+      expect(result.isError).toBeFalsy();
+      expect(result.content).toBe('{\n  "a": 1\n}');
+    });
+
+    it("returns decoded text for file artifacts", async () => {
+      await handleArtifactsTool(
+        { command: "create", filename: "note.txt", content: "hello" },
+        storage,
+        harness.slice,
+      );
+      const result = await handleArtifactsTool(
+        { command: "get", filename: "note.txt" },
+        storage,
+        harness.slice,
+      );
+      expect(result.content).toBe("hello");
+    });
+
+    it("errors when file is missing from slice", async () => {
+      const result = await handleArtifactsTool(
+        { command: "get", filename: "missing.txt" },
+        storage,
+        harness.slice,
+      );
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  describe("delete", () => {
+    it("removes from both storage and slice regardless of kind", async () => {
+      await handleArtifactsTool(
+        { command: "create", filename: "x.json", content: "{}" },
+        storage,
+        harness.slice,
+      );
+      await handleArtifactsTool(
+        { command: "create", filename: "y.html", content: "<p/>" },
+        storage,
+        harness.slice,
+      );
+
+      await handleArtifactsTool({ command: "delete", filename: "x.json" }, storage, harness.slice);
+      await handleArtifactsTool({ command: "delete", filename: "y.html" }, storage, harness.slice);
+
+      expect(await storage.get("x.json")).toBeNull();
+      expect(await storage.get("y.html")).toBeNull();
+      expect(harness.state.artifacts).toEqual([]);
+    });
+  });
+
+  describe("validation", () => {
+    it("rejects missing command", async () => {
+      const result = await handleArtifactsTool(
+        // @ts-expect-error: validating runtime behavior
+        { filename: "x.txt" },
+        storage,
+        harness.slice,
+      );
+      expect(result.isError).toBe(true);
+    });
+
+    it("rejects missing filename", async () => {
+      const result = await handleArtifactsTool(
+        // @ts-expect-error: validating runtime behavior
+        { command: "create" },
+        storage,
+        harness.slice,
+      );
+      expect(result.isError).toBe(true);
+    });
+
+    it("throws when aborted", async () => {
+      const controller = new AbortController();
+      controller.abort();
+      await expect(
+        handleArtifactsTool(
+          { command: "create", filename: "x.txt", content: "a" },
+          storage,
+          harness.slice,
+          controller.signal,
+        ),
+      ).rejects.toThrow("Execution aborted");
+    });
+  });
+});

--- a/src/features/tools/handlers/artifacts-handler.ts
+++ b/src/features/tools/handlers/artifacts-handler.ts
@@ -1,4 +1,5 @@
-import type { ArtifactStoragePort } from "@/ports/artifact-storage";
+import type { ArtifactStoragePort, ArtifactValue } from "@/ports/artifact-storage";
+import { getMimeType } from "@/shared/artifact-mime";
 import type { ArtifactEntry } from "@/shared/artifact-types";
 import { detectType } from "@/shared/artifact-types";
 
@@ -25,7 +26,6 @@ export async function handleArtifactsTool(
   artifactSlice: ArtifactSlice,
   signal?: AbortSignal,
 ): Promise<{ content: string; isError?: boolean }> {
-  // Validate args
   if (!args) {
     return { content: "Error: No arguments provided", isError: true };
   }
@@ -47,7 +47,6 @@ export async function handleArtifactsTool(
           return { content: "Error: content is required for create command", isError: true };
         }
 
-        // Check if file already exists
         const existing = artifactSlice.artifacts.find((a) => a.name === filename);
         if (existing) {
           return {
@@ -56,31 +55,23 @@ export async function handleArtifactsTool(
           };
         }
 
-        // Determine type and save
+        const value = stringContentToArtifactValue(filename, args.content);
+        if (!value.ok) {
+          return { content: value.error, isError: true };
+        }
+
+        await artifactStorage.put(filename, value.value);
+
         const type = detectType(filename);
         const entry: ArtifactEntry = {
           name: filename,
           type,
-          source: type === "json" ? "json" : "file",
+          source: value.value.kind,
           updatedAt: Date.now(),
         };
-
-        if (type === "json") {
-          await artifactStorage.put(filename, { kind: "json", data: JSON.parse(args.content) });
-        } else {
-          const mimeType = getMimeType(filename);
-          await artifactStorage.put(filename, {
-            kind: "file",
-            bytes: new TextEncoder().encode(args.content),
-            mimeType,
-          });
-        }
-
-        // Update store
         artifactSlice.setArtifacts([...artifactSlice.artifacts, entry]);
         artifactSlice.selectArtifact(filename);
 
-        // Auto-open panel for previewable files
         if (type === "html" || type === "markdown") {
           artifactSlice.setArtifactPanelOpen(true);
         }
@@ -101,19 +92,13 @@ export async function handleArtifactsTool(
           };
         }
 
-        const type = detectType(filename);
-        if (type === "json") {
-          await artifactStorage.put(filename, { kind: "json", data: JSON.parse(args.content) });
-        } else {
-          const mimeType = getMimeType(filename);
-          await artifactStorage.put(filename, {
-            kind: "file",
-            bytes: new TextEncoder().encode(args.content),
-            mimeType,
-          });
+        const value = stringContentToArtifactValue(filename, args.content);
+        if (!value.ok) {
+          return { content: value.error, isError: true };
         }
 
-        // Update timestamp
+        await artifactStorage.put(filename, value.value);
+
         const updated = artifactSlice.artifacts.map((a) =>
           a.name === filename ? { ...a, updatedAt: Date.now() } : a,
         );
@@ -135,20 +120,13 @@ export async function handleArtifactsTool(
           return { content: `Error: File ${filename} not found`, isError: true };
         }
 
-        // Get current content
-        let currentContent: string;
-        if (existing.type === "json") {
-          const artifact = await artifactStorage.get(filename);
-          currentContent = artifact?.kind === "json" ? JSON.stringify(artifact.data, null, 2) : "";
-        } else {
-          const file = await artifactStorage.get(filename);
-          if (!file || file.kind !== "file") {
-            return { content: `Error: Could not read file ${filename}`, isError: true };
-          }
-          currentContent = new TextDecoder().decode(file.bytes);
+        const stored = await artifactStorage.get(filename);
+        if (!stored) {
+          return { content: `Error: Could not read file ${filename}`, isError: true };
         }
 
-        // Check if old_str exists
+        const currentContent = artifactValueToString(stored);
+
         if (!args.old_str || !currentContent.includes(args.old_str)) {
           return {
             content: `Error: String not found in file. Here is the full content:\n\n${currentContent}`,
@@ -156,21 +134,14 @@ export async function handleArtifactsTool(
           };
         }
 
-        // Apply update
         const newContent = currentContent.replace(args.old_str, args.new_str);
-
-        if (existing.type === "json") {
-          await artifactStorage.put(filename, { kind: "json", data: JSON.parse(newContent) });
-        } else {
-          const mimeType = getMimeType(filename);
-          await artifactStorage.put(filename, {
-            kind: "file",
-            bytes: new TextEncoder().encode(newContent),
-            mimeType,
-          });
+        const value = stringContentToArtifactValue(filename, newContent);
+        if (!value.ok) {
+          return { content: value.error, isError: true };
         }
 
-        // Update timestamp
+        await artifactStorage.put(filename, value.value);
+
         const updated = artifactSlice.artifacts.map((a) =>
           a.name === filename ? { ...a, updatedAt: Date.now() } : a,
         );
@@ -185,19 +156,12 @@ export async function handleArtifactsTool(
           return { content: `Error: File ${filename} not found`, isError: true };
         }
 
-        let content: string;
-        if (existing.type === "json") {
-          const artifact = await artifactStorage.get(filename);
-          content = artifact?.kind === "json" ? JSON.stringify(artifact.data, null, 2) : "";
-        } else {
-          const file = await artifactStorage.get(filename);
-          if (!file || file.kind !== "file") {
-            return { content: `Error: Could not read file ${filename}`, isError: true };
-          }
-          content = new TextDecoder().decode(file.bytes);
+        const stored = await artifactStorage.get(filename);
+        if (!stored) {
+          return { content: `Error: Could not read file ${filename}`, isError: true };
         }
 
-        return { content };
+        return { content: artifactValueToString(stored) };
       }
 
       case "delete": {
@@ -219,8 +183,6 @@ export async function handleArtifactsTool(
       }
 
       case "logs": {
-        // For HTML files, logs are collected by the HtmlSandbox component
-        // Return a placeholder - actual logs would need to be tracked
         return {
           content:
             "Logs feature requires HTML file execution. Use the artifacts panel to view console output.",
@@ -238,21 +200,40 @@ export async function handleArtifactsTool(
   }
 }
 
-function getMimeType(filename: string): string {
-  const ext = filename.split(".").pop()?.toLowerCase() || "";
-  const mimeTypes: Record<string, string> = {
-    html: "text/html",
-    css: "text/css",
-    js: "application/javascript",
-    json: "application/json",
-    png: "image/png",
-    jpg: "image/jpeg",
-    jpeg: "image/jpeg",
-    gif: "image/gif",
-    svg: "image/svg+xml",
-    md: "text/markdown",
-    txt: "text/plain",
-    csv: "text/csv",
+// top-level `artifacts` tool は string content を受け取る。拡張子で kind を
+// 決めるのは「content をどう解釈するか」の content 層の判断であり、
+// ADR-007 が排除したかった "どの store に保存するか" の storage 層の判断とは別物。
+// `.json` のみ JSON parse + JSON kind、他はすべて file kind として保存する。
+function stringContentToArtifactValue(
+  filename: string,
+  content: string,
+): { ok: true; value: ArtifactValue } | { ok: false; error: string } {
+  const isJsonFile = detectType(filename) === "json";
+
+  if (isJsonFile) {
+    try {
+      return { ok: true, value: { kind: "json", data: JSON.parse(content) } };
+    } catch (e) {
+      return {
+        ok: false,
+        error: `Error: Invalid JSON content for ${filename}: ${e instanceof Error ? e.message : String(e)}`,
+      };
+    }
+  }
+
+  return {
+    ok: true,
+    value: {
+      kind: "file",
+      bytes: new TextEncoder().encode(content),
+      mimeType: getMimeType(filename),
+    },
   };
-  return mimeTypes[ext] || "application/octet-stream";
+}
+
+function artifactValueToString(value: ArtifactValue): string {
+  if (value.kind === "json") {
+    return JSON.stringify(value.data, null, 2);
+  }
+  return new TextDecoder().decode(value.bytes);
 }

--- a/src/shared/artifact-mime.ts
+++ b/src/shared/artifact-mime.ts
@@ -1,0 +1,24 @@
+const MIME_TYPES: Record<string, string> = {
+  html: "text/html",
+  htm: "text/html",
+  css: "text/css",
+  js: "application/javascript",
+  json: "application/json",
+  png: "image/png",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  gif: "image/gif",
+  webp: "image/webp",
+  svg: "image/svg+xml",
+  md: "text/markdown",
+  markdown: "text/markdown",
+  txt: "text/plain",
+  csv: "text/csv",
+  pdf: "application/pdf",
+  xml: "application/xml",
+};
+
+export function getMimeType(filename: string): string {
+  const ext = filename.split(".").pop()?.toLowerCase() ?? "";
+  return MIME_TYPES[ext] ?? "application/octet-stream";
+}


### PR DESCRIPTION
## Summary

#139 で新 Port に移行済みだった `artifacts-handler.ts` を、ADR-007 の観点で整理する Issue #134 の実装。

### 変更

- string content ↔ `ArtifactValue` の変換を `stringContentToArtifactValue` / `artifactValueToString` に抽出し、`create` / `rewrite` / `update` の重複を解消
- `JSON.parse` 失敗を catch して actionable なエラー (\`Invalid JSON content for ...\`) を AI に返す
- mime 判定を \`src/shared/artifact-mime.ts\` に切り出し、後続 #133 でも参照できるよう共通化

### `detectType` 残置の整理

ADR-007 が排除したかった **storage 分岐** (どの store に保存するか) は完全に消滅済み。content 層での \`.json\` 判定 (string 引数を JSON parse すべきか) は top-level tool が string content を受け取る API 仕様上必要な責務として残す (コメントで意図を明記)。

### テスト (19 ケース追加)

- create: JSON/file 振り分け、panel 自動展開、重複 reject、不正 JSON エラー、未知拡張子
- rewrite / update / get / delete: kind 問わず動く
- JSON round-trip via update の find/replace
- validation / AbortSignal

## Test plan

- [x] 全テスト pass (1033/1033)
- [x] TypeScript 0 error
- [x] fmt / lint clean
- [x] 依存 issue: #132 (merge 済み)

## 関連

- Issue #134
- ADR-007: docs/decisions/007-artifact-storage-unification.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)