### PR TITLE
feat(artifacts): surface kind in UI and remove redundant addArtifact [ADR-007 4/7]

### DIFF
--- a/src/features/artifacts/ArtifactFileItem.tsx
+++ b/src/features/artifacts/ArtifactFileItem.tsx
@@ -12,6 +12,10 @@ const TYPE_ICONS: Record<ArtifactEntry["type"], React.ReactNode> = {
   binary: <File size={14} />,
 };
 
+function kindLabel(source: ArtifactEntry["source"]): string {
+  return source === "json" ? "JSON 値" : "ファイル";
+}
+
 export function ArtifactFileItem({
   artifact,
   selected,
@@ -37,11 +41,23 @@ export function ArtifactFileItem({
       }}
       className="hover-highlight"
     >
-      <Box c={selected ? "indigo" : "dimmed"} style={{ flexShrink: 0 }}>
+      <Box
+        c={selected ? "indigo" : "dimmed"}
+        style={{ flexShrink: 0 }}
+        title={kindLabel(artifact.source)}
+      >
         {TYPE_ICONS[artifact.type]}
       </Box>
       <Text size="xs" truncate style={{ flex: 1 }} fw={selected ? 500 : 400}>
         {artifact.name}
+      </Text>
+      <Text
+        size="10"
+        c="dimmed"
+        style={{ flexShrink: 0, textTransform: "uppercase", letterSpacing: 0.5 }}
+        data-testid="artifact-kind-badge"
+      >
+        {artifact.source}
       </Text>
       <ActionIcon
         variant="subtle"

--- a/src/features/artifacts/__tests__/ArtifactFileItem.test.ts
+++ b/src/features/artifacts/__tests__/ArtifactFileItem.test.ts
@@ -1,0 +1,102 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { MantineProvider } from "@mantine/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ArtifactStoragePort } from "@/ports/artifact-storage";
+import { initStore, useStore } from "@/store";
+import { ArtifactFileItem } from "../ArtifactFileItem";
+
+function makeStorage(): ArtifactStoragePort {
+  return {
+    put: vi.fn(),
+    get: vi.fn(),
+    list: vi.fn().mockResolvedValue([]),
+    delete: vi.fn(),
+    clearAll: vi.fn(),
+    setSessionId: vi.fn(),
+    createOrUpdate: vi.fn(),
+    saveFile: vi.fn(),
+    getFile: vi.fn(),
+    listFiles: vi.fn().mockResolvedValue([]),
+    deleteFile: vi.fn(),
+  };
+}
+
+describe("ArtifactFileItem", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    vi.stubGlobal(
+      "matchMedia",
+      vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    );
+    initStore(makeStorage());
+    useStore.setState(useStore.getInitialState());
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.restoreAllMocks();
+  });
+
+  async function render(artifact: Parameters<typeof ArtifactFileItem>[0]["artifact"]) {
+    await act(async () => {
+      root.render(
+        createElement(
+          MantineProvider,
+          null,
+          createElement(ArtifactFileItem, { artifact, selected: false }),
+        ),
+      );
+    });
+  }
+
+  it("shows 'json' kind badge for source === 'json'", async () => {
+    await render({
+      name: "data.json",
+      type: "json",
+      source: "json",
+      updatedAt: Date.now(),
+    });
+    const badge = container.querySelector('[data-testid="artifact-kind-badge"]');
+    expect(badge?.textContent).toBe("json");
+  });
+
+  it("shows 'file' kind badge for source === 'file'", async () => {
+    await render({
+      name: "page.html",
+      type: "html",
+      source: "file",
+      updatedAt: Date.now(),
+    });
+    const badge = container.querySelector('[data-testid="artifact-kind-badge"]');
+    expect(badge?.textContent).toBe("file");
+  });
+
+  it("renders the filename", async () => {
+    await render({
+      name: "my-artifact.md",
+      type: "markdown",
+      source: "file",
+      updatedAt: Date.now(),
+    });
+    expect(container.textContent).toContain("my-artifact.md");
+  });
+});

--- a/src/features/artifacts/artifact-slice.ts
+++ b/src/features/artifacts/artifact-slice.ts
@@ -13,11 +13,6 @@ export interface ArtifactSlice {
   removeArtifact(name: string): Promise<void>;
   clearArtifacts(): void;
   setArtifacts(artifacts: ArtifactEntry[]): void;
-  addArtifact(
-    name: string,
-    type: ArtifactEntry["type"],
-    source: ArtifactEntry["source"],
-  ): Promise<void>;
 }
 
 export function createArtifactSlice(
@@ -68,22 +63,5 @@ export function createArtifactSlice(
     },
 
     setArtifacts: (artifacts) => set({ artifacts }),
-
-    addArtifact: async (name, type, source) => {
-      const entry: ArtifactEntry = {
-        name,
-        type,
-        source,
-        updatedAt: Date.now(),
-      };
-      set((s) => {
-        const existing = s.artifacts.findIndex((a) => a.name === name);
-        const artifacts =
-          existing >= 0
-            ? s.artifacts.map((a, i) => (i === existing ? entry : a))
-            : [...s.artifacts, entry];
-        return { artifacts, selectedArtifact: name };
-      });
-    },
   });
 }

