### PR TITLE
feat(tools): REPL helper saveArtifact with auto type inference [ADR-007 2/7]

### DIFF
--- a/src/features/tools/providers/__tests__/artifact-provider.test.ts
+++ b/src/features/tools/providers/__tests__/artifact-provider.test.ts
@@ -1,0 +1,283 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { InMemoryArtifactStorage } from "@/adapters/storage/in-memory-storage";
+import type { ProviderContext } from "@/ports/runtime-provider";
+import { ArtifactProvider, inferArtifactValue } from "../artifact-provider";
+
+function makeContext(storage: InMemoryArtifactStorage): ProviderContext {
+  return {
+    browser: {} as ProviderContext["browser"],
+    artifactStorage: storage,
+  };
+}
+
+describe("ArtifactProvider.handleRequest", () => {
+  let provider: ArtifactProvider;
+  let storage: InMemoryArtifactStorage;
+  let ctx: ProviderContext;
+
+  beforeEach(() => {
+    provider = new ArtifactProvider();
+    storage = new InMemoryArtifactStorage();
+    ctx = makeContext(storage);
+  });
+
+  describe("saveArtifact", () => {
+    it("saves objects as kind:json", async () => {
+      const result = await provider.handleRequest(
+        { id: "1", action: "saveArtifact", name: "products", data: [{ name: "A" }] },
+        ctx,
+      );
+
+      expect(result.ok).toBe(true);
+      const stored = await storage.get("products");
+      expect(stored).toEqual({ kind: "json", data: [{ name: "A" }] });
+    });
+
+    it("saves strings without extension as kind:json", async () => {
+      await provider.handleRequest(
+        { id: "1", action: "saveArtifact", name: "note", data: "hello" },
+        ctx,
+      );
+      const stored = await storage.get("note");
+      expect(stored).toEqual({ kind: "json", data: "hello" });
+    });
+
+    it("saves strings with extension as kind:file (UTF-8)", async () => {
+      await provider.handleRequest(
+        { id: "1", action: "saveArtifact", name: "report.html", data: "<h1>ok</h1>" },
+        ctx,
+      );
+      const stored = await storage.get("report.html");
+      expect(stored?.kind).toBe("file");
+      if (stored?.kind !== "file") return;
+      expect(stored.mimeType).toBe("text/html");
+      expect(new TextDecoder().decode(stored.bytes)).toBe("<h1>ok</h1>");
+    });
+
+    it("saves strings with explicit mimeType as kind:file even without extension", async () => {
+      await provider.handleRequest(
+        {
+          id: "1",
+          action: "saveArtifact",
+          name: "untitled",
+          data: "raw text",
+          mimeType: "text/plain",
+        },
+        ctx,
+      );
+      const stored = await storage.get("untitled");
+      expect(stored?.kind).toBe("file");
+      if (stored?.kind !== "file") return;
+      expect(stored.mimeType).toBe("text/plain");
+    });
+
+    it("saves Uint8Array as kind:file with inferred mimeType", async () => {
+      const bytes = new Uint8Array([1, 2, 3]);
+      await provider.handleRequest(
+        { id: "1", action: "saveArtifact", name: "icon.png", data: bytes },
+        ctx,
+      );
+      const stored = await storage.get("icon.png");
+      expect(stored?.kind).toBe("file");
+      if (stored?.kind !== "file") return;
+      expect(stored.mimeType).toBe("image/png");
+      expect(Array.from(stored.bytes)).toEqual([1, 2, 3]);
+    });
+
+    it("respects visible: false", async () => {
+      await provider.handleRequest(
+        {
+          id: "1",
+          action: "saveArtifact",
+          name: "_debug",
+          data: { log: 1 },
+          visible: false,
+        },
+        ctx,
+      );
+      const list = await storage.list();
+      const entry = list.find((a) => a.name === "_debug");
+      expect(entry?.visible).toBe(false);
+    });
+
+    it("defaults to visible: true when option omitted", async () => {
+      await provider.handleRequest(
+        { id: "1", action: "saveArtifact", name: "public", data: { x: 1 } },
+        ctx,
+      );
+      const list = await storage.list();
+      expect(list.find((a) => a.name === "public")?.visible).toBe(true);
+    });
+  });
+
+  describe("getArtifact", () => {
+    it("returns ArtifactValue for json", async () => {
+      await storage.put("x", { kind: "json", data: { foo: 1 } });
+      const result = await provider.handleRequest(
+        { id: "1", action: "getArtifact", name: "x" },
+        ctx,
+      );
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value).toEqual({ kind: "json", data: { foo: 1 } });
+    });
+
+    it("returns ArtifactValue for file", async () => {
+      await storage.put("y.png", {
+        kind: "file",
+        bytes: new Uint8Array([9, 8, 7]),
+        mimeType: "image/png",
+      });
+      const result = await provider.handleRequest(
+        { id: "1", action: "getArtifact", name: "y.png" },
+        ctx,
+      );
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      const value = result.value as { kind: string; bytes: Uint8Array; mimeType: string };
+      expect(value.kind).toBe("file");
+      expect(Array.from(value.bytes)).toEqual([9, 8, 7]);
+      expect(value.mimeType).toBe("image/png");
+    });
+
+    it("returns error when missing", async () => {
+      const result = await provider.handleRequest(
+        { id: "1", action: "getArtifact", name: "nope" },
+        ctx,
+      );
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.message).toContain("not found");
+    });
+  });
+
+  describe("listArtifacts", () => {
+    it("returns ArtifactMeta[] with both kinds", async () => {
+      await storage.put("a.json", { kind: "json", data: { x: 1 } });
+      await storage.put("b.html", {
+        kind: "file",
+        bytes: new TextEncoder().encode("<p/>"),
+        mimeType: "text/html",
+      });
+      const result = await provider.handleRequest({ id: "1", action: "listArtifacts" }, ctx);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      const list = result.value as Array<{ name: string; kind: string }>;
+      const names = list.map((a) => a.name).sort();
+      expect(names).toEqual(["a.json", "b.html"]);
+      const kinds = Object.fromEntries(list.map((a) => [a.name, a.kind]));
+      expect(kinds).toEqual({ "a.json": "json", "b.html": "file" });
+    });
+  });
+
+  describe("deleteArtifact", () => {
+    it("deletes regardless of kind", async () => {
+      await storage.put("x.json", { kind: "json", data: {} });
+      await provider.handleRequest({ id: "1", action: "deleteArtifact", name: "x.json" }, ctx);
+      expect(await storage.get("x.json")).toBeNull();
+    });
+  });
+
+  describe("deprecated wire protocol", () => {
+    it("still accepts createOrUpdateArtifact and routes to json", async () => {
+      const result = await provider.handleRequest(
+        { id: "1", action: "createOrUpdateArtifact", name: "legacy", data: { foo: 1 } },
+        ctx,
+      );
+      expect(result.ok).toBe(true);
+      const stored = await storage.get("legacy");
+      expect(stored).toEqual({ kind: "json", data: { foo: 1 } });
+    });
+
+    it("still accepts returnFile (base64) and routes to file", async () => {
+      const contentBase64 = btoa("hello");
+      await provider.handleRequest(
+        {
+          id: "1",
+          action: "returnFile",
+          name: "legacy.txt",
+          contentBase64,
+          mimeType: "text/plain",
+        },
+        ctx,
+      );
+      const stored = await storage.get("legacy.txt");
+      expect(stored?.kind).toBe("file");
+      if (stored?.kind !== "file") return;
+      expect(new TextDecoder().decode(stored.bytes)).toBe("hello");
+      expect(stored.mimeType).toBe("text/plain");
+    });
+  });
+
+  it("rejects unknown action", async () => {
+    const result = await provider.handleRequest({ id: "1", action: "bogus" }, ctx);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.message).toContain("Unknown artifact action");
+  });
+});
+
+describe("inferArtifactValue", () => {
+  it("Uint8Array → file", () => {
+    const value = inferArtifactValue("x.bin", new Uint8Array([1, 2]), undefined);
+    expect(value.kind).toBe("file");
+  });
+
+  it("object → json", () => {
+    const value = inferArtifactValue("x", { foo: 1 }, undefined);
+    expect(value).toEqual({ kind: "json", data: { foo: 1 } });
+  });
+
+  it("null → json", () => {
+    const value = inferArtifactValue("x", null, undefined);
+    expect(value).toEqual({ kind: "json", data: null });
+  });
+
+  it("number → json", () => {
+    const value = inferArtifactValue("x", 42, undefined);
+    expect(value).toEqual({ kind: "json", data: 42 });
+  });
+
+  it("boolean → json", () => {
+    const value = inferArtifactValue("x", true, undefined);
+    expect(value).toEqual({ kind: "json", data: true });
+  });
+
+  it("array → json", () => {
+    const value = inferArtifactValue("x", [1, 2, 3], undefined);
+    expect(value).toEqual({ kind: "json", data: [1, 2, 3] });
+  });
+
+  it("string + no extension + no mimeType → json", () => {
+    const value = inferArtifactValue("note", "hello", undefined);
+    expect(value).toEqual({ kind: "json", data: "hello" });
+  });
+
+  it("string + extension → file", () => {
+    const value = inferArtifactValue("doc.md", "# title", undefined);
+    expect(value.kind).toBe("file");
+    if (value.kind !== "file") return;
+    expect(value.mimeType).toBe("text/markdown");
+  });
+
+  it("string + explicit mimeType → file", () => {
+    const value = inferArtifactValue("untitled", "raw", "text/plain");
+    expect(value.kind).toBe("file");
+    if (value.kind !== "file") return;
+    expect(value.mimeType).toBe("text/plain");
+  });
+
+  it("file with unknown extension → file with octet-stream", () => {
+    const value = inferArtifactValue("blob.xyz", "data", undefined);
+    expect(value.kind).toBe("file");
+    if (value.kind !== "file") return;
+    expect(value.mimeType).toBe("application/octet-stream");
+  });
+
+  it("explicit mimeType overrides extension inference", () => {
+    const value = inferArtifactValue("page.html", "raw", "text/plain");
+    expect(value.kind).toBe("file");
+    if (value.kind !== "file") return;
+    expect(value.mimeType).toBe("text/plain");
+  });
+});

