### PR TITLE
chore(release): v0.1.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sitesurf",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "AIと一緒にWebページを操作するChrome拡張機能",
   "license": "MIT",
   "type": "module",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "SiteSurf",
   "description": "AIと一緒にWebページを操作するChrome拡張",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "action": {
     "default_title": "SiteSurfを開く",
     "default_icon": {


### PR DESCRIPTION
## Summary

v0.1.6 → v0.1.7 のリリース版上げ。

### 🚨 BREAKING CHANGES

旧 artifact helper を完全削除 (#137 / PR #155):

- \`createOrUpdateArtifact(name, data)\` → **削除**、代わりに \`saveArtifact(name, data)\` を使用
- \`returnFile(name, content, mimeType)\` → **削除**、代わりに \`saveArtifact(name, content, { mimeType })\` を使用

v0.1.6 では deprecation warning 付きで動作していたが、v0.1.7 以降は呼び出し時に ReferenceError / Unknown action エラーになる。

### その他の変更

- **#151**: Adapter 内部型 \`StoredArtifactRecord\` を共通ファイル (\`src/adapters/storage/artifact-record.ts\`) に集約 (PR #154)
- docs の古い API 記述を削除

## Test plan

- [x] package.json / public/manifest.json の version 更新
- [x] 全テスト pass (1075/1075)
- [x] TypeScript 0 error
- [x] dist/sandbox.html に legacy 名 0 件
- [x] 本ブランチ merge 後、\`v0.1.7\` タグを push → release.yml が dist.zip 付きで GitHub Release を自動作成

🤖 Generated with [Claude Code](https://claude.com/claude-code)