--- a/src/features/tools/index.ts
+++ b/src/features/tools/index.ts
@@ -33,10 +33,7 @@ import { handleArtifactsTool } from "./handlers/artifacts-handler";
 export { replToolDef, buildReplToolDef, executeRepl, formatSkillsForSandbox };
 export { navigateToolDef, executeNavigate };
 export { inspectToolDef, executeInspect };
-export {
-  skillToolDef,
-  executeSkill,
-};
+export { skillToolDef, executeSkill };
 export { bgFetchToolDef, executeBgFetch };
 export { artifactsTool, handleArtifactsTool };
 export type {
@@ -112,9 +109,6 @@ export function createToolExecutorWithSkills(
           artifactStorage,
           args as { title?: string; code: string },
           skillMatches,
-          (name) => {
-            void useStore.getState().addArtifact(name, "json", "json");
-          },
           signal,
           hooks?.onConsoleLog,
         );
@@ -125,13 +119,16 @@ export function createToolExecutorWithSkills(
           args as { url?: string; newTab?: boolean; listTabs?: boolean; switchToTab?: number },
         );
       case "inspect":
-        return executeInspect(browser, args as {
-          action: "pick_element" | "screenshot" | "extract_image";
-          message?: string;
-          selector?: string;
-          selectors?: string[];
-          maxWidth?: number;
-        });
+        return executeInspect(
+          browser,
+          args as {
+            action: "pick_element" | "screenshot" | "extract_image";
+            message?: string;
+            selector?: string;
+            selectors?: string[];
+            maxWidth?: number;
+          },
+        );
       case "bg_fetch": {
         const bgFetchEnabled = useStore.getState().settings.enableBgFetch;
         if (!bgFetchEnabled) {

--- a/src/features/tools/repl.ts
+++ b/src/features/tools/repl.ts
@@ -274,7 +274,6 @@ async function handleSandboxRequest(
   artifactStorage: ArtifactStoragePort,
   signal?: AbortSignal,
   onReturnFile?: (name: string) => void,
-  onCreateOrUpdateArtifact?: (name: string) => void,
   skillMatches?: readonly SkillMatch[],
 ): Promise<void> {
   const registry = getProviderRegistry();
@@ -304,10 +303,6 @@ async function handleSandboxRequest(
         const name = (msg as { name?: string }).name;
         if (name) onReturnFile(name);
       }
-      if (msg.action === "createOrUpdateArtifact" && onCreateOrUpdateArtifact) {
-        const name = (msg as { name?: string }).name;
-        if (name) onCreateOrUpdateArtifact(name);
-      }
       sandboxWindow.postMessage(
         { type: "sandbox-response", id: msg.id, ok: true, value: result.value },
         "*",
@@ -336,7 +331,6 @@ export async function executeRepl(
   artifactStorage: ArtifactStoragePort,
   args: { title?: string; code: string },
   skillMatches?: readonly SkillMatch[],
-  onArtifactCreated?: (name: string) => void,
   signal?: AbortSignal,
   onConsoleLog?: (message: string) => void,
 ): Promise<Result<ReplResult, ToolError>> {
@@ -418,7 +412,6 @@ export async function executeRepl(
           artifactStorage,
           signal,
           (name) => returnedFileNames.add(name),
-          onArtifactCreated,
           skillMatches,
         );
         return;


### PR DESCRIPTION
## Summary

Issue #135 実装。slice / UI / REPL 側を新 Port に合わせて整理する。

### slice 側

- **\`addArtifact\` メソッドを削除**
  - REPL 完了後 \`artifactAutoExpand.onReplCompleted\` が \`loadArtifacts()\` を呼び storage から再同期する経路と重複していた
  - hardcode された \`("json", "json")\` で saveArtifact の file kind を反映できなかった不具合も解消
  - stale state race が消滅し単一経路化

### REPL 側

- \`handleSandboxRequest\` / \`executeRepl\` から \`onCreateOrUpdateArtifact\` / \`onArtifactCreated\` パラメータを削除
- \`tools/index.ts\` の \`repl\` ケースも引数整合

### UI 側 (\`ArtifactFileItem\`)

- **kind バッジ**を右端に追加 (\`source\` 値 "json"/"file" を uppercase + letter-spacing で小さく表示)
- アイコン側に \`title\` 属性 (hover で "JSON 値" / "ファイル" の日本語ラベル)
- \`data-testid=\"artifact-kind-badge\"\` でテスト対応

### 新規テスト

- \`ArtifactFileItem.test.ts\` 3 ケース: json / file バッジ表示、filename レンダリング

## Test plan

- [x] 全テスト pass (1062/1062)
- [x] \`addArtifact\` 削除で既存テスト破壊なし
- [x] \`visible: false\` フィルタは従来どおり
- [x] TypeScript 0 error
- [x] fmt / lint clean

## 関連

- Issue #135
- ADR-007: docs/decisions/007-artifact-storage-unification.md
- 依存: #132 (merge 済み), #134 (PR #141 merge 済み), #133 (PR #142 merge 済み)

🤖 Generated with [Claude Code](https://claude.com/claude-code)