### PR TITLE
chore(release): v0.1.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sitesurf",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "AIと一緒にWebページを操作するChrome拡張機能",
   "license": "MIT",
   "type": "module",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "SiteSurf",
   "description": "AIと一緒にWebページを操作するChrome拡張",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "action": {
     "default_title": "SiteSurfを開く",
     "default_icon": {


### PR DESCRIPTION
## Summary

v0.1.5 → v0.1.6 のリリース版上げ。

### 主な変更 (v0.1.5 以降)

**ADR-007: Artifact ストレージ統一**

旧 2 ストア構造 (JSON store + File store) を単一ストアに統合し、AI エージェントの mental model を単純化:

- [#131](https://github.com/takemo101/sitesurf/pull/131) ADR-007 承認
- [#139](https://github.com/takemo101/sitesurf/pull/139) [1/7] 新 \`ArtifactStoragePort\` + IndexedDB v4 adapter + migration
- [#140](https://github.com/takemo101/sitesurf/pull/140) 死にコードと重複型定義の cleanup
- [#141](https://github.com/takemo101/sitesurf/pull/141) [3/7] artifacts-handler 新 Port 統一
- [#142](https://github.com/takemo101/sitesurf/pull/142) [2/7] REPL helper \`saveArtifact\` + 自動型判別
- [#143](https://github.com/takemo101/sitesurf/pull/143) [4/7] UI kind バッジ + visible フィルタ
- [#144](https://github.com/takemo101/sitesurf/pull/144) [5/7] description / system prompt 書き換え
- [#146](https://github.com/takemo101/sitesurf/pull/146) REPL UI Files セクションが saveArtifact を拾うよう修正 (closes #145)
- [#147](https://github.com/takemo101/sitesurf/pull/147) sandbox.html の saveArtifact バインド漏れ修正

**新 API (v0.1.6 以降)**

REPL 内から:
\`\`\`js
await saveArtifact(name, data, options?) // 自動型判別 (JSON / string / Uint8Array)
await getArtifact(name)                   // { kind: "json"|"file", ...}
await listArtifacts()                     // ArtifactMeta[]
await deleteArtifact(name)
\`\`\`

旧 \`createOrUpdateArtifact\` / \`returnFile\` は deprecation wrapper として動作 (console.warn 発生)。次期 v0.1.7 で削除予定 (#137)。

## Test plan

- [x] package.json / public/manifest.json の version 更新
- [x] ADR-007 関連 7 PR 全て merge 済み
- [x] 全テスト pass (1067/1067)
- [x] 本ブランチ merge 後、\`v0.1.6\` タグを push → release.yml が dist.zip 付きで GitHub Release を自動作成

🤖 Generated with [Claude Code](https://claude.com/claude-code)