### PR TITLE
refactor(storage): consolidate StoredArtifactRecord into shared internal type

### DIFF
--- a/src/adapters/storage/artifact-record.ts
+++ b/src/adapters/storage/artifact-record.ts
@@ -1,0 +1,27 @@
+import type { ArtifactKind, ArtifactMeta } from "@/ports/artifact-storage";
+
+/**
+ * Artifact の storage 内部表現。
+ * `ArtifactMeta` の全 field に加えて、実データ (data | bytes) と
+ * session-scoped key / sessionId を持つ。
+ *
+ * - in-memory / IndexedDB の両 Adapter、および indexeddb-database.ts の
+ *   upgrade 時 migration で同じ shape を流用する
+ * - 型定義が乖離すると Adapter 間の挙動が drift する (ADR-007 統合レビュー
+ *   で発見、#151) ため共有型として集約する
+ */
+export interface StoredArtifactRecord extends ArtifactMeta {
+  key: string;
+  sessionId: string | null;
+  kind: ArtifactKind;
+  /** kind === "json" のときだけ存在 */
+  data?: unknown;
+  /** kind === "file" のときだけ存在 */
+  bytes?: Uint8Array;
+}
+
+export const GLOBAL_SESSION_KEY = "__global__";
+
+export function createArtifactKey(sessionId: string | null, name: string): string {
+  return `${sessionId ?? GLOBAL_SESSION_KEY}::${name}`;
+}

--- a/src/adapters/storage/artifact-storage.ts
+++ b/src/adapters/storage/artifact-storage.ts
@@ -5,6 +5,7 @@ import type {
   ArtifactValue,
 } from "@/ports/artifact-storage";
 import { createLogger } from "@/shared/logger";
+import { GLOBAL_SESSION_KEY, type StoredArtifactRecord } from "./artifact-record";
 import {
   APP_META_STORE,
   ARTIFACTS_MIGRATION_DONE_KEY,
@@ -15,14 +16,6 @@ import {
 } from "./indexeddb-database";
 
 const log = createLogger("artifact-storage");
-const GLOBAL_SESSION_KEY = "__global__";
-
-type StoredArtifactRecord = ArtifactMeta & {
-  key: string;
-  sessionId: string | null;
-  data?: unknown;
-  bytes?: Uint8Array;
-};
 
 type AppMetaRecord = {
   key: string;

--- a/src/adapters/storage/in-memory-storage.ts
+++ b/src/adapters/storage/in-memory-storage.ts
@@ -5,18 +5,10 @@ import type {
   ArtifactValue,
 } from "@/ports/artifact-storage";
 import type { StoragePort } from "@/ports/storage";
-
-const GLOBAL_SESSION_KEY = "__global__";
-
-type StoredArtifact = ArtifactMeta & {
-  key: string;
-  sessionId: string | null;
-  data?: unknown;
-  bytes?: Uint8Array;
-};
+import { GLOBAL_SESSION_KEY, type StoredArtifactRecord } from "./artifact-record";
 
 export class InMemoryArtifactStorage implements ArtifactStoragePort {
-  private artifacts = new Map<string, StoredArtifact>();
+  private artifacts = new Map<string, StoredArtifactRecord>();
   private sessionId: string | null = null;
 
   async put(name: string, value: ArtifactValue, options?: { visible?: boolean }): Promise<void> {

--- a/src/adapters/storage/indexeddb-database.ts
+++ b/src/adapters/storage/indexeddb-database.ts
@@ -1,3 +1,5 @@
+import { createArtifactKey, type StoredArtifactRecord } from "./artifact-record";
+
 const DEFAULT_DB_NAME = "tandemweb";
 const CURRENT_DB_VERSION = 4;
 const SESSIONS_STORE = "sessions";
@@ -12,7 +14,6 @@ const LEGACY_JSON_ARTIFACTS_STORE = "json-artifacts";
 const LEGACY_FILES_STORE = "files";
 const ARTIFACTS_MIGRATION_DONE_KEY = "artifacts-migration-v1-done";
 const MIGRATION_NOTES_KEY = "migration-notes";
-const GLOBAL_SESSION_KEY = "__global__";
 
 type LegacyJsonArtifactRecord = {
   name: string;
@@ -32,20 +33,6 @@ type LegacyFileArtifactRecord = {
   updatedAt?: number;
   visible?: boolean;
   sessionId?: string | null;
-};
-
-type UnifiedArtifactRecord = {
-  key: string;
-  sessionId: string | null;
-  name: string;
-  kind: "json" | "file";
-  data?: unknown;
-  bytes?: Uint8Array;
-  mimeType?: string;
-  size: number;
-  visible: boolean;
-  createdAt: number;
-  updatedAt: number;
 };
 
 type MigrationNote = {
@@ -199,7 +186,7 @@ function migrateLegacyArtifacts(
   migrateJson();
 }
 
-function toUnifiedJsonRecord(legacy: LegacyJsonArtifactRecord): UnifiedArtifactRecord {
+function toUnifiedJsonRecord(legacy: LegacyJsonArtifactRecord): StoredArtifactRecord {
   const now = Date.now();
   const sessionId = legacy.sessionId ?? null;
   const encoded = new TextEncoder().encode(JSON.stringify(legacy.data));
@@ -216,7 +203,7 @@ function toUnifiedJsonRecord(legacy: LegacyJsonArtifactRecord): UnifiedArtifactR
   };
 }
 
-function toUnifiedFileRecord(legacy: LegacyFileArtifactRecord): UnifiedArtifactRecord {
+function toUnifiedFileRecord(legacy: LegacyFileArtifactRecord): StoredArtifactRecord {
   const now = Date.now();
   const sessionId = legacy.sessionId ?? null;
   const bytes = base64ToBytes(legacy.contentBase64);
@@ -232,10 +219,6 @@ function toUnifiedFileRecord(legacy: LegacyFileArtifactRecord): UnifiedArtifactR
     createdAt: legacy.createdAt ?? now,
     updatedAt: legacy.updatedAt ?? legacy.createdAt ?? now,
   };
-}
-
-function createArtifactKey(sessionId: string | null, name: string): string {
-  return `${sessionId ?? GLOBAL_SESSION_KEY}::${name}`;
 }
 
 function base64ToBytes(base64: string): Uint8Array {


### PR DESCRIPTION
## Summary

ADR-007 統合レビュー Finding 2 (#151) の対応。3 ファイルに重複していた adapter 内部型を共通ファイルに集約。

### 変更

- **新設**: \`src/adapters/storage/artifact-record.ts\`
  - \`StoredArtifactRecord\` (ArtifactMeta + key + sessionId + data?/bytes?)
  - \`GLOBAL_SESSION_KEY\` 定数
  - \`createArtifactKey(sessionId, name)\` helper
- **統合**: 3 ファイルの重複型を削除
  - \`artifact-storage.ts\` の \`StoredArtifactRecord\`
  - \`in-memory-storage.ts\` の \`StoredArtifact\`
  - \`indexeddb-database.ts\` の \`UnifiedArtifactRecord\` + \`GLOBAL_SESSION_KEY\` + \`createArtifactKey\`

shape が全 3 箇所で同一だったため behavior 変化なし。

## Test plan

- [x] 全テスト pass (1076/1076)
- [x] TypeScript 0 error
- [x] fmt / lint clean

## 関連

- Closes #151
- ADR-007 統合レビュー: #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)