### PR TITLE
docs: sync design docs with current implementation

### DIFF
--- a/docs/design/artifact-panel-detail.md
+++ b/docs/design/artifact-panel-detail.md
@@ -1,704 +1,226 @@
-# アーティファクトパネル 詳細設計
+# Artifact Panel 詳細設計
+
+> **注記 (2026-04 以降)**: ADR-007 ([#131](https://github.com/takemo101/sitesurf/pull/131)) により Artifact ストレージは単一ストア構造に統合されました。本ドキュメントは統合後の現状を反映しています。旧 2 ストア構造 (JSON store + File store 分離) の設計は [ADR-007](../decisions/007-artifact-storage-unification.md) を参照。
 
 ## 概要
 
-AIが `saveArtifact` (ADR-007 統一 API) で保存したデータをユーザーが確認・プレビューできる UI を提供する。
-既存拡張 の **Flex side-by-side** パターンを採用し、アーティファクトがある場合のみ右パネルを表示する。
+AI が `saveArtifact()` で保存したデータをユーザーが確認・プレビューできる UI パネル。**Flex side-by-side** パターンで、可視 artifact がある場合のみ右パネルを表示する。
 
-## 既存拡張 との対応関係
-
-| 既存拡張                         | Sitesurf                                     | 差分                             |
-| -------------------------------- | -------------------------------------------- | -------------------------------- |
-| LitElement `@state`              | Zustand `ArtifactSlice`                      | フレームワーク差異のみ           |
-| `ArtifactsPanel` (Web Component) | `ArtifactPanel.tsx` (React)                  | 同等機能を React で再実装        |
-| `ArtifactsRuntimeProvider`       | 既存 `repl.ts` (変更なし)                    | sandbox ↔ storage 連携は実装済み |
-| `sandboxUrlProvider`             | 既存 `chrome.runtime.getURL("sandbox.html")` | 変更なし                         |
-
-## 現状確認（実装済みの範囲）
-
-以下は**すでに実装済み**であり、今回の実装では変更不要。
-
-- `src/shared/deps-context.tsx`: `artifactStorage: ArtifactStoragePort` を持つ `AppDeps` 定義済み
-- `src/sidepanel/main.tsx`: `ChromeArtifactStorage` の生成・`AppDeps` への注入済み
-- `src/ports/artifact-storage.ts`: `ArtifactStoragePort` インターフェース定義済み
-- `src/adapters/storage/artifact-storage.ts`: `ChromeArtifactStorage` 実装済み
-- `public/sandbox.html`: `createOrUpdateArtifact` / `returnFile` などの API 済み
-
-## アーキテクチャ上の位置づけ
+## アーキテクチャ
 
 ```
 features/artifacts/
   artifact-slice.ts      ← ArtifactSlice (Zustand)
-  ArtifactPanel.tsx      ← アーティファクト一覧 + プレビュー
-  ArtifactFileItem.tsx   ← 1 ファイル分の行コンポーネント
-  ArtifactPreview.tsx    ← ファイル種別ごとのプレビュー
-  types.ts               ← ArtifactEntry 型
+  ArtifactPanel.tsx      ← 一覧 + プレビューの全体コンテナ
+  ArtifactFileItem.tsx   ← 1 ファイル分の行コンポーネント (kind バッジ付き)
+  ArtifactPreview.tsx    ← 種別ごとのプレビュー (HTML / Markdown / JSON / Image / Code / Default)
+  CodeView.tsx           ← syntax highlighter
+  types.ts               ← ArtifactEntry 型 (shared/artifact-types.ts を再エクスポート)
 ```
 
-`features/artifacts/` は `ports/artifact-storage.ts` にのみ依存し、Adapter には依存しない。
+`features/artifacts/` は `ports/artifact-storage.ts` にのみ依存し、Adapter には依存しない (Feature-Sliced + Ports & Adapters)。
 
-## レイアウト設計
+## データフロー
 
-### アーティファクトなし（通常時）
-
-```
-┌─── 400px ──────────────────────┐
-│ Header                          │
-├─────────────────────────────────┤
-│ SettingsPanel (Collapse)        │
-├─────────────────────────────────┤
-│ TabBar                          │
-├─────────────────────────────────┤
-│                                 │
-│ ChatArea (flex:1)               │
-│                                 │
-├─────────────────────────────────┤
-│ InputArea                       │
-└─────────────────────────────────┘
-```
-
-### アーティファクトあり（分割表示）
+### 保存と UI 反映 (REPL 経由)
 
 ```
-┌─── 400px ──────────────────────┐
-│ Header                          │
-├─────────────────────────────────┤
-│ SettingsPanel (Collapse)        │
-├─────────────────────────────────┤
-│ TabBar                          │
-├──────────────┬──────────────────┤
-│              │ [📄] results.json│
-│ ChatArea     │ [🌐] chart.html  │
-│ (flex:1,     │ [📝] memo.md     │
-│  minWidth:0) ├──────────────────┤
-│              │ [プレビューエリア]│
-│              │ (flex:1,        │
-│              │  overflow:auto)  │
-├──────────────┴──────────────────┤
-│ InputArea                       │
-└─────────────────────────────────┘
-
-ChatArea: flex={1}, minWidth: 0 (現状の ScrollArea flex={1} を維持)
-ArtifactPanel: width 180px, flexShrink: 0
+[AI] saveArtifact("page.html", "<h1>...</h1>") を REPL で呼ぶ
+  ↓ sandbox.html が postMessage で sandbox-request を親 (side panel) に送る
+ArtifactProvider.handleRequest → ArtifactStoragePort.put()
+  ↓ IndexedDB (ARTIFACTS_STORE = "artifacts-v2") に書き込み
+exec-result メッセージ受信 → REPL 完了
+  ↓ orchestration/agent-loop.ts: artifactAutoExpand.onReplCompleted(prevNames)
+use-agent.ts: loadArtifacts() → Zustand slice を storage から再同期
+  ↓ 差分を検出 → 新規 artifact を selectArtifact()
+  ↓ kind: "file" かつ preview 価値の高い拡張子 (html/markdown) なら setArtifactPanelOpen(true)
+ArtifactPanel が再描画され、visible:true の項目のみ表示
 ```
 
-### 分割の実装方針
+### Top-level `artifacts` tool 経由
 
-- `ChatArea` の現行 props は `{ onSend?: (text: string) => void }` のみ。`style` prop はない。
-- 分割の flex 制御は `MainLayout` 内のラッパー `Group` で行い、`ChatArea` には style を渡さない。
-- `ChatArea` の `ScrollArea flex={1}` はそのまま維持し、ラッパー `Box` 内で `flex: 1` になるよう包む。
-- `artifactPanelOpen`（UISlice 拡張）が `true` かつアーティファクトが 1 件以上のときのみ ArtifactPanel を表示。
-- アーティファクトが 0 件になったら自動で `artifactPanelOpen = false`。
-
-### ChatArea ラッパーの構造
-
-```tsx
-// MainLayout 内
-<Group gap={0} style={{ flex: 1, overflow: "hidden", alignItems: "stretch" }}>
-  {/* ChatArea を Box で包み、flex:1 を Box 側に設定する */}
-  <Box
-    style={{ flex: 1, minWidth: 0, overflow: "hidden", display: "flex", flexDirection: "column" }}
-  >
-    <ChatArea onSend={handleSend} />
-  </Box>
-  {showArtifacts && <ArtifactPanel />}
-</Group>
+```
+[AI] { name: "artifacts", command: "create", filename: "x.html", content: "..." }
+  ↓
+features/tools/handlers/artifacts-handler.ts: handleArtifactsTool()
+  ↓ stringContentToArtifactValue で ArtifactValue に変換
+ArtifactStoragePort.put()
+  ↓ artifactSlice.setArtifacts() で即時 UI 反映
 ```
 
-## Port への追加
+## Port 設計 (ADR-007 統一)
 
-`returnFile` で保存したファイルには削除機能がないため、`ArtifactStoragePort` に `deleteFile` を追加する。
+```ts
+// src/ports/artifact-storage.ts
+export type ArtifactKind = "json" | "file";
 
-```typescript
-// ports/artifact-storage.ts に追加
+export interface ArtifactMeta {
+  name: string;
+  kind: ArtifactKind;
+  mimeType?: string;  // kind === "file" のみ
+  size: number;
+  visible: boolean;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export type ArtifactValue =
+  | { kind: "json"; data: unknown }
+  | { kind: "file"; bytes: Uint8Array; mimeType: string };
+
 export interface ArtifactStoragePort {
-  // ... 既存のメソッド ...
-  deleteFile(name: string): Promise<void>; // 追加
+  put(name: string, value: ArtifactValue, options?: { visible?: boolean }): Promise<void>;
+  get(name: string): Promise<ArtifactValue | null>;
+  list(): Promise<ArtifactMeta[]>;
+  delete(name: string): Promise<void>;
+  setSessionId(sessionId: string | null): void;
+  clearAll(): Promise<void>;
+  // 以下は deprecation wrapper (v0.1.7 で削除予定 / #137)
+  createOrUpdate / saveFile / getFile / listFiles / deleteFile
 }
 ```
 
-```typescript
-// adapters/storage/artifact-storage.ts に実装追加
-async deleteFile(name: string): Promise<void> {
-  const key = FILE_PREFIX + sanitizeKey(name);
-  await chrome.storage.local.remove(key);
-}
-```
+Adapter: `src/adapters/storage/artifact-storage.ts` (`ChromeArtifactStorage`) が IndexedDB 単一 store `artifacts-v2` にキー `${sessionId}::${name}` で保存。
 
-## 状態管理設計
+## ArtifactEntry (UI 側の表現)
 
-### ArtifactSlice
-
-```typescript
-// features/artifacts/artifact-slice.ts
-
-export interface ArtifactSlice {
-  artifacts: ArtifactEntry[]; // アーティファクト一覧（メタデータのみ）
-  selectedArtifact: string | null; // 選択中のファイル名
-
-  loadArtifacts(): Promise<void>; // storage から一覧を再取得
-  selectArtifact(name: string): void;
-  removeArtifact(name: string): Promise<void>;
-  clearArtifacts(): Promise<void>;
-}
-```
-
-**ArtifactEntry にデータ本体は持たない。** ファイル一覧はメタデータのみ store に保持し、
-プレビュー表示時に `ArtifactStoragePort` から都度取得する（ファイル内容が大きい場合も安全）。
-
-### UISlice 拡張
-
-```typescript
-// sidepanel/ui-store.ts に追加
-artifactPanelOpen: boolean;
-setArtifactPanelOpen(v: boolean): void;
-toggleArtifactPanel(): void;
-```
-
-### store への統合
-
-`store/index.ts` は現在 `create()` 内で 4 slice を合成している。
-`ArtifactSlice` は `ArtifactStoragePort` を必要とするため、クロージャパターンで注入する。
-
-```typescript
-// store/types.ts
-import type { ArtifactSlice } from "@/features/artifacts/artifact-slice";
-export type AppStore = ChatSlice & SettingsSlice & SessionSlice & UISlice & ArtifactSlice;
-```
-
-```typescript
-// store/index.ts
-import { create } from "zustand";
-import { createArtifactSlice } from "@/features/artifacts/artifact-slice";
-import type { ArtifactStoragePort } from "@/ports/artifact-storage";
-
-// artifactStorage は main.tsx から initStore() 経由で注入する
-let _artifactStorage: ArtifactStoragePort;
-
-export function initStore(artifactStorage: ArtifactStoragePort): void {
-  _artifactStorage = artifactStorage;
-}
-
-export const useStore = create<AppStore>()((...a) => ({
-  ...createChatSlice(...a),
-  ...createSettingsSlice(...a),
-  ...createSessionSlice(...a),
-  ...createUISlice(...a),
-  ...createArtifactSlice(() => _artifactStorage)(...a),
-}));
-```
-
-> **注意**: `useStore` は変更しない。`_artifactStorage` のみモジュール内変数として管理する。
-> `initStore()` は `main.tsx` の `createRoot` より前に呼ぶ必要がある。
-
-### ArtifactSlice 実装
-
-```typescript
-// features/artifacts/artifact-slice.ts
-export function createArtifactSlice(
-  getStorage: () => ArtifactStoragePort,
-): StateCreator<AppStore, [], [], ArtifactSlice> {
-  return (set, get) => ({
-    artifacts: [],
-    selectedArtifact: null,
-
-    loadArtifacts: async () => {
-      const storage = getStorage();
-      const [jsonNames, fileNames] = await Promise.all([storage.list(), storage.listFiles()]);
-      // 重複除去: json/file 両方に同名ファイルがあり得るので Set で管理
-      const seen = new Set<string>();
-      const entries: ArtifactEntry[] = [];
-      for (const name of jsonNames) {
-        if (!seen.has(name)) {
-          seen.add(name);
-          entries.push({ name, type: detectType(name), updatedAt: Date.now() });
-        }
-      }
-      for (const name of fileNames) {
-        if (!seen.has(name)) {
-          seen.add(name);
-          entries.push({ name, type: detectType(name), updatedAt: Date.now() });
-        }
-      }
-      set({ artifacts: entries });
-    },
-
-    selectArtifact: (name) => set({ selectedArtifact: name }),
-
-    removeArtifact: async (name) => {
-      const storage = getStorage();
-      const entry = get().artifacts.find((a) => a.name === name);
-      if (!entry) return;
-      // ファイル種別に応じた削除先を選択
-      if (entry.type === "image" || entry.type === "binary" || entry.type === "html") {
-        await storage.deleteFile(name);
-      } else {
-        await storage.delete(name);
-      }
-      set((s) => ({
-        artifacts: s.artifacts.filter((a) => a.name !== name),
-        selectedArtifact: s.selectedArtifact === name ? null : s.selectedArtifact,
-      }));
-    },
-
-    clearArtifacts: async () => {
-      await getStorage().clearAll();
-      set({ artifacts: [], selectedArtifact: null });
-    },
-  });
-}
-```
-
-## アーティファクト更新の検知
-
-AIが `createOrUpdateArtifact`（JSON）または `returnFile`（ファイル）を呼び出した後、パネルに反映するトリガーが必要。
-
-### トリガー条件
-
-`result.files` は `returnFile()` で保存したファイルのみを返す。`createOrUpdateArtifact()` で保存した JSON は含まれない。
-どちらの API を呼び出しても store に反映するため、**repl ツールが成功したら常に** `loadArtifacts()` を呼ぶ。
-
-### 更新フロー
-
-```
-[AI] createOrUpdateArtifact() または returnFile() 呼び出し
-  ↓
-repl.ts: artifactStorage.createOrUpdate() / saveFile() 実行
-  ↓
-exec-result メッセージ受信
-  ↓
-orchestration/agent-loop.ts: executeToolCall 内でツール結果処理
-  ↓
-useStore.getState().loadArtifacts()   ← JSON + File 両方を再取得
-  ↓
-artifacts.length > 0 なら setArtifactPanelOpen(true)
-```
-
-### 実装箇所
-
-```typescript
-// orchestration/agent-loop.ts の executeToolCall 内（変更箇所のみ）
-if (name === "repl" && toolResult.ok) {
-  await useStore.getState().loadArtifacts();
-  const { artifacts } = useStore.getState();
-  if (artifacts.length > 0) {
-    useStore.getState().setArtifactPanelOpen(true);
-  }
-}
-```
-
-> **負荷について**: `loadArtifacts()` は `chrome.storage.local.get(null)` を 2 回呼ぶ（list + listFiles）。
-> repl ツールの毎回呼び出しに実行されるが、データ量が少ない Chrome 拡張実装では許容範囲内。
-
-## UIコンポーネント設計
-
-### コンポーネントツリー
-
-```
-MainLayout (App.tsx)
-├── Group (flex:1, overflow:hidden)
-│   ├── Box (flex:1, minWidth:0, flexDir:column)  ← ChatArea のラッパー
-│   │   └── ChatArea
-│   └── ArtifactPanel (w:180px, flexShrink:0)  ← artifactPanelOpen && artifacts.length > 0 時のみ
-│       ├── ArtifactPanelHeader (「Artifacts」 + CloseButton)
-│       ├── ScrollArea (mah:120px)  ← ファイル一覧
-│       │   └── ArtifactFileItem[]
-│       └── Box (flex:1, overflow:auto, minHeight:0)  ← プレビュー
-│           ├── JsonPreview
-│           ├── HtmlPreview
-│           ├── MarkdownPreview
-│           ├── ImagePreview
-│           └── TextPreview
-└── InputArea
-```
-
-### ArtifactPanel
-
-```tsx
-// features/artifacts/ArtifactPanel.tsx
-
-export function ArtifactPanel() {
-  const artifacts = useStore((s) => s.artifacts);
-  const selectedArtifact = useStore((s) => s.selectedArtifact);
-  const setArtifactPanelOpen = useStore((s) => s.setArtifactPanelOpen);
-
-  // アーティファクトが 0 件になったらパネルを自動クローズ
-  useEffect(() => {
-    if (artifacts.length === 0) {
-      setArtifactPanelOpen(false);
-    }
-  }, [artifacts.length, setArtifactPanelOpen]);
-
-  return (
-    <Stack
-      w={180}
-      gap={0}
-      style={{
-        borderLeft: "1px solid var(--mantine-color-default-border)",
-        flexShrink: 0,
-        overflow: "hidden",
-        // 親 Group の alignItems: stretch により高さは自動計算
-      }}
-    >
-      {/* ヘッダー */}
-      <Group
-        px="xs"
-        py={4}
-        justify="space-between"
-        style={{ borderBottom: "1px solid var(--mantine-color-default-border)", flexShrink: 0 }}
-      >
-        <Text size="xs" fw={600}>
-          Artifacts
-        </Text>
-        <ActionIcon variant="subtle" size="xs" onClick={() => setArtifactPanelOpen(false)}>
-          <X size={10} />
-        </ActionIcon>
-      </Group>
-
-      {/* ファイル一覧 */}
-      <ScrollArea mah={120} style={{ flexShrink: 0 }}>
-        <Stack gap={0}>
-          {artifacts.map((artifact) => (
-            <ArtifactFileItem
-              key={artifact.name}
-              artifact={artifact}
-              selected={selectedArtifact === artifact.name}
-            />
-          ))}
-        </Stack>
-      </ScrollArea>
-
-      {/* プレビュー */}
-      <Box style={{ flex: 1, overflow: "auto", minHeight: 0 }}>
-        {selectedArtifact ? (
-          <ArtifactPreview name={selectedArtifact} />
-        ) : (
-          <Stack align="center" justify="center" h="100%">
-            <Text size="xs" c="dimmed" ta="center" px="xs">
-              ファイルを選択
-            </Text>
-          </Stack>
-        )}
-      </Box>
-    </Stack>
-  );
-}
-```
-
-### ArtifactFileItem
-
-```tsx
-// features/artifacts/ArtifactFileItem.tsx
-
-const TYPE_ICONS: Record<ArtifactEntry["type"], React.ReactNode> = {
-  json: <Braces size={10} />,
-  html: <Globe size={10} />,
-  markdown: <FileText size={10} />,
-  text: <FileText size={10} />,
-  image: <ImageIcon size={10} />,
-  binary: <File size={10} />,
-};
-
-export function ArtifactFileItem({
-  artifact,
-  selected,
-}: {
-  artifact: ArtifactEntry;
-  selected: boolean;
-}) {
-  const selectArtifact = useStore((s) => s.selectArtifact);
-  const removeArtifact = useStore((s) => s.removeArtifact);
-
-  return (
-    <UnstyledButton
-      onClick={() => selectArtifact(artifact.name)}
-      px="xs"
-      py={4}
-      style={{
-        background: selected ? "var(--mantine-color-indigo-light)" : undefined,
-        display: "flex",
-        alignItems: "center",
-        gap: 4,
-        width: "100%",
-      }}
-      className="hover-highlight"
-    >
-      <Box c="dimmed" style={{ flexShrink: 0 }}>
-        {TYPE_ICONS[artifact.type]}
-      </Box>
-      <Text size="10px" truncate style={{ flex: 1 }}>
-        {artifact.name}
-      </Text>
-      <ActionIcon
-        variant="subtle"
-        size="xs"
-        color="red"
-        className="show-on-hover"
-        onClick={(e) => {
-          e.stopPropagation();
-          removeArtifact(artifact.name);
-        }}
-      >
-        <Trash2 size={8} />
-      </ActionIcon>
-    </UnstyledButton>
-  );
-}
-```
-
-### ArtifactPreview
-
-```tsx
-// features/artifacts/ArtifactPreview.tsx
-
-export function ArtifactPreview({ name }: { name: string }) {
-  const [content, setContent] = useState<string | object | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const deps = useDeps();
-  const artifact = useStore((s) => s.artifacts.find((a) => a.name === name));
-
-  useEffect(() => {
-    setLoading(true);
-    setContent(null);
-    setError(null);
-    if (!artifact) return;
-
-    let cancelled = false;
-    const load = async () => {
-      try {
-        if (artifact.type === "json") {
-          const data = await deps.artifactStorage.get(name);
-          if (!cancelled) setContent(data as object);
-        } else {
-          const file = await deps.artifactStorage.getFile(name);
-          if (!cancelled && file) setContent(file.contentBase64);
-        }
-      } catch (e) {
-        if (!cancelled) setError(e instanceof Error ? e.message : String(e));
-      } finally {
-        if (!cancelled) setLoading(false);
-      }
-    };
-    load();
-    return () => {
-      cancelled = true;
-    };
-  }, [name]);
-
-  if (loading) {
-    return (
-      <Stack align="center" justify="center" h="100%" p="xs">
-        <Loader size="xs" color="indigo" />
-      </Stack>
-    );
-  }
-  if (error) {
-    return (
-      <Text size="10px" c="red" p="xs">
-        {error}
-      </Text>
-    );
-  }
-  if (!artifact || content === null) return null;
-
-  switch (artifact.type) {
-    case "json":
-      return <JsonPreview data={content as object} />;
-    case "html":
-      return <HtmlPreview base64={content as string} />;
-    case "markdown":
-      return <MarkdownPreview base64={content as string} />;
-    case "image":
-      return <ImagePreview base64={content as string} mimeType={getMimeType(name)} />;
-    default:
-      return <TextPreview base64={content as string} />;
-  }
-}
-```
-
-**変更点**: `name` のみを `useEffect` の依存配列に含める（`artifact` は派生値のため不要）。キャンセルフラグで競合防止。
-
-### プレビュー種別ごとの実装
-
-#### JsonPreview
-
-```tsx
-function JsonPreview({ data }: { data: object }) {
-  return (
-    <Box p="xs">
-      <Code block style={{ fontSize: 9, whiteSpace: "pre-wrap", wordBreak: "break-all" }}>
-        {JSON.stringify(data, null, 2)}
-      </Code>
-    </Box>
-  );
-}
-```
-
-#### HtmlPreview
-
-Chrome 拡張の Content Security Policy 制約下では `blob:` URL が機能しない場合がある。
-`<iframe srcDoc>` は Manifest V3 で動作することが確認されており、コード実行なしの安全な表示には `sandbox` 属性なしで使用する。
-スクリプト実行が必要な場合は `sandbox="allow-scripts"` を追加するが、プレビュー目的なら機能しないリスクより表示を優先する。
-
-```tsx
-function HtmlPreview({ base64 }: { base64: string }) {
-  const html = atob(base64);
-  return (
-    <iframe
-      srcDoc={html}
-      style={{ width: "100%", height: "100%", minHeight: 120, border: "none" }}
-      title="HTML Preview"
-    />
-  );
-}
-```
-
-#### MarkdownPreview
-
-```tsx
-function MarkdownPreview({ base64 }: { base64: string }) {
-  const text = useMemo(
-    () => new TextDecoder().decode(Uint8Array.from(atob(base64), (c) => c.charCodeAt(0))),
-    [base64],
-  );
-  return (
-    <Box p="xs">
-      <MarkdownContent content={text} />
-    </Box>
-  );
-}
-```
-
-#### ImagePreview
-
-```tsx
-function ImagePreview({ base64, mimeType }: { base64: string; mimeType: string }) {
-  return (
-    <Box p="xs">
-      <img
-        src={`data:${mimeType};base64,${base64}`}
-        alt="artifact"
-        style={{ maxWidth: "100%", borderRadius: 4 }}
-      />
-    </Box>
-  );
-}
-```
-
-#### TextPreview
-
-```tsx
-function TextPreview({ base64 }: { base64: string }) {
-  const text = useMemo(
-    () => new TextDecoder().decode(Uint8Array.from(atob(base64), (c) => c.charCodeAt(0))),
-    [base64],
-  );
-  return (
-    <Box p="xs">
-      <Code block style={{ fontSize: 9, whiteSpace: "pre-wrap", wordBreak: "break-all" }}>
-        {text}
-      </Code>
-    </Box>
-  );
-}
-```
-
-## ファイル種別の自動判定
-
-```typescript
-// features/artifacts/types.ts
-
+```ts
+// src/shared/artifact-types.ts
 export type ArtifactType = "json" | "html" | "markdown" | "text" | "image" | "binary";
 
 export interface ArtifactEntry {
   name: string;
-  type: ArtifactType;
+  type: ArtifactType; // 拡張子から detectType() で導出
+  source: "json" | "file"; // Port の ArtifactMeta.kind と対応
   updatedAt: number;
 }
+```
 
-const EXT_MAP: Record<string, ArtifactType> = {
-  json: "json",
-  html: "html",
-  htm: "html",
-  md: "markdown",
-  markdown: "markdown",
-  txt: "text",
-  csv: "text",
-  png: "image",
-  jpg: "image",
-  jpeg: "image",
-  gif: "image",
-  webp: "image",
-  svg: "image",
+UI は `type` (拡張子由来、プレビューの振り分け) と `source` (kind、バッジ表示) の 2 軸を持つ。data 本体は保持せず、プレビュー時に `storage.get()` で都度取得する (大きいファイルでも安全)。
+
+## ArtifactSlice (現行)
+
+```ts
+export interface ArtifactSlice {
+  artifacts: ArtifactEntry[];
+  selectedArtifact: string | null;
+  loadArtifacts(): Promise<void>;
+  setArtifactSessionId(sessionId: string | null): void;
+  selectArtifact(name: string | null): void;
+  removeArtifact(name: string): Promise<void>;
+  clearArtifacts(): void;
+  setArtifacts(artifacts: ArtifactEntry[]): void;
+}
+```
+
+### loadArtifacts の挙動 (ADR-007 後)
+
+1 回の `storage.list()` で統合された `ArtifactMeta[]` を取得
+→ `visible: true` でフィルタ
+→ `kind` から `source`、`detectType(name)` から `type` を導出して `ArtifactEntry[]` に変換
+
+旧 v0.1.5 実装では `list()` + `listFiles()` の 2 経路をマージしていたが、ADR-007 で 1 経路に統一。
+
+## レイアウト
+
+### Panel なし (artifacts 0 件)
+
+```
+┌─── 400px ──────────────────────┐
+│ Header                          │
+├─────────────────────────────────┤
+│ ChatArea (flex:1)               │
+├─────────────────────────────────┤
+│ InputArea                       │
+└─────────────────────────────────┘
+```
+
+### Panel あり (`artifactPanelOpen && visible 件数 > 0`)
+
+```
+┌─── 400px ──────────────────────┐
+│ Header                          │
+├──────────────┬──────────────────┤
+│ ChatArea     │ [📄] results.json JSON│
+│ (flex:1,     │ [🌐] chart.html   FILE│
+│  minWidth:0) │ [📝] memo.md      FILE│
+│              ├──────────────────┤
+│              │ [プレビュー領域] │
+├──────────────┴──────────────────┤
+│ InputArea                       │
+└─────────────────────────────────┘
+```
+
+- `MainLayout` 内のラッパー `Group` で flex 制御 (ChatArea を Box で包み `flex: 1` を Box 側に)
+- Panel の幅は固定、`artifacts.filter(a => a.visible).length > 0` の時だけ描画
+
+## 主要コンポーネント
+
+### ArtifactFileItem
+
+- 左端: `TYPE_ICONS[artifact.type]` (json/html/markdown/text/image/binary で 6 種)
+  - `title` 属性で `"JSON 値"` / `"ファイル"` の tooltip
+- 中央: ファイル名 (truncate)
+- 右端: **kind バッジ** (`source` の値 "json"/"file" を uppercase + letter-spacing で小さく表示)
+- 最右: 削除ボタン (hover 時のみ表示)
+
+### ArtifactPreview
+
+`ArtifactPanel` が `artifactStorage.get(name)` で `ArtifactValue` を取り出し、kind / mimeType / bytes または data を `ArtifactPreview` に渡す。
+
+分岐:
+
+- `type === "html"` → `HtmlPreview` (extension `sandbox.html` iframe で実行)
+- `type === "markdown"` → `MarkdownPreview` (react-markdown)
+- `type === "image"` → `ImagePreview` (`kind: "file"` の bytes を data URL に変換)
+- `type === "json"` → `DataPreview` (テーブル / 整形 / ソース タブ)
+- その他の code 拡張子 → `CodePreview`
+- それ以外 → `DefaultPreview`
+
+### HtmlPreview (sandbox iframe)
+
+Extension Pages の CSP により `new Function()` / `eval()` は不可。そのため `public/sandbox.html` を iframe で読み込み、`postMessage` で HTML を流し込んで `document.write()` + console 転送で実行する ([ADR-005](../decisions/005-extension-page-csp-constraints.md) 参照)。
+
+## 自動展開のルール
+
+`use-agent.ts` の `artifactAutoExpand.onReplCompleted`:
+
+```ts
+onReplCompleted: async (prevNames) => {
+  await useStore.getState().loadArtifacts();
+  const { artifacts } = useStore.getState();
+  const newArtifact = artifacts.find((a) => !prevNames.has(a.name));
+  if (!newArtifact) return;
+  useStore.getState().selectArtifact(newArtifact.name);
+  if (newArtifact.type === "html" || newArtifact.type === "markdown") {
+    useStore.getState().setArtifactPanelOpen(true);
+  }
 };
-
-export function detectType(name: string): ArtifactType {
-  const ext = name.split(".").pop()?.toLowerCase() ?? "";
-  return EXT_MAP[ext] ?? "binary";
-}
-
-export function getMimeType(name: string): string {
-  const ext = name.split(".").pop()?.toLowerCase() ?? "";
-  const MIME: Record<string, string> = {
-    png: "image/png",
-    jpg: "image/jpeg",
-    jpeg: "image/jpeg",
-    gif: "image/gif",
-    webp: "image/webp",
-    svg: "image/svg+xml",
-  };
-  return MIME[ext] ?? "application/octet-stream";
-}
 ```
 
-## セッション切替時のリセット
+- `loadArtifacts()` は `visible: true` の項目のみ slice に載るため、`visible: false` artifact は自動展開対象外
+- 新規 visible artifact のうち `html` / `markdown` のみ Panel を自動で開く。それ以外 (json / image 等) は選択だけ行い、既存の Panel 状態を維持
 
-`session-slice.ts` の `loadSession` にアーティファクトリセットを追加する。
+## セッション分離
 
-```typescript
-// features/sessions/session-slice.ts の loadSession 内（変更箇所のみ）
-loadSession: (session) => {
-  set({
-    activeSessionSnapshot: session,
-    activeSessionId: session.id,
-    messages: session.messages,
-    history: session.history,
-  });
-  // アーティファクトリストをリセットして再読込
-  useStore.getState().setArtifactPanelOpen(false);
-  // loadArtifacts は非同期なので void で呼び出す
-  void useStore.getState().loadArtifacts();
-},
-```
-
-> **考慮**: `loadSession` は現状同期関数。`loadArtifacts` は非同期なので、パネルを閉じてから読み込むことで移行を自然に見せる。
-
-> **備考**: 現状 `ChromeArtifactStorage` はセッション横断でデータを共有。セッション分離は v2 以降の拡張で対応する。
-
-## ファイル追加・変更一覧
-
-| ファイル                                      | 変更種別 | 内容                                                         |
-| --------------------------------------------- | -------- | ------------------------------------------------------------ |
-| `src/ports/artifact-storage.ts`               | 変更     | `deleteFile(name)` メソッドを Port に追加                    |
-| `src/adapters/storage/artifact-storage.ts`    | 変更     | `deleteFile` 実装を追加                                      |
-| `src/features/artifacts/types.ts`             | 新規     | `ArtifactEntry`, `ArtifactType`, `detectType`, `getMimeType` |
-| `src/features/artifacts/artifact-slice.ts`    | 新規     | `ArtifactSlice`, `createArtifactSlice`                       |
-| `src/features/artifacts/ArtifactPanel.tsx`    | 新規     | パネル本体 (一覧 + プレビュー制御)                           |
-| `src/features/artifacts/ArtifactFileItem.tsx` | 新規     | 1 ファイル行 UI                                              |
-| `src/features/artifacts/ArtifactPreview.tsx`  | 新規     | プレビュー種別切替                                           |
-| `src/store/types.ts`                          | 変更     | `ArtifactSlice` を `AppStore` に追加                         |
-| `src/store/index.ts`                          | 変更     | `initStore()` + `createArtifactSlice` を追加                 |
-| `src/sidepanel/App.tsx`                       | 変更     | `MainLayout` に `Box` ラッパー + `ArtifactPanel` を組み込み  |
-| `src/sidepanel/ui-store.ts`                   | 変更     | `artifactPanelOpen` + 操作関数を追加                         |
-| `src/sidepanel/main.tsx`                      | 変更     | `initStore(artifactStorage)` を呼び出す                      |
-| `src/orchestration/agent-loop.ts`             | 変更     | repl 成功後に `loadArtifacts()` を呼ぶ                       |
-| `src/features/sessions/session-slice.ts`      | 変更     | `loadSession` 内にアーティファクトリセットを追加             |
+- Artifact は `sessionId` で isolation される
+- `ArtifactStoragePort.setSessionId(sessionId)` を呼ぶと以降の put/get/list が対象セッションに限定される
+- セッション切替時は `useStore.getState().loadArtifacts()` が新 sessionId 下の一覧を再取得 → UI が切り替わる
 
 ## 関連ドキュメント
 
-- [アーキテクチャ概要](../architecture/overview.md)
-- [状態管理設計](../architecture/state-management.md)
-- [DI 注入設計](./di-wiring.md)
-- [ツール設計](../architecture/tools.md)
-- [UI/UX 設計](./ui-ux-design.md)
+- [ADR-007: artifact storage unification](../decisions/007-artifact-storage-unification.md) — 統一の経緯と決定
+- [ADR-005: extension page CSP constraints](../decisions/005-extension-page-csp-constraints.md) — HtmlPreview の iframe 方針
+- [sandbox-implementation.md](./sandbox-implementation.md) — REPL 用 sandbox iframe の詳細
+- [bg-fetch.md](./bg-fetch.md) — bgFetch ループ + saveArtifact パターン
+
+## 関連ソース
+
+- `src/features/artifacts/ArtifactPanel.tsx` — Panel 本体
+- `src/features/artifacts/ArtifactFileItem.tsx` — 行 + kind バッジ
+- `src/features/artifacts/ArtifactPreview.tsx` — プレビュー分岐
+- `src/features/artifacts/artifact-slice.ts` — Zustand slice
+- `src/features/tools/providers/artifact-provider.ts` — REPL helper (`saveArtifact` 等)
+- `src/features/tools/handlers/artifacts-handler.ts` — top-level `artifacts` tool
+- `src/adapters/storage/artifact-storage.ts` — `ChromeArtifactStorage` (IndexedDB)
+- `src/ports/artifact-storage.ts` — Port 定義

--- a/docs/design/security-middleware-design.md
+++ b/docs/design/security-middleware-design.md
@@ -8,7 +8,7 @@
 
 ## Overview
 
-ツール出力（`browserjs` / `bg_fetch` / `read_page` 等）に紛れ込んだ「指示らしき文字列」をリアルタイム検出し、AI に渡る前に安全な要約だけを返すミドルウェア。実装は `src/features/security/`。
+ツール出力（`browserjs` / `bg_fetch` / `readPage` 等、REPL 内 helper を含む）に紛れ込んだ「指示らしき文字列」をリアルタイム検出し、AI に渡る前に安全な要約だけを返すミドルウェア。実装は `src/features/security/`。
 
 ---
 
@@ -430,7 +430,7 @@ interface SecuritySettings {
 
 ## Comparison with 既存拡張
 
-| Feature            | 既存拡張                | Sitesurf             |
+| Feature            | 既存拡張                | Sitesurf              |
 | ------------------ | ----------------------- | --------------------- |
 | Detection          | Pattern-based in prompt | Dedicated middleware  |
 | Alert              | Text warning            | Inline visual warning |

--- a/docs/design/skill-system.md
+++ b/docs/design/skill-system.md
@@ -556,8 +556,9 @@ async function executeRepl(...) {
 }
 ```
 
-スキルは `new Function(`return (${code})`)()` で復元してから `browserjs(fn)` で実行します。
-これは sandbox iframe 経由の実行パスであり、ユーザー自身が入力したコードと同等のセキュリティレベルです。
+スキルは `BrowserJsProvider.handleRequest` が target page に `executeScript` する際、`browser-js-provider.ts` の `buildSkillInjection()` が `window[skillId][extractorId] = (extractor.code);` を scriptCode 先頭に prepend する形で注入されます (PR #128)。AI は `browserjs(() => window.youtube.getVideoInfo())` のように `window` 経由で呼び出します。
+
+Extension Pages の CSP により `new Function()` / `eval()` は使えないため (ADR-005)、extractor code は target page 側 (MAIN world または USER_SCRIPT world) で `chrome.scripting.executeScript` / `chrome.userScripts.execute` 経由で実行されます。
 
 ### 起動シーケンス
 

--- a/docs/design/ui-components-detail.md
+++ b/docs/design/ui-components-detail.md
@@ -959,7 +959,7 @@ AIに送信されるメッセージ:
 ```
 
 AIは周辺DOMから `<span class="price">¥298,800</span>` を認識し、
-read_page を呼ばずに回答できる。
+REPL 内 `readPage()` を呼ばずに回答できる。
 
 ### pendingElement の状態管理
 


### PR DESCRIPTION
## Summary

実装と乖離していた設計ドキュメントを現状に合わせて同期。

### 主要な書き換え

#### \`docs/design/artifact-panel-detail.md\` (全面書き直し, 789 → 220 行)

- ADR-007 以前の 2 ストア構造 (JSON store + File store) を前提にした v0.1.4 時代の**実装前設計**から、ADR-007 後の単一ストア + \`saveArtifact\` 前提に書き直し
- 古いコード例 (\`createOrUpdateArtifact\` / \`returnFile\` / \`getFile\` / \`listFiles\` 等) を削除し、現行 Port API (\`put\` / \`get\` / \`list\` / \`delete\`) に更新
- UI kind バッジ、\`visible\` フィルタ、自動展開ルールなど v0.1.6 の実装を反映
- 冒頭に ADR-007 への注記リンクを追加

#### \`docs/design/skill-system.md\`

- \`new Function(\\\`return (\${code})\\\`)()\` で extractor を実行する旧記述を、PR #128 で導入された「target page の window に prepend して browserjs() 経由で呼び出す」パターンに更新
- ADR-005 (extension page CSP) との整合性も明記

#### \`docs/design/security-middleware-design.md\` / \`ui-components-detail.md\`

- \`read_page\` → REPL 内 helper \`readPage()\` に修正 (#94 で廃止済み)

### 維持した historical 記述

- \`docs/architecture/overview.md\` の「v0.1.4 時点と比較: xxx 廃止」等は意図的に残す (読者が変化を追えるため)
- \`docs/design/implementation-plan.md\` は既に \`⚠️ HISTORICAL\` マーク付きで保存されている
- \`docs/decisions/007-artifact-storage-unification.md\` 内の旧 API 言及は ADR 自身の記述として当然なので残置

## Test plan

- [x] \`createOrUpdateArtifact\` / \`returnFile\` 参照が current docs から消滅 (ADR-007 と deprecation 注記を除く)
- [x] \`read_page\` の直接呼び出しを示唆する記述を削除 (historical note は維持)
- [x] Skill injection の挙動が現実装と一致
- [x] fmt pass

## 関連

- ADR-007: docs/decisions/007-artifact-storage-unification.md
- PR #128 (skill window injection)
- PR #94 (read_page 格下げ)
- v0.1.6 リリース

🤖 Generated with [Claude Code](https://claude.com/claude-code)