### PR TITLE
fix(sandbox): expose saveArtifact and deprecation wrappers in REPL

### DIFF
--- a/public/sandbox.html
+++ b/public/sandbox.html
@@ -50,23 +50,25 @@
         return btoa(binary);
       }
 
-      // Artifact functions
-      async function createOrUpdateArtifact(name, data) {
+      // Artifact functions (ADR-007 unified API)
+      async function saveArtifact(name, data, options) {
         if (typeof name !== "string" || !name) {
           throw new Error("Artifact name must be a non-empty string");
         }
-        return sendToParent("createOrUpdateArtifact", { name, data });
+        const opts = options || {};
+        return sendToParent("saveArtifact", {
+          name,
+          data,
+          mimeType: opts.mimeType,
+          visible: opts.visible,
+        });
       }
 
       async function getArtifact(name) {
         if (typeof name !== "string" || !name) {
           throw new Error("Artifact name must be a non-empty string");
         }
-        const data = await sendToParent("getArtifact", { name });
-        if (data === null) {
-          throw new Error(`Artifact '${name}' not found`);
-        }
-        return data;
+        return sendToParent("getArtifact", { name });
       }
 
       async function listArtifacts() {
@@ -80,30 +82,27 @@
         return sendToParent("deleteArtifact", { name });
       }
 
-      // File return function
+      // Deprecated helpers (forward to saveArtifact)
+      async function createOrUpdateArtifact(name, data) {
+        console.warn("createOrUpdateArtifact() is deprecated; use saveArtifact(name, data).");
+        return saveArtifact(name, data);
+      }
+
+      // File return function (deprecated; forwards to saveArtifact)
       async function returnFile(name, content, mimeType) {
+        console.warn(
+          "returnFile() is deprecated; use saveArtifact(name, content, { mimeType }).",
+        );
         if (typeof name !== "string" || !name) {
           throw new Error("File name must be a non-empty string");
         }
         if (!mimeType || typeof mimeType !== "string") {
           throw new Error("MIME type is required");
         }
-
-        // Convert to base64
-        let base64;
-        let size;
-        if (typeof content === "string") {
-          const utf8Bytes = new TextEncoder().encode(content);
-          base64 = arrayBufferToBase64(utf8Bytes);
-          size = utf8Bytes.length;
-        } else if (content instanceof Uint8Array) {
-          base64 = arrayBufferToBase64(content);
-          size = content.length;
-        } else {
+        if (typeof content !== "string" && !(content instanceof Uint8Array)) {
           throw new Error("Content must be string or Uint8Array");
         }
-
-        return sendToParent("returnFile", { name, contentBase64: base64, mimeType, size });
+        return saveArtifact(name, content, { mimeType });
       }
 
       // Native input functions (for bot-resistant sites)
@@ -260,10 +259,11 @@
               "readPage",
               "bgFetch",
               "skills",
-              "createOrUpdateArtifact",
+              "saveArtifact",
               "getArtifact",
               "listArtifacts",
               "deleteArtifact",
+              "createOrUpdateArtifact",
               "returnFile",
               "nativeClick",
               "nativeDoubleClick",
@@ -286,10 +286,11 @@
               readPage,
               bgFetch,
               skills,
-              createOrUpdateArtifact,
+              saveArtifact,
               getArtifact,
               listArtifacts,
               deleteArtifact,
+              createOrUpdateArtifact,
               returnFile,
               nativeClick,
               nativeDoubleClick,


### PR DESCRIPTION
## Summary

**ADR-007 の致命的な抜け漏れ**: 新 \`saveArtifact\` helper を追加したつもりが、sandbox.html (実際に REPL コードが走る場所) の更新が漏れていて、AI が \`saveArtifact(...)\` を呼ぶと **\"saveArtifact is not defined\"** で失敗していた。

### 根本原因

\`ArtifactProvider.getRuntimeCode()\` は定義されているが、**どこからも呼び出されない dead code**。REPL で実行される関数の実体は \`public/sandbox.html\` に hardcode されており、そこに saveArtifact が入っていなかった。

### 修正内容

1. **saveArtifact 関数を sandbox.html に追加** (\`action: \"saveArtifact\"\` で provider へ転送)
2. **createOrUpdateArtifact / returnFile を deprecation wrapper 化** — \`console.warn\` 付きで内部は saveArtifact へ forward
3. **getArtifact の戻り値取り扱いを新 shape (ArtifactValue union) に素通し** (旧: null なら throw → 新: provider 側で \"not found\" エラーを返すのを任せる)
4. **AsyncFunction 引数リストに saveArtifact を追加** — REPL コード内で新名前として呼べるようバインド。legacy 名も引き続きバインド済み

### 影響

- これで \`saveArtifact(name, data, options)\` が REPL から呼べるようになる
- 旧 \`createOrUpdateArtifact\` / \`returnFile\` も引き続き動く (deprecation 警告付き)
- dist の再ビルドが必要 (\`vp build\`) — sandbox.html が static asset として入る

## Test plan

- [x] 全テスト pass (1067/1067)
- [x] TypeScript 0 error
- [x] \`dist/sandbox.html\` に \`saveArtifact\` が 10 箇所含まれることを確認
- [ ] 手動検証: 拡張機能を reload して REPL で \`await saveArtifact(\"test.json\", {foo: 1})\` が通ること

## 関連

- ADR-007: docs/decisions/007-artifact-storage-unification.md
- 統合レビュー: #138
- 先行 PR: #142 (ArtifactProvider に new API handler は入っていたが sandbox 側が未対応だった)

🤖 Generated with [Claude Code](https://claude.com/claude-code)