### PR TITLE
fix(tools): show saveArtifact files in REPL result UI

### DIFF
--- a/src/features/tools/__tests__/repl.test.ts
+++ b/src/features/tools/__tests__/repl.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildReplToolDef } from "../repl";
+import { buildReplToolDef, isFileSaveAction } from "../repl";
 
 describe("buildReplToolDef", () => {
   it("COMMON_PATTERNS をデフォルトでは含めない", () => {
@@ -32,5 +32,36 @@ describe("buildReplToolDef", () => {
 
     expect(def.description).toContain("window.youtube.getVideoInfo()");
     expect(def.description).not.toContain("new Function(`return (${code})`)()");
+  });
+});
+
+describe("isFileSaveAction", () => {
+  it("returnFile は常に true", () => {
+    expect(isFileSaveAction("returnFile", { success: true })).toBe(true);
+    expect(isFileSaveAction("returnFile", null)).toBe(true);
+  });
+
+  it("saveArtifact + kind:file は true", () => {
+    expect(isFileSaveAction("saveArtifact", { success: true, name: "x.html", kind: "file" })).toBe(
+      true,
+    );
+  });
+
+  it("saveArtifact + kind:json は false", () => {
+    expect(isFileSaveAction("saveArtifact", { success: true, name: "data", kind: "json" })).toBe(
+      false,
+    );
+  });
+
+  it("saveArtifact で result が不正な形でも false (throw しない)", () => {
+    expect(isFileSaveAction("saveArtifact", null)).toBe(false);
+    expect(isFileSaveAction("saveArtifact", "unexpected")).toBe(false);
+    expect(isFileSaveAction("saveArtifact", {})).toBe(false);
+  });
+
+  it("関係ない action は false", () => {
+    expect(isFileSaveAction("getArtifact", { kind: "file" })).toBe(false);
+    expect(isFileSaveAction("listArtifacts", [])).toBe(false);
+    expect(isFileSaveAction("createOrUpdateArtifact", { success: true })).toBe(false);
   });
 });

--- a/src/features/tools/repl.ts
+++ b/src/features/tools/repl.ts
@@ -266,6 +266,19 @@ function uint8ArrayToBase64(bytes: Uint8Array): string {
 /**
  * Providerを使用してsandboxリクエストを処理する
  */
+/**
+ * REPL tool result UI の "Files" セクションに載せるべき保存アクションかを判定する。
+ * - legacy `returnFile` は常に file (action 自体が file 専用)
+ * - 新 `saveArtifact` は自動型判別なので、provider の返した `kind === "file"` の時だけ拾う
+ *   (kind: "json" を含めると REPL 内の単なる state 保存が毎回 "Files" に出てしまう)
+ */
+export function isFileSaveAction(action: string, resultValue: unknown): boolean {
+  if (action === "returnFile") return true;
+  if (action !== "saveArtifact") return false;
+  if (typeof resultValue !== "object" || resultValue === null) return false;
+  return (resultValue as { kind?: unknown }).kind === "file";
+}
+
 async function handleSandboxRequest(
   msg: { id: string; action: string; [key: string]: unknown },
   sandboxWindow: WindowProxy,
@@ -298,9 +311,11 @@ async function handleSandboxRequest(
     );
 
     if (result.ok) {
-      if (msg.action === "returnFile" && onReturnFile) {
+      if (onReturnFile) {
         const name = (msg as { name?: string }).name;
-        if (name) onReturnFile(name);
+        if (name && isFileSaveAction(msg.action, result.value)) {
+          onReturnFile(name);
+        }
       }
       sandboxWindow.postMessage(
         { type: "sandbox-response", id: msg.id, ok: true, value: result.value },


### PR DESCRIPTION
## Summary

ADR-007 統合レビュー (#138) で発見した UI 不整合 (#145) の修正。

REPL tool result UI の "Files" セクションは legacy \`returnFile\` action でしか artifact を拾わなかったため、新 \`saveArtifact\` で file を保存しても inline の "Files" リストに出ない状態だった。機能としては Artifact Panel への表示は正しく動作していたが、REPL 結果内の listing 不整合として残る。

### 修正

\`handleSandboxRequest\` に \`isFileSaveAction(action, resultValue)\` を追加:

| action | 判定 |
|--------|------|
| \`returnFile\` | 常に true |
| \`saveArtifact\` | \`result.value.kind === \"file\"\` の時だけ true |
| \`saveArtifact\` (kind:json) | false (REPL 内の state 保存まで拾うと UI ノイズになるため除外) |
| 他 | false |

### テスト

\`isFileSaveAction\` を export して 5 ケース単体テスト:
- returnFile は常に true
- saveArtifact + kind:file は true
- saveArtifact + kind:json は false
- saveArtifact で不正な result 形でも throw せず false
- 関係ない action は false

## Test plan

- [x] 全テスト pass (1066/1066)
- [x] TypeScript 0 error
- [x] fmt / lint clean

## 関連

- Closes #145
- Refs: ADR-007 統合レビュー #138
- 前提: ADR-007 実装一式 (#139 #140 #141 #142 #143 #144)

🤖 Generated with [Claude Code](https://claude.com/claude-code)