--- a/src/features/tools/providers/artifact-provider.ts
+++ b/src/features/tools/providers/artifact-provider.ts
@@ -1,57 +1,72 @@
+import type { ArtifactValue } from "@/ports/artifact-storage";
 import type { RuntimeProvider, SandboxRequest, ProviderContext } from "@/ports/runtime-provider";
+import { getMimeType } from "@/shared/artifact-mime";
 import type { Result, ToolError } from "@/shared/errors";
 import { ok, err } from "@/shared/errors";
 
 /**
- * ArtifactProvider - Artifact Functions の提供
+ * ArtifactProvider - Artifact Functions の提供 (ADR-007)
  *
- * JSONデータの永続化ストレージを提供する。
+ * AI は `saveArtifact / getArtifact / listArtifacts / deleteArtifact` の 4 helper で
+ * JSON 値・ファイルを同一ネームスペースで扱う。旧 `createOrUpdateArtifact` /
+ * `returnFile` は deprecation wrapper として残し、内部で `saveArtifact` へ forward する。
  */
 export class ArtifactProvider implements RuntimeProvider {
   readonly actions = [
-    "createOrUpdateArtifact",
+    "saveArtifact",
     "getArtifact",
     "listArtifacts",
     "deleteArtifact",
+    // Legacy action names still accepted; wrapper helpers ride on them as a safety net
+    // even though the emitted runtime now sends only the new names.
+    "createOrUpdateArtifact",
     "returnFile",
   ] as const;
 
   getDescription(): string {
     return `## Artifact Functions (Data Persistence)
 
-Store and retrieve JSON data across REPL executions:
+Artifacts persist across REPL executions in a single unified store. Save JSON
+values, text, or binary bytes with the same API.
 
-- \`await createOrUpdateArtifact(name, data)\` - Save JSON data
-- \`await getArtifact(name)\` - Retrieve saved data
-- \`await listArtifacts()\` - List all artifact names
-- \`await deleteArtifact(name)\` - Delete an artifact
+- \`await saveArtifact(name, data, options?)\` — save anything
+  - \`data\`: object/array/number → JSON; \`Uint8Array\` → binary file;
+    \`string\` + \`options.mimeType\` or \`name\` has extension → file (UTF-8); otherwise → JSON string
+  - \`options.mimeType\`: override inferred MIME (e.g. "text/plain")
+  - \`options.visible\`: \`false\` keeps it out of the UI Artifact Panel (scratch data)
+- \`await getArtifact(name)\` — returns \`{ kind: "json", data }\` or \`{ kind: "file", bytes, mimeType }\`
+- \`await listArtifacts()\` — returns \`[{ name, kind, mimeType?, size, visible, createdAt, updatedAt }, ...]\`
+- \`await deleteArtifact(name)\` — delete (any kind)
 
 \`\`\`javascript
-// Save scraping results
-await createOrUpdateArtifact("products", [{ name: "A" }, { name: "B" }]);
+// JSON
+await saveArtifact("products", [{ name: "A" }]);
+const result = await getArtifact("products");
+// result => { kind: "json", data: [{ name: "A" }] }
 
-// Retrieve in another script
-const products = await getArtifact("products");
+// HTML (string + extension → file)
+await saveArtifact("report.html", "<!doctype html><h1>ok</h1>");
+
+// Binary
+await saveArtifact("icon.png", new Uint8Array([...]), { mimeType: "image/png" });
+
+// Scratch data (hidden from UI)
+await saveArtifact("_debug", logEntries, { visible: false });
+
+// Inspect what you have
+const items = await listArtifacts();
+// items => [{ name: "products", kind: "json", size: 24, visible: true, ... }, ...]
 \`\`\`
 
-## File Functions
+### Deprecated (will be removed in a future release)
 
-Return files to the AI:
-
-- \`await returnFile(name, content, mimeType)\`
-  - name: filename (e.g., "data.csv")
-  - content: string or Uint8Array
-  - mimeType: e.g., "text/csv", "application/pdf"
-
-\`\`\`javascript
-const csv = "name,price\\nA,100\\nB,200";
-await returnFile("products.csv", csv, "text/csv");
-\`\`\``;
+- \`createOrUpdateArtifact(name, data)\` → use \`saveArtifact(name, data)\`
+- \`returnFile(name, content, mimeType)\` → use \`saveArtifact(name, content, { mimeType })\``;
   }
 
   getRuntimeCode(): string {
     return `
-function createOrUpdateArtifact(name, data) {
+function __artifactRequest(action, payload) {
   return new Promise((resolve, reject) => {
     const id = 'req_' + Date.now() + '_' + Math.random().toString(36).slice(2, 8);
     const handler = (event) => {
@@ -65,107 +80,41 @@ function createOrUpdateArtifact(name, data) {
       }
     };
     window.addEventListener('message', handler);
-    window.parent.postMessage({ type: 'sandbox-request', id, action: 'createOrUpdateArtifact', name, data }, '*');
+    window.parent.postMessage({ type: 'sandbox-request', id, action, ...payload }, '*');
+  });
+}
+
+function saveArtifact(name, data, options) {
+  const opts = options || {};
+  return __artifactRequest('saveArtifact', {
+    name,
+    data,
+    mimeType: opts.mimeType,
+    visible: opts.visible,
   });
 }
 
 function getArtifact(name) {
-  return new Promise((resolve, reject) => {
-    const id = 'req_' + Date.now() + '_' + Math.random().toString(36).slice(2, 8);
-    const handler = (event) => {
-      if (event.data?.type === 'sandbox-response' && event.data.id === id) {
-        window.removeEventListener('message', handler);
-        if (event.data.ok) {
-          resolve(event.data.value);
-        } else {
-          reject(new Error(event.data.error));
-        }
-      }
-    };
-    window.addEventListener('message', handler);
-    window.parent.postMessage({ type: 'sandbox-request', id, action: 'getArtifact', name }, '*');
-  });
+  return __artifactRequest('getArtifact', { name });
 }
 
 function listArtifacts() {
-  return new Promise((resolve, reject) => {
-    const id = 'req_' + Date.now() + '_' + Math.random().toString(36).slice(2, 8);
-    const handler = (event) => {
-      if (event.data?.type === 'sandbox-response' && event.data.id === id) {
-        window.removeEventListener('message', handler);
-        if (event.data.ok) {
-          resolve(event.data.value);
-        } else {
-          reject(new Error(event.data.error));
-        }
-      }
-    };
-    window.addEventListener('message', handler);
-    window.parent.postMessage({ type: 'sandbox-request', id, action: 'listArtifacts' }, '*');
-  });
+  return __artifactRequest('listArtifacts', {});
 }
 
 function deleteArtifact(name) {
-  return new Promise((resolve, reject) => {
-    const id = 'req_' + Date.now() + '_' + Math.random().toString(36).slice(2, 8);
-    const handler = (event) => {
-      if (event.data?.type === 'sandbox-response' && event.data.id === id) {
-        window.removeEventListener('message', handler);
-        if (event.data.ok) {
-          resolve(event.data.value);
-        } else {
-          reject(new Error(event.data.error));
-        }
-      }
-    };
-    window.addEventListener('message', handler);
-    window.parent.postMessage({ type: 'sandbox-request', id, action: 'deleteArtifact', name }, '*');
-  });
+  return __artifactRequest('deleteArtifact', { name });
+}
+
+// --- Deprecated helpers (forward to saveArtifact) ---
+function createOrUpdateArtifact(name, data) {
+  console.warn('createOrUpdateArtifact() is deprecated; use saveArtifact(name, data).');
+  return saveArtifact(name, data);
 }
 
 function returnFile(name, content, mimeType) {
-  return new Promise((resolve, reject) => {
-    const id = 'req_' + Date.now() + '_' + Math.random().toString(36).slice(2, 8);
-    const handler = (event) => {
-      if (event.data?.type === 'sandbox-response' && event.data.id === id) {
-        window.removeEventListener('message', handler);
-        if (event.data.ok) {
-          resolve(event.data.value);
-        } else {
-          reject(new Error(event.data.error));
-        }
-      }
-    };
-    window.addEventListener('message', handler);
-    const bytes = toUtf8Bytes(content);
-    const size = bytes.byteLength;
-    const contentBase64 = arrayBufferToBase64(bytes);
-    window.parent.postMessage({ type: 'sandbox-request', id, action: 'returnFile', name, contentBase64, mimeType, size }, '*');
-  });
-}
-
-function toUtf8Bytes(content) {
-  if (typeof content === 'string') {
-    return new TextEncoder().encode(content);
-  }
-
-  if (content instanceof Uint8Array) {
-    return content;
-  }
-
-  if (ArrayBuffer.isView(content)) {
-    return new Uint8Array(content.buffer, content.byteOffset, content.byteLength);
-  }
-
-  return new Uint8Array(content);
-}
-
-function arrayBufferToBase64(bytes) {
-  let binary = '';
-  for (let i = 0; i < bytes.byteLength; i++) {
-    binary += String.fromCharCode(bytes[i]);
-  }
-  return btoa(binary);
+  console.warn('returnFile() is deprecated; use saveArtifact(name, content, { mimeType }).');
+  return saveArtifact(name, content, { mimeType });
 }`;
   }
 
@@ -178,34 +127,44 @@ function arrayBufferToBase64(bytes) {
 
     try {
       switch (action) {
-        case "createOrUpdateArtifact": {
-          const { name, data } = request as unknown as { name: string; data: unknown };
-          await artifactStorage.put(name, { kind: "json", data });
-          return ok({ success: true, name });
+        case "saveArtifact": {
+          const { name, data, mimeType, visible } = request as unknown as {
+            name: string;
+            data: unknown;
+            mimeType?: string;
+            visible?: boolean;
+          };
+          const value = inferArtifactValue(name, data, mimeType);
+          await artifactStorage.put(name, value, visible === undefined ? undefined : { visible });
+          return ok({ success: true, name, kind: value.kind });
         }
 
         case "getArtifact": {
           const { name } = request as unknown as { name: string };
           const artifact = await artifactStorage.get(name);
-          if (artifact === null || artifact.kind !== "json") {
+          if (artifact === null) {
             return err({
               code: "tool_script_error",
               message: `Artifact '${name}' not found`,
             });
           }
-          return ok(artifact.data);
+          return ok(artifact);
         }
 
         case "listArtifacts": {
-          const list = (await artifactStorage.list())
-            .filter((artifact) => artifact.kind === "json")
-            .map((artifact) => artifact.name);
-          return ok(list);
+          return ok(await artifactStorage.list());
         }
 
         case "deleteArtifact": {
           const { name } = request as unknown as { name: string };
           await artifactStorage.delete(name);
+          return ok({ success: true, name });
+        }
+
+        // --- Legacy wire protocol (no longer emitted by getRuntimeCode, kept for safety) ---
+        case "createOrUpdateArtifact": {
+          const { name, data } = request as unknown as { name: string; data: unknown };
+          await artifactStorage.put(name, { kind: "json", data });
           return ok({ success: true, name });
         }
 
@@ -240,6 +199,41 @@ function arrayBufferToBase64(bytes) {
       });
     }
   }
+}
+
+/**
+ * saveArtifact の自動型判別:
+ * - Uint8Array → file (mimeType 指定なければ拡張子から推測)
+ * - string かつ mimeType 指定あり → file
+ * - string かつ name に拡張子あり → file (mimeType は拡張子から)
+ * - それ以外 (object / array / primitive / 拡張子なしの string) → json
+ */
+export function inferArtifactValue(
+  name: string,
+  data: unknown,
+  mimeType: string | undefined,
+): ArtifactValue {
+  if (data instanceof Uint8Array) {
+    return {
+      kind: "file",
+      bytes: data,
+      mimeType: mimeType ?? getMimeType(name),
+    };
+  }
+
+  if (typeof data === "string" && (mimeType || hasFileExtension(name))) {
+    return {
+      kind: "file",
+      bytes: new TextEncoder().encode(data),
+      mimeType: mimeType ?? getMimeType(name),
+    };
+  }
+
+  return { kind: "json", data };
+}
+
+function hasFileExtension(name: string): boolean {
+  return /\.[^./\\]+$/.test(name);
 }
 
 function base64ToBytes(base64: string): Uint8Array {


### PR DESCRIPTION
## Summary

ADR-007 step 4 (#133) の実装。REPL 内で AI が呼ぶ artifact helper を **新 4 本に統一**する。

### 新 helper

- \`saveArtifact(name, data, options?)\` — 自動型判別 (Uint8Array → file / 拡張子 or mimeType 指定 string → file / それ以外 → json)
- \`getArtifact(name)\` — \`ArtifactValue\` (\`{kind, data|bytes|mimeType}\`) を返す
- \`listArtifacts()\` — \`ArtifactMeta[]\` を返す
- \`deleteArtifact(name)\` — 不変

### 破壊的変更

- \`getArtifact\` / \`listArtifacts\` の戻り値 shape が変更される (旧: JSON data / string[] → 新: ArtifactValue / ArtifactMeta[])
- ただし REPL runtime code は毎回新しく injection されるので、常に新 API で動作する
- #136 で description を新 API 前提に書き直すため AI プロンプトとも同期

### 旧 helper (deprecation wrapper)

\`createOrUpdateArtifact\` / \`returnFile\` は \`console.warn\` 付きで runtime code に残置。handleRequest も旧 wire action を safety net として受け続ける (#137 で最終削除予定)。

### 自動型判別

\`inferArtifactValue(name, data, mimeType?)\` に集約、純関数として export。

## Test plan

- [x] ArtifactProvider.handleRequest: 14 ケース (saveArtifact 7 / getArtifact 3 / listArtifacts / deleteArtifact / deprecated wire 2 / unknown action)
- [x] \`inferArtifactValue\` 単体: 12 ケース (Uint8Array / object / null / number / boolean / array / string w/ or w/o extension / explicit mimeType override)
- [x] 全テスト pass (1059/1059)
- [x] TypeScript 0 error
- [x] fmt / lint clean

## 関連

- Issue #133
- ADR-007: docs/decisions/007-artifact-storage-unification.md
- 依存: #132 (merge 済み), #134 (PR #141 merge 済み)

🤖 Generated with [Claude Code](https://claude.com/claude-code)