### PR TITLE
refactor(runtime-provider): drop unused getRuntimeCode + add sandbox contract test

### DIFF
--- a/src/features/tools/providers/__tests__/fetch-provider.test.ts
+++ b/src/features/tools/providers/__tests__/fetch-provider.test.ts
@@ -19,7 +19,9 @@ function setEnableBgFetch(enabled: boolean): void {
 }
 
 function stubSendMessage(response: BgFetchResponse) {
-  const sendMessage = vi.fn<(msg: BgFetchMessage) => Promise<BgFetchResponse>>(async () => response);
+  const sendMessage = vi.fn<(msg: BgFetchMessage) => Promise<BgFetchResponse>>(
+    async () => response,
+  );
   const runtime = { sendMessage } as unknown as typeof chrome.runtime;
   (globalThis as unknown as { chrome: { runtime: typeof chrome.runtime } }).chrome = { runtime };
   return sendMessage;
@@ -36,12 +38,6 @@ describe("FetchProvider", () => {
     expect(provider.actions).toContain("bgFetch");
   });
 
-  it("getRuntimeCode は bgFetch 関数定義を含む", () => {
-    const code = new FetchProvider().getRuntimeCode();
-    expect(code).toContain("async function bgFetch(url, options)");
-    expect(code).toContain("action: 'bgFetch'");
-  });
-
   it("getDescription は repl description と同じ bgFetch helper 説明を再利用する", () => {
     const description = new FetchProvider().getDescription();
     expect(description).toBe(buildBgFetchHelperDescription());
@@ -52,10 +48,7 @@ describe("FetchProvider", () => {
 
   it("url 欠落時は tool_script_error を返す", async () => {
     const provider = new FetchProvider();
-    const result = await provider.handleRequest(
-      { id: "req-1", action: "bgFetch" },
-      makeContext(),
-    );
+    const result = await provider.handleRequest({ id: "req-1", action: "bgFetch" }, makeContext());
     expect(result.ok).toBe(false);
     if (result.ok) return;
     expect(result.error.code).toBe("tool_script_error");

--- a/src/features/tools/providers/__tests__/sandbox-contract.test.ts
+++ b/src/features/tools/providers/__tests__/sandbox-contract.test.ts
@@ -1,0 +1,168 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  ArtifactProvider,
+  BrowserJsProvider,
+  FetchProvider,
+  NativeInputProvider,
+  NavigateProvider,
+  ReadPageProvider,
+} from "..";
+
+/**
+ * sandbox.html と provider の action / helper 名が drift していないことを担保する。
+ *
+ * 背景: 当初 RuntimeProvider.getRuntimeCode() で sandbox にコードを注入する設計だったが、
+ * 実際には呼ばれない dead code になっており、実体は public/sandbox.html の hardcode。
+ * そのため provider 側に action を追加しても sandbox.html を更新し忘れると
+ * "xxx is not defined" で failure する (例: ADR-007 で saveArtifact → PR #147 で修正)。
+ *
+ * 本テストは 3 観点で drift を検出する:
+ *  1. provider.actions の全 action が sandbox.html 内で sendToParent("<action>", ...) として emit される
+ *  2. sandbox.html の AsyncFunction 引数名と実際の関数定義が一致する
+ *  3. 既知の全 helper (各 provider の action に対応するもの) が AsyncFunction 引数に列挙されている
+ */
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SANDBOX_HTML_PATH = join(__dirname, "..", "..", "..", "..", "..", "public", "sandbox.html");
+const sandboxHtml = readFileSync(SANDBOX_HTML_PATH, "utf-8");
+
+function extractSendToParentActions(html: string): Set<string> {
+  const actions = new Set<string>();
+  const regex = /sendToParent\s*\(\s*["']([^"']+)["']/g;
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(html)) !== null) {
+    actions.add(match[1]);
+  }
+  return actions;
+}
+
+function extractAsyncFunctionArgNames(html: string): string[] {
+  // `new AsyncFunction(` から始まり `msg.code,\n)` で閉じるブロックを抽出
+  const start = html.indexOf("new AsyncFunction(");
+  if (start === -1) throw new Error("new AsyncFunction not found in sandbox.html");
+  const afterOpen = html.indexOf("(", start) + 1;
+  const closeIdx = html.indexOf("msg.code", afterOpen);
+  if (closeIdx === -1) throw new Error("msg.code marker not found");
+  const slice = html.substring(afterOpen, closeIdx);
+  // 引数名は "foo" の形で並んでいる
+  return Array.from(slice.matchAll(/"([^"]+)"/g)).map((m) => m[1]);
+}
+
+function extractAsyncFunctionCallNames(html: string): string[] {
+  // `const result = await fn(` から ` );` が現れるまでを抽出
+  const start = html.indexOf("await fn(");
+  if (start === -1) throw new Error("await fn( not found in sandbox.html");
+  const open = html.indexOf("(", start) + 1;
+  let depth = 1;
+  let i = open;
+  while (i < html.length && depth > 0) {
+    const ch = html[i];
+    if (ch === "(") depth += 1;
+    else if (ch === ")") depth -= 1;
+    if (depth === 0) break;
+    i += 1;
+  }
+  const slice = html.substring(open, i);
+  return slice
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+function extractTopLevelFunctionDefs(html: string): Set<string> {
+  const names = new Set<string>();
+  const regex = /^\s*(?:async\s+)?function\s+([A-Za-z_$][\w$]*)\s*\(/gm;
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(html)) !== null) {
+    names.add(match[1]);
+  }
+  return names;
+}
+
+describe("sandbox.html contract", () => {
+  const providers = [
+    { name: "BrowserJsProvider", provider: new BrowserJsProvider() },
+    { name: "NavigateProvider", provider: new NavigateProvider() },
+    { name: "ReadPageProvider", provider: new ReadPageProvider() },
+    { name: "FetchProvider", provider: new FetchProvider() },
+    { name: "NativeInputProvider", provider: new NativeInputProvider() },
+    { name: "ArtifactProvider", provider: new ArtifactProvider() },
+  ];
+
+  describe("provider.actions ↔ sandbox sendToParent() の対応", () => {
+    const emitted = extractSendToParentActions(sandboxHtml);
+
+    for (const { name, provider } of providers) {
+      // Artifact provider は deprecated wire action (createOrUpdateArtifact, returnFile) も
+      // 受理するが、sandbox 側は新 action しか emit しないのでスキップする
+      const emittedRequired =
+        name === "ArtifactProvider"
+          ? provider.actions.filter(
+              (a) => !["createOrUpdateArtifact", "returnFile"].includes(a),
+            )
+          : provider.actions;
+
+      it(`${name}: 宣言された action を sandbox から emit できる`, () => {
+        for (const action of emittedRequired) {
+          expect(
+            emitted.has(action),
+            `sandbox.html が sendToParent("${action}", ...) を呼んでいません (${name})`,
+          ).toBe(true);
+        }
+      });
+    }
+
+    it("sandbox が emit する action はすべて何らかの provider に登録されている", () => {
+      const registered = new Set<string>();
+      for (const { provider } of providers) {
+        for (const a of provider.actions) registered.add(a);
+      }
+      for (const action of emitted) {
+        expect(
+          registered.has(action),
+          `sandbox.html が sendToParent("${action}", ...) を呼ぶがどの provider にも登録されていない`,
+        ).toBe(true);
+      }
+    });
+  });
+
+  describe("AsyncFunction の引数と関数定義の整合", () => {
+    const argNames = extractAsyncFunctionArgNames(sandboxHtml);
+    const callNames = extractAsyncFunctionCallNames(sandboxHtml);
+    const defined = extractTopLevelFunctionDefs(sandboxHtml);
+
+    it("AsyncFunction の引数リストと fn() の呼び出し引数が一致する", () => {
+      expect(callNames).toEqual(argNames);
+    });
+
+    it("各引数名に対応する top-level 関数定義がある (skills / console を除く)", () => {
+      for (const arg of argNames) {
+        if (arg === "skills" || arg === "console") continue;
+        expect(
+          defined.has(arg),
+          `sandbox.html に async function ${arg}() の定義がありません (AsyncFunction の bind 失敗 → REPL で "is not defined" になります)`,
+        ).toBe(true);
+      }
+    });
+
+    it("全 provider の helper (action 名 = 関数名) が AsyncFunction で bind されている", () => {
+      const bound = new Set(argNames);
+      for (const { name, provider } of providers) {
+        for (const action of provider.actions) {
+          // BrowserJsProvider / NavigateProvider / ReadPageProvider / FetchProvider:
+          //   action 名 = REPL 内での関数名
+          // NativeInputProvider: action 名 = 関数名
+          // ArtifactProvider: saveArtifact, getArtifact, listArtifacts, deleteArtifact,
+          //   createOrUpdateArtifact (deprecated wrapper), returnFile (deprecated wrapper)
+          expect(
+            bound.has(action),
+            `action "${action}" が sandbox.html の AsyncFunction 引数に含まれていません (${name})`,
+          ).toBe(true);
+        }
+      }
+    });
+  });
+});

--- a/src/features/tools/providers/artifact-provider.ts
+++ b/src/features/tools/providers/artifact-provider.ts
@@ -64,60 +64,6 @@ const items = await listArtifacts();
 - \`returnFile(name, content, mimeType)\` → use \`saveArtifact(name, content, { mimeType })\``;
   }
 
-  getRuntimeCode(): string {
-    return `
-function __artifactRequest(action, payload) {
-  return new Promise((resolve, reject) => {
-    const id = 'req_' + Date.now() + '_' + Math.random().toString(36).slice(2, 8);
-    const handler = (event) => {
-      if (event.data?.type === 'sandbox-response' && event.data.id === id) {
-        window.removeEventListener('message', handler);
-        if (event.data.ok) {
-          resolve(event.data.value);
-        } else {
-          reject(new Error(event.data.error));
-        }
-      }
-    };
-    window.addEventListener('message', handler);
-    window.parent.postMessage({ type: 'sandbox-request', id, action, ...payload }, '*');
-  });
-}
-
-function saveArtifact(name, data, options) {
-  const opts = options || {};
-  return __artifactRequest('saveArtifact', {
-    name,
-    data,
-    mimeType: opts.mimeType,
-    visible: opts.visible,
-  });
-}
-
-function getArtifact(name) {
-  return __artifactRequest('getArtifact', { name });
-}
-
-function listArtifacts() {
-  return __artifactRequest('listArtifacts', {});
-}
-
-function deleteArtifact(name) {
-  return __artifactRequest('deleteArtifact', { name });
-}
-
-// --- Deprecated helpers (forward to saveArtifact) ---
-function createOrUpdateArtifact(name, data) {
-  console.warn('createOrUpdateArtifact() is deprecated; use saveArtifact(name, data).');
-  return saveArtifact(name, data);
-}
-
-function returnFile(name, content, mimeType) {
-  console.warn('returnFile() is deprecated; use saveArtifact(name, content, { mimeType }).');
-  return saveArtifact(name, content, { mimeType });
-}`;
-  }
-
   async handleRequest(
     request: SandboxRequest,
     context: ProviderContext,
@@ -161,7 +107,9 @@ function returnFile(name, content, mimeType) {
           return ok({ success: true, name });
         }
 
-        // --- Legacy wire protocol (no longer emitted by getRuntimeCode, kept for safety) ---
+        // --- Legacy wire protocol: sandbox.html の deprecation wrapper (createOrUpdateArtifact /
+        // returnFile) が送ってくる action を引き続き受ける。これらは saveArtifact に forward するだけ。
+        // #137 で sandbox.html 側の wrapper と合わせて v0.1.7 で削除予定。 ---
         case "createOrUpdateArtifact": {
           const { name, data } = request as unknown as { name: string; data: unknown };
           await artifactStorage.put(name, { kind: "json", data });

--- a/src/features/tools/providers/browser-js-provider.ts
+++ b/src/features/tools/providers/browser-js-provider.ts
@@ -83,27 +83,6 @@ await browserjs(() => {
 \`\`\``;
   }
 
-  getRuntimeCode(): string {
-    return `
-function browserjs(fn, ...args) {
-  return new Promise((resolve, reject) => {
-    const id = 'req_' + Date.now() + '_' + Math.random().toString(36).slice(2, 8);
-    const handler = (event) => {
-      if (event.data?.type === 'sandbox-response' && event.data.id === id) {
-        window.removeEventListener('message', handler);
-        if (event.data.ok) {
-          resolve(event.data.value);
-        } else {
-          reject(new Error(event.data.error));
-        }
-      }
-    };
-    window.addEventListener('message', handler);
-    window.parent.postMessage({ type: 'sandbox-request', id, action: 'browserjs', code: fn.toString(), args }, '*');
-  });
-}`;
-  }
-
   async handleRequest(
     request: SandboxRequest,
     context: ProviderContext,

--- a/src/features/tools/providers/fetch-provider.ts
+++ b/src/features/tools/providers/fetch-provider.ts
@@ -36,38 +36,6 @@ export class FetchProvider implements RuntimeProvider {
     return buildBgFetchHelperDescription();
   }
 
-  getRuntimeCode(): string {
-    return `
-async function bgFetch(url, options) {
-  const opts = options || {};
-  return new Promise((resolve, reject) => {
-    const id = 'req_' + Date.now() + '_' + Math.random().toString(36).slice(2, 8);
-    const handler = (event) => {
-      if (event.data && event.data.type === 'sandbox-response' && event.data.id === id) {
-        window.removeEventListener('message', handler);
-        if (event.data.ok) {
-          resolve(event.data.value);
-        } else {
-          reject(new Error(event.data.error));
-        }
-      }
-    };
-    window.addEventListener('message', handler);
-    window.parent.postMessage({
-      type: 'sandbox-request',
-      id,
-      action: 'bgFetch',
-      url,
-      method: opts.method,
-      headers: opts.headers,
-      body: opts.body,
-      responseType: opts.responseType,
-      timeout: opts.timeout,
-    }, '*');
-  });
-}`;
-  }
-
   async handleRequest(
     request: SandboxRequest,
     _context: ProviderContext,

--- a/src/features/tools/providers/native-input-provider.ts
+++ b/src/features/tools/providers/native-input-provider.ts
@@ -107,69 +107,6 @@ await nativeScroll('.target-section', { behavior: 'smooth', block: 'center' });
 \`\`\``;
   }
 
-  getRuntimeCode(): string {
-    const actions = [
-      "nativeClick",
-      "nativeDoubleClick",
-      "nativeRightClick",
-      "nativeHover",
-      "nativeFocus",
-      "nativeBlur",
-      "nativeScroll",
-      "nativeSelectText",
-      "nativeType",
-      "nativePress",
-      "nativeKeyDown",
-      "nativeKeyUp",
-    ];
-
-    return actions
-      .map((action) => {
-        const isGlobal =
-          action === "nativePress" || action === "nativeKeyDown" || action === "nativeKeyUp";
-        if (isGlobal) {
-          return `
-function ${action}(key) {
-  return new Promise((resolve, reject) => {
-    const id = 'req_' + Date.now() + '_' + Math.random().toString(36).slice(2, 8);
-    const handler = (event) => {
-      if (event.data?.type === 'sandbox-response' && event.data.id === id) {
-        window.removeEventListener('message', handler);
-        if (event.data.ok) {
-          resolve(event.data.value);
-        } else {
-          reject(new Error(event.data.error));
-        }
-      }
-    };
-    window.addEventListener('message', handler);
-    window.parent.postMessage({ type: 'sandbox-request', id, action: '${action}', key }, '*');
-  });
-}`;
-        } else {
-          return `
-function ${action}(selector, ...args) {
-  return new Promise((resolve, reject) => {
-    const id = 'req_' + Date.now() + '_' + Math.random().toString(36).slice(2, 8);
-    const handler = (event) => {
-      if (event.data?.type === 'sandbox-response' && event.data.id === id) {
-        window.removeEventListener('message', handler);
-        if (event.data.ok) {
-          resolve(event.data.value);
-        } else {
-          reject(new Error(event.data.error));
-        }
-      }
-    };
-    window.addEventListener('message', handler);
-    window.parent.postMessage({ type: 'sandbox-request', id, action: '${action}', selector, args }, '*');
-  });
-}`;
-        }
-      })
-      .join("\n");
-  }
-
   async handleRequest(
     request: SandboxRequest,
     context: ProviderContext,

--- a/src/features/tools/providers/navigate-provider.ts
+++ b/src/features/tools/providers/navigate-provider.ts
@@ -41,27 +41,6 @@ for (const url of urls) {
 \`\`\``;
   }
 
-  getRuntimeCode(): string {
-    return `
-function navigate(url) {
-  return new Promise((resolve, reject) => {
-    const id = 'req_' + Date.now() + '_' + Math.random().toString(36).slice(2, 8);
-    const handler = (event) => {
-      if (event.data?.type === 'sandbox-response' && event.data.id === id) {
-        window.removeEventListener('message', handler);
-        if (event.data.ok) {
-          resolve(event.data.value);
-        } else {
-          reject(new Error(event.data.error));
-        }
-      }
-    };
-    window.addEventListener('message', handler);
-    window.parent.postMessage({ type: 'sandbox-request', id, action: 'navigate', url }, '*');
-  });
-}`;
-  }
-
   async handleRequest(
     request: SandboxRequest,
     context: ProviderContext,

--- a/src/features/tools/providers/read-page-provider.ts
+++ b/src/features/tools/providers/read-page-provider.ts
@@ -24,27 +24,6 @@ Read the current page with the same lightweight extraction used by the legacy re
 - For precise field extraction, follow up with browserjs()`;
   }
 
-  getRuntimeCode(): string {
-    return `
-async function readPage(maxDepth) {
-  return new Promise((resolve, reject) => {
-    const id = 'req_' + Date.now() + '_' + Math.random().toString(36).slice(2, 8);
-    const handler = (event) => {
-      if (event.data?.type === 'sandbox-response' && event.data.id === id) {
-        window.removeEventListener('message', handler);
-        if (event.data.ok) {
-          resolve(event.data.value);
-        } else {
-          reject(new Error(event.data.error));
-        }
-      }
-    };
-    window.addEventListener('message', handler);
-    window.parent.postMessage({ type: 'sandbox-request', id, action: 'readPage', maxDepth }, '*');
-  });
-}`;
-  }
-
   async handleRequest(
     request: SandboxRequest,
     context: ProviderContext,

--- a/src/ports/runtime-provider.ts
+++ b/src/ports/runtime-provider.ts
@@ -14,6 +14,11 @@ import type { SkillMatch } from "@/shared/skill-types";
  * - 動的description生成: REPLツールのdescriptionを実行時に動的に構築
  * - 拡張性: 新しい機能の追加が容易
  * - テスト容易性: 各Providerを個別にテスト可能
+ *
+ * NOTE: REPL 内で AI が呼べる helper 関数の実体 (async function xxx) は
+ * `public/sandbox.html` に hardcode されている。provider 側は
+ * `handleRequest()` で sandbox から届く sandbox-request を処理する責務のみ。
+ * 両者の action 名は `sandbox-contract.test.ts` で drift を検知している。
  */
 
 /**
@@ -65,12 +70,6 @@ export interface RuntimeProvider {
   getDescription(): string;
 
   /**
-   * Sandboxに注入されるランタイムコードを生成
-   * @returns JavaScriptコード文字列
-   */
-  getRuntimeCode(): string;
-
-  /**
    * メッセージを処理する
    * @param request Sandboxからのリクエスト
    * @param context 実行コンテキスト
@@ -111,12 +110,5 @@ export class ProviderRegistry {
    */
   getCombinedDescription(): string {
     return this.providers.map((p) => p.getDescription()).join("\n\n");
-  }
-
-  /**
-   * 全Providerのruntime codeを結合して返す
-   */
-  getCombinedRuntimeCode(): string {
-    return this.providers.map((p) => p.getRuntimeCode()).join("\n\n");
   }
 }


### PR DESCRIPTION
## Summary

ADR-007 で \`saveArtifact is not defined\` エラー (#147) の根本原因になった **\"getRuntimeCode() は定義されているがどこからも呼ばれない dead code\"** 問題を解消する (#150)。

### 変更内容

#### 1. getRuntimeCode() の完全削除

- \`RuntimeProvider\` インターフェイスから \`getRuntimeCode()\` を削除
- \`ProviderRegistry.getCombinedRuntimeCode()\` を削除
- 6 provider (browser-js / navigate / read-page / fetch / native-input / artifact) から実装をそれぞれ削除
- \`RuntimeProvider\` の doc コメントに **「helper 関数の実体は public/sandbox.html に hardcode、drift 検知は sandbox-contract.test.ts」** と明記
- \`fetch-provider.test.ts\` の \`getRuntimeCode()\` テストケースも削除

#### 2. drift 検知テストの追加

\`sandbox-contract.test.ts\` を新設、3 観点で sandbox.html と provider の乖離を検出:

1. **provider.actions の全 action が sandbox.html 内で \`sendToParent(\"<action>\", ...)\` として emit されているか**
2. **AsyncFunction 引数リストと invocation 引数が一致しているか**
3. **引数に対応する top-level 関数定義 (\`async function xxx()\` / \`function xxx()\`) が存在し、かつ全 provider の action 名が bind されているか**

これにより、今後新 action を provider 側だけに追加すると test が失敗する → PR レビューで確実に drift を検出できる。

### 効果

- **dead code ~250 行削減**
- \"getRuntimeCode() を更新すれば AI に helper が届く\" という誤解を招く API が消滅 → SSOT が \`public/sandbox.html\` であることが明確化
- 新 action 追加時は sandbox.html を更新しないと CI で fail する (**saveArtifact 類似のバグが再発しない**)

## Test plan

- [x] \`sandbox-contract.test.ts\` 10 ケース pass
- [x] 全テスト pass (1076/1076)
- [x] TypeScript 0 error
- [x] fmt / lint clean

### drift 検知の動作確認 (任意)

sandbox.html から saveArtifact 関数定義を一時的に削除 → test が失敗する。元に戻せば pass。

## 関連

- Closes #150
- 統合レビュー: #138
- 関連 PR: #147 (sandbox.html に saveArtifact を追加、本 test が既にあれば防げた事象)

🤖 Generated with [Claude Code](https://claude.com/claude-code)