### PR TITLE
feat: add Kimi K2.6 and k2p6 models

### DIFF
--- a/scripts/generate-models.ts
+++ b/scripts/generate-models.ts
@@ -25,7 +25,7 @@ const PROVIDER_MAP: Record<string, { key: string; defaultModel: string }> = {
   openai: { key: "openai", defaultModel: "gpt-5.4" },
   google: { key: "google", defaultModel: "gemini-2.5-flash" },
   "github-copilot": { key: "copilot", defaultModel: "gpt-4.1" },
-  "kimi-for-coding": { key: "kimi-coding", defaultModel: "k2p5" },
+  "kimi-for-coding": { key: "kimi-coding", defaultModel: "k2p6" },
   zai: { key: "zai", defaultModel: "glm-5.1" },
   "zai-coding-plan": { key: "zai-coding", defaultModel: "glm-5.1" },
 };

--- a/scripts/generate-models.ts
+++ b/scripts/generate-models.ts
@@ -25,6 +25,7 @@ const PROVIDER_MAP: Record<string, { key: string; defaultModel: string }> = {
   openai: { key: "openai", defaultModel: "gpt-5.4" },
   google: { key: "google", defaultModel: "gemini-2.5-flash" },
   "github-copilot": { key: "copilot", defaultModel: "gpt-4.1" },
+  moonshotai: { key: "kimi", defaultModel: "kimi-k2.6" },
   "kimi-for-coding": { key: "kimi-coding", defaultModel: "k2p6" },
   zai: { key: "zai", defaultModel: "glm-5.1" },
   "zai-coding-plan": { key: "zai-coding", defaultModel: "glm-5.1" },

--- a/src/features/settings/__tests__/persistence.test.ts
+++ b/src/features/settings/__tests__/persistence.test.ts
@@ -341,4 +341,26 @@ describe("persistence", () => {
 
     expect(result?.autoCompact).toBe(true);
   });
+
+  it("kimi / kimi-coding の保存済み model が空でも K2.6 系 default で復元される", async () => {
+    const kimiStorage = new InMemoryStorage();
+    await kimiStorage.set("sitesurf_settings", {
+      provider: "kimi",
+      model: "",
+      modelByProvider: { kimi: "" },
+    });
+
+    const kimiResult = await loadSettings(kimiStorage);
+    expect(kimiResult?.model).toBe("kimi-k2.6");
+
+    const codingStorage = new InMemoryStorage();
+    await codingStorage.set("sitesurf_settings", {
+      provider: "kimi-coding",
+      model: "",
+      modelByProvider: { "kimi-coding": "" },
+    });
+
+    const codingResult = await loadSettings(codingStorage);
+    expect(codingResult?.model).toBe("k2p6");
+  });
 });

--- a/src/shared/__tests__/constants.test.ts
+++ b/src/shared/__tests__/constants.test.ts
@@ -68,6 +68,16 @@ describe("PROVIDERS定数", () => {
   it("google は apikey 認証", () => {
     expect(PROVIDERS.google.authType).toBe("apikey");
   });
+
+  it("kimi は K2.6 をデフォルトに含む", () => {
+    expect(PROVIDERS.kimi.defaultModel).toBe("kimi-k2.6");
+    expect(PROVIDERS.kimi.models).toContain("kimi-k2.6");
+  });
+
+  it("kimi-coding は k2p6 をデフォルトに含む", () => {
+    expect(PROVIDERS["kimi-coding"].defaultModel).toBe("k2p6");
+    expect(PROVIDERS["kimi-coding"].models).toContain("k2p6");
+  });
 });
 
 describe("THEME_STORAGE_KEY", () => {

--- a/src/shared/__tests__/constants.test.ts
+++ b/src/shared/__tests__/constants.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { PROVIDERS, THEME_STORAGE_KEY } from "../constants";
+import { GENERATED_MODELS } from "../models.generated";
 import type { ProviderId, ProviderInfo, ColorScheme } from "../constants";
 
 describe("PROVIDERS定数", () => {
@@ -77,6 +78,15 @@ describe("PROVIDERS定数", () => {
   it("kimi-coding は k2p6 をデフォルトに含む", () => {
     expect(PROVIDERS["kimi-coding"].defaultModel).toBe("k2p6");
     expect(PROVIDERS["kimi-coding"].models).toContain("k2p6");
+  });
+
+  it("kimi と kimi-coding は models.generated.ts から取得される", () => {
+    expect(GENERATED_MODELS.kimi).toBeDefined();
+    expect(GENERATED_MODELS.kimi.models.some((model) => model.id === "kimi-k2.5")).toBe(true);
+    expect(GENERATED_MODELS["kimi-coding"].defaultModel).toBe("k2p6");
+    expect(GENERATED_MODELS["kimi-coding"].models.some((model) => model.id === "k2p6")).toBe(
+      true,
+    );
   });
 });
 

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -29,7 +29,8 @@ export interface ProviderInfo {
 
 function modelsFor(key: string, fallback?: string[]): string[] {
   const generated = (GENERATED_MODELS[key]?.models ?? []).map((m) => m.id);
-  return generated.length > 0 ? generated : (fallback ?? []);
+  if (generated.length === 0) return fallback ?? [];
+  return [...new Set([...generated, ...(fallback ?? [])])];
 }
 
 function defaultFor(key: string, fallback: string): string {

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -92,8 +92,9 @@ export const PROVIDERS: Record<ProviderId, ProviderInfo> = {
   kimi: {
     id: "kimi",
     name: "Kimi (Moonshot AI)",
-    defaultModel: defaultFor("kimi", "kimi-k2.5"),
+    defaultModel: defaultFor("kimi", "kimi-k2.6"),
     models: modelsFor("kimi", [
+      "kimi-k2.6",
       "kimi-k2.5",
       "kimi-k2-turbo-preview",
       "kimi-k2-0905-preview",
@@ -109,8 +110,8 @@ export const PROVIDERS: Record<ProviderId, ProviderInfo> = {
   "kimi-coding": {
     id: "kimi-coding",
     name: "Kimi for Coding",
-    defaultModel: defaultFor("kimi-coding", "k2p5"),
-    models: modelsFor("kimi-coding", ["k2p5", "kimi-k2-thinking"]),
+    defaultModel: defaultFor("kimi-coding", "k2p6"),
+    models: modelsFor("kimi-coding", ["k2p6", "k2p5", "kimi-k2-thinking"]),
     authType: "apikey",
     placeholder: "sk-...",
   },

--- a/src/shared/models.generated.ts
+++ b/src/shared/models.generated.ts
@@ -14,639 +14,679 @@ export interface ProviderModels {
 }
 
 export const GENERATED_MODELS: Record<string, ProviderModels> = {
-  anthropic: {
-    defaultModel: "claude-sonnet-4-6",
-    models: [
+  "anthropic": {
+    "defaultModel": "claude-sonnet-4-6",
+    "models": [
       {
-        id: "claude-3-5-haiku-20241022",
-        name: "Claude Haiku 3.5",
-        reasoning: false,
+        "id": "claude-3-5-haiku-20241022",
+        "name": "Claude Haiku 3.5",
+        "reasoning": false
       },
       {
-        id: "claude-3-5-haiku-latest",
-        name: "Claude Haiku 3.5 (latest)",
-        reasoning: false,
+        "id": "claude-3-5-haiku-latest",
+        "name": "Claude Haiku 3.5 (latest)",
+        "reasoning": false
       },
       {
-        id: "claude-3-5-sonnet-20240620",
-        name: "Claude Sonnet 3.5",
-        reasoning: false,
+        "id": "claude-3-5-sonnet-20240620",
+        "name": "Claude Sonnet 3.5",
+        "reasoning": false
       },
       {
-        id: "claude-3-5-sonnet-20241022",
-        name: "Claude Sonnet 3.5 v2",
-        reasoning: false,
+        "id": "claude-3-5-sonnet-20241022",
+        "name": "Claude Sonnet 3.5 v2",
+        "reasoning": false
       },
       {
-        id: "claude-3-haiku-20240307",
-        name: "Claude Haiku 3",
-        reasoning: false,
+        "id": "claude-3-haiku-20240307",
+        "name": "Claude Haiku 3",
+        "reasoning": false
       },
       {
-        id: "claude-3-opus-20240229",
-        name: "Claude Opus 3",
-        reasoning: false,
+        "id": "claude-3-opus-20240229",
+        "name": "Claude Opus 3",
+        "reasoning": false
       },
       {
-        id: "claude-3-sonnet-20240229",
-        name: "Claude Sonnet 3",
-        reasoning: false,
+        "id": "claude-3-sonnet-20240229",
+        "name": "Claude Sonnet 3",
+        "reasoning": false
       },
       {
-        id: "claude-3-7-sonnet-20250219",
-        name: "Claude Sonnet 3.7",
-        reasoning: true,
+        "id": "claude-3-7-sonnet-20250219",
+        "name": "Claude Sonnet 3.7",
+        "reasoning": true
       },
       {
-        id: "claude-haiku-4-5",
-        name: "Claude Haiku 4.5 (latest)",
-        reasoning: true,
+        "id": "claude-haiku-4-5",
+        "name": "Claude Haiku 4.5 (latest)",
+        "reasoning": true
       },
       {
-        id: "claude-haiku-4-5-20251001",
-        name: "Claude Haiku 4.5",
-        reasoning: true,
+        "id": "claude-haiku-4-5-20251001",
+        "name": "Claude Haiku 4.5",
+        "reasoning": true
       },
       {
-        id: "claude-opus-4-0",
-        name: "Claude Opus 4 (latest)",
-        reasoning: true,
+        "id": "claude-opus-4-0",
+        "name": "Claude Opus 4 (latest)",
+        "reasoning": true
       },
       {
-        id: "claude-opus-4-1",
-        name: "Claude Opus 4.1 (latest)",
-        reasoning: true,
+        "id": "claude-opus-4-1",
+        "name": "Claude Opus 4.1 (latest)",
+        "reasoning": true
       },
       {
-        id: "claude-opus-4-1-20250805",
-        name: "Claude Opus 4.1",
-        reasoning: true,
+        "id": "claude-opus-4-1-20250805",
+        "name": "Claude Opus 4.1",
+        "reasoning": true
       },
       {
-        id: "claude-opus-4-20250514",
-        name: "Claude Opus 4",
-        reasoning: true,
+        "id": "claude-opus-4-20250514",
+        "name": "Claude Opus 4",
+        "reasoning": true
       },
       {
-        id: "claude-opus-4-5",
-        name: "Claude Opus 4.5 (latest)",
-        reasoning: true,
+        "id": "claude-opus-4-5",
+        "name": "Claude Opus 4.5 (latest)",
+        "reasoning": true
       },
       {
-        id: "claude-opus-4-5-20251101",
-        name: "Claude Opus 4.5",
-        reasoning: true,
+        "id": "claude-opus-4-5-20251101",
+        "name": "Claude Opus 4.5",
+        "reasoning": true
       },
       {
-        id: "claude-opus-4-6",
-        name: "Claude Opus 4.6",
-        reasoning: true,
+        "id": "claude-opus-4-6",
+        "name": "Claude Opus 4.6",
+        "reasoning": true
       },
       {
-        id: "claude-opus-4-7",
-        name: "Claude Opus 4.7",
-        reasoning: true,
+        "id": "claude-opus-4-7",
+        "name": "Claude Opus 4.7",
+        "reasoning": true
       },
       {
-        id: "claude-sonnet-4-0",
-        name: "Claude Sonnet 4 (latest)",
-        reasoning: true,
+        "id": "claude-sonnet-4-0",
+        "name": "Claude Sonnet 4 (latest)",
+        "reasoning": true
       },
       {
-        id: "claude-sonnet-4-20250514",
-        name: "Claude Sonnet 4",
-        reasoning: true,
+        "id": "claude-sonnet-4-20250514",
+        "name": "Claude Sonnet 4",
+        "reasoning": true
       },
       {
-        id: "claude-sonnet-4-5",
-        name: "Claude Sonnet 4.5 (latest)",
-        reasoning: true,
+        "id": "claude-sonnet-4-5",
+        "name": "Claude Sonnet 4.5 (latest)",
+        "reasoning": true
       },
       {
-        id: "claude-sonnet-4-5-20250929",
-        name: "Claude Sonnet 4.5",
-        reasoning: true,
+        "id": "claude-sonnet-4-5-20250929",
+        "name": "Claude Sonnet 4.5",
+        "reasoning": true
       },
       {
-        id: "claude-sonnet-4-6",
-        name: "Claude Sonnet 4.6",
-        reasoning: true,
-      },
-    ],
+        "id": "claude-sonnet-4-6",
+        "name": "Claude Sonnet 4.6",
+        "reasoning": true
+      }
+    ]
   },
-  openai: {
-    defaultModel: "gpt-5.4",
-    models: [
+  "openai": {
+    "defaultModel": "gpt-5.4",
+    "models": [
       {
-        id: "gpt-4",
-        name: "GPT-4",
-        reasoning: false,
+        "id": "gpt-4",
+        "name": "GPT-4",
+        "reasoning": false
       },
       {
-        id: "gpt-4-turbo",
-        name: "GPT-4 Turbo",
-        reasoning: false,
+        "id": "gpt-4-turbo",
+        "name": "GPT-4 Turbo",
+        "reasoning": false
       },
       {
-        id: "gpt-4.1",
-        name: "GPT-4.1",
-        reasoning: false,
+        "id": "gpt-4.1",
+        "name": "GPT-4.1",
+        "reasoning": false
       },
       {
-        id: "gpt-4.1-mini",
-        name: "GPT-4.1 mini",
-        reasoning: false,
+        "id": "gpt-4.1-mini",
+        "name": "GPT-4.1 mini",
+        "reasoning": false
       },
       {
-        id: "gpt-4.1-nano",
-        name: "GPT-4.1 nano",
-        reasoning: false,
+        "id": "gpt-4.1-nano",
+        "name": "GPT-4.1 nano",
+        "reasoning": false
       },
       {
-        id: "gpt-4o",
-        name: "GPT-4o",
-        reasoning: false,
+        "id": "gpt-4o",
+        "name": "GPT-4o",
+        "reasoning": false
       },
       {
-        id: "gpt-4o-2024-05-13",
-        name: "GPT-4o (2024-05-13)",
-        reasoning: false,
+        "id": "gpt-4o-2024-05-13",
+        "name": "GPT-4o (2024-05-13)",
+        "reasoning": false
       },
       {
-        id: "gpt-4o-2024-08-06",
-        name: "GPT-4o (2024-08-06)",
-        reasoning: false,
+        "id": "gpt-4o-2024-08-06",
+        "name": "GPT-4o (2024-08-06)",
+        "reasoning": false
       },
       {
-        id: "gpt-4o-2024-11-20",
-        name: "GPT-4o (2024-11-20)",
-        reasoning: false,
+        "id": "gpt-4o-2024-11-20",
+        "name": "GPT-4o (2024-11-20)",
+        "reasoning": false
       },
       {
-        id: "gpt-4o-mini",
-        name: "GPT-4o mini",
-        reasoning: false,
+        "id": "gpt-4o-mini",
+        "name": "GPT-4o mini",
+        "reasoning": false
       },
       {
-        id: "gpt-5.3-chat-latest",
-        name: "GPT-5.3 Chat (latest)",
-        reasoning: false,
+        "id": "gpt-5.3-chat-latest",
+        "name": "GPT-5.3 Chat (latest)",
+        "reasoning": false
       },
       {
-        id: "gpt-5",
-        name: "GPT-5",
-        reasoning: true,
+        "id": "gpt-5",
+        "name": "GPT-5",
+        "reasoning": true
       },
       {
-        id: "gpt-5-mini",
-        name: "GPT-5 Mini",
-        reasoning: true,
+        "id": "gpt-5-mini",
+        "name": "GPT-5 Mini",
+        "reasoning": true
       },
       {
-        id: "gpt-5-nano",
-        name: "GPT-5 Nano",
-        reasoning: true,
+        "id": "gpt-5-nano",
+        "name": "GPT-5 Nano",
+        "reasoning": true
       },
       {
-        id: "gpt-5-pro",
-        name: "GPT-5 Pro",
-        reasoning: true,
+        "id": "gpt-5-pro",
+        "name": "GPT-5 Pro",
+        "reasoning": true
       },
       {
-        id: "gpt-5.1",
-        name: "GPT-5.1",
-        reasoning: true,
+        "id": "gpt-5.1",
+        "name": "GPT-5.1",
+        "reasoning": true
       },
       {
-        id: "gpt-5.1-chat-latest",
-        name: "GPT-5.1 Chat",
-        reasoning: true,
+        "id": "gpt-5.1-chat-latest",
+        "name": "GPT-5.1 Chat",
+        "reasoning": true
       },
       {
-        id: "gpt-5.2",
-        name: "GPT-5.2",
-        reasoning: true,
+        "id": "gpt-5.2",
+        "name": "GPT-5.2",
+        "reasoning": true
       },
       {
-        id: "gpt-5.2-chat-latest",
-        name: "GPT-5.2 Chat",
-        reasoning: true,
+        "id": "gpt-5.2-chat-latest",
+        "name": "GPT-5.2 Chat",
+        "reasoning": true
       },
       {
-        id: "gpt-5.2-pro",
-        name: "GPT-5.2 Pro",
-        reasoning: true,
+        "id": "gpt-5.2-pro",
+        "name": "GPT-5.2 Pro",
+        "reasoning": true
       },
       {
-        id: "gpt-5.4",
-        name: "GPT-5.4",
-        reasoning: true,
+        "id": "gpt-5.4",
+        "name": "GPT-5.4",
+        "reasoning": true
       },
       {
-        id: "gpt-5.4-mini",
-        name: "GPT-5.4 mini",
-        reasoning: true,
+        "id": "gpt-5.4-mini",
+        "name": "GPT-5.4 mini",
+        "reasoning": true
       },
       {
-        id: "gpt-5.4-nano",
-        name: "GPT-5.4 nano",
-        reasoning: true,
+        "id": "gpt-5.4-nano",
+        "name": "GPT-5.4 nano",
+        "reasoning": true
       },
       {
-        id: "gpt-5.4-pro",
-        name: "GPT-5.4 Pro",
-        reasoning: true,
+        "id": "gpt-5.4-pro",
+        "name": "GPT-5.4 Pro",
+        "reasoning": true
       },
       {
-        id: "o1",
-        name: "o1",
-        reasoning: true,
+        "id": "o1",
+        "name": "o1",
+        "reasoning": true
       },
       {
-        id: "o1-pro",
-        name: "o1-pro",
-        reasoning: true,
+        "id": "o1-pro",
+        "name": "o1-pro",
+        "reasoning": true
       },
       {
-        id: "o3",
-        name: "o3",
-        reasoning: true,
+        "id": "o3",
+        "name": "o3",
+        "reasoning": true
       },
       {
-        id: "o3-deep-research",
-        name: "o3-deep-research",
-        reasoning: true,
+        "id": "o3-deep-research",
+        "name": "o3-deep-research",
+        "reasoning": true
       },
       {
-        id: "o3-mini",
-        name: "o3-mini",
-        reasoning: true,
+        "id": "o3-mini",
+        "name": "o3-mini",
+        "reasoning": true
       },
       {
-        id: "o3-pro",
-        name: "o3-pro",
-        reasoning: true,
+        "id": "o3-pro",
+        "name": "o3-pro",
+        "reasoning": true
       },
       {
-        id: "o4-mini",
-        name: "o4-mini",
-        reasoning: true,
+        "id": "o4-mini",
+        "name": "o4-mini",
+        "reasoning": true
       },
       {
-        id: "o4-mini-deep-research",
-        name: "o4-mini-deep-research",
-        reasoning: true,
-      },
-    ],
+        "id": "o4-mini-deep-research",
+        "name": "o4-mini-deep-research",
+        "reasoning": true
+      }
+    ]
   },
-  google: {
-    defaultModel: "gemini-2.5-flash",
-    models: [
+  "google": {
+    "defaultModel": "gemini-2.5-flash",
+    "models": [
       {
-        id: "gemini-1.5-flash",
-        name: "Gemini 1.5 Flash",
-        reasoning: false,
+        "id": "gemini-1.5-flash",
+        "name": "Gemini 1.5 Flash",
+        "reasoning": false
       },
       {
-        id: "gemini-1.5-flash-8b",
-        name: "Gemini 1.5 Flash-8B",
-        reasoning: false,
+        "id": "gemini-1.5-flash-8b",
+        "name": "Gemini 1.5 Flash-8B",
+        "reasoning": false
       },
       {
-        id: "gemini-1.5-pro",
-        name: "Gemini 1.5 Pro",
-        reasoning: false,
+        "id": "gemini-1.5-pro",
+        "name": "Gemini 1.5 Pro",
+        "reasoning": false
       },
       {
-        id: "gemini-2.0-flash",
-        name: "Gemini 2.0 Flash",
-        reasoning: false,
+        "id": "gemini-2.0-flash",
+        "name": "Gemini 2.0 Flash",
+        "reasoning": false
       },
       {
-        id: "gemini-2.0-flash-lite",
-        name: "Gemini 2.0 Flash Lite",
-        reasoning: false,
+        "id": "gemini-2.0-flash-lite",
+        "name": "Gemini 2.0 Flash Lite",
+        "reasoning": false
       },
       {
-        id: "gemini-2.5-flash",
-        name: "Gemini 2.5 Flash",
-        reasoning: true,
+        "id": "gemini-2.5-flash",
+        "name": "Gemini 2.5 Flash",
+        "reasoning": true
       },
       {
-        id: "gemini-2.5-flash-lite",
-        name: "Gemini 2.5 Flash Lite",
-        reasoning: true,
+        "id": "gemini-2.5-flash-lite",
+        "name": "Gemini 2.5 Flash Lite",
+        "reasoning": true
       },
       {
-        id: "gemini-2.5-pro",
-        name: "Gemini 2.5 Pro",
-        reasoning: true,
+        "id": "gemini-2.5-pro",
+        "name": "Gemini 2.5 Pro",
+        "reasoning": true
       },
       {
-        id: "gemini-3-flash-preview",
-        name: "Gemini 3 Flash Preview",
-        reasoning: true,
+        "id": "gemini-3-flash-preview",
+        "name": "Gemini 3 Flash Preview",
+        "reasoning": true
       },
       {
-        id: "gemini-3-pro-preview",
-        name: "Gemini 3 Pro Preview",
-        reasoning: true,
+        "id": "gemini-3-pro-preview",
+        "name": "Gemini 3 Pro Preview",
+        "reasoning": true
       },
       {
-        id: "gemini-3.1-flash-lite-preview",
-        name: "Gemini 3.1 Flash Lite Preview",
-        reasoning: true,
+        "id": "gemini-3.1-flash-lite-preview",
+        "name": "Gemini 3.1 Flash Lite Preview",
+        "reasoning": true
       },
       {
-        id: "gemini-3.1-pro-preview",
-        name: "Gemini 3.1 Pro Preview",
-        reasoning: true,
+        "id": "gemini-3.1-pro-preview",
+        "name": "Gemini 3.1 Pro Preview",
+        "reasoning": true
       },
       {
-        id: "gemini-3.1-pro-preview-customtools",
-        name: "Gemini 3.1 Pro Preview Custom Tools",
-        reasoning: true,
+        "id": "gemini-3.1-pro-preview-customtools",
+        "name": "Gemini 3.1 Pro Preview Custom Tools",
+        "reasoning": true
       },
       {
-        id: "gemini-flash-latest",
-        name: "Gemini Flash Latest",
-        reasoning: true,
+        "id": "gemini-flash-latest",
+        "name": "Gemini Flash Latest",
+        "reasoning": true
       },
       {
-        id: "gemini-flash-lite-latest",
-        name: "Gemini Flash-Lite Latest",
-        reasoning: true,
+        "id": "gemini-flash-lite-latest",
+        "name": "Gemini Flash-Lite Latest",
+        "reasoning": true
       },
       {
-        id: "gemini-live-2.5-flash",
-        name: "Gemini Live 2.5 Flash",
-        reasoning: true,
+        "id": "gemini-live-2.5-flash",
+        "name": "Gemini Live 2.5 Flash",
+        "reasoning": true
       },
       {
-        id: "gemini-live-2.5-flash-preview-native-audio",
-        name: "Gemini Live 2.5 Flash Preview Native Audio",
-        reasoning: true,
-      },
-    ],
+        "id": "gemini-live-2.5-flash-preview-native-audio",
+        "name": "Gemini Live 2.5 Flash Preview Native Audio",
+        "reasoning": true
+      }
+    ]
   },
-  copilot: {
-    defaultModel: "gpt-4.1",
-    models: [
+  "copilot": {
+    "defaultModel": "gpt-4.1",
+    "models": [
       {
-        id: "gemini-2.5-pro",
-        name: "Gemini 2.5 Pro",
-        reasoning: false,
+        "id": "gemini-2.5-pro",
+        "name": "Gemini 2.5 Pro",
+        "reasoning": false
       },
       {
-        id: "gpt-4.1",
-        name: "GPT-4.1",
-        reasoning: false,
+        "id": "gpt-4.1",
+        "name": "GPT-4.1",
+        "reasoning": false
       },
       {
-        id: "gpt-4o",
-        name: "GPT-4o",
-        reasoning: false,
+        "id": "gpt-4o",
+        "name": "GPT-4o",
+        "reasoning": false
       },
       {
-        id: "claude-haiku-4.5",
-        name: "Claude Haiku 4.5",
-        reasoning: true,
+        "id": "claude-haiku-4.5",
+        "name": "Claude Haiku 4.5",
+        "reasoning": true
       },
       {
-        id: "claude-opus-4.5",
-        name: "Claude Opus 4.5",
-        reasoning: true,
+        "id": "claude-opus-4.5",
+        "name": "Claude Opus 4.5",
+        "reasoning": true
       },
       {
-        id: "claude-opus-4.6",
-        name: "Claude Opus 4.6",
-        reasoning: true,
+        "id": "claude-opus-4.6",
+        "name": "Claude Opus 4.6",
+        "reasoning": true
       },
       {
-        id: "claude-sonnet-4",
-        name: "Claude Sonnet 4",
-        reasoning: true,
+        "id": "claude-opus-4.7",
+        "name": "Claude Opus 4.7",
+        "reasoning": true
       },
       {
-        id: "claude-sonnet-4.5",
-        name: "Claude Sonnet 4.5",
-        reasoning: true,
+        "id": "claude-sonnet-4",
+        "name": "Claude Sonnet 4",
+        "reasoning": true
       },
       {
-        id: "claude-sonnet-4.6",
-        name: "Claude Sonnet 4.6",
-        reasoning: true,
+        "id": "claude-sonnet-4.5",
+        "name": "Claude Sonnet 4.5",
+        "reasoning": true
       },
       {
-        id: "gemini-3-flash-preview",
-        name: "Gemini 3 Flash",
-        reasoning: true,
+        "id": "claude-sonnet-4.6",
+        "name": "Claude Sonnet 4.6",
+        "reasoning": true
       },
       {
-        id: "gemini-3-pro-preview",
-        name: "Gemini 3 Pro Preview",
-        reasoning: true,
+        "id": "gemini-3-flash-preview",
+        "name": "Gemini 3 Flash",
+        "reasoning": true
       },
       {
-        id: "gemini-3.1-pro-preview",
-        name: "Gemini 3.1 Pro Preview",
-        reasoning: true,
+        "id": "gemini-3-pro-preview",
+        "name": "Gemini 3 Pro Preview",
+        "reasoning": true
       },
       {
-        id: "gpt-5",
-        name: "GPT-5",
-        reasoning: true,
+        "id": "gemini-3.1-pro-preview",
+        "name": "Gemini 3.1 Pro Preview",
+        "reasoning": true
       },
       {
-        id: "gpt-5-mini",
-        name: "GPT-5-mini",
-        reasoning: true,
+        "id": "gpt-5",
+        "name": "GPT-5",
+        "reasoning": true
       },
       {
-        id: "gpt-5.1",
-        name: "GPT-5.1",
-        reasoning: true,
+        "id": "gpt-5-mini",
+        "name": "GPT-5-mini",
+        "reasoning": true
       },
       {
-        id: "gpt-5.2",
-        name: "GPT-5.2",
-        reasoning: true,
+        "id": "gpt-5.1",
+        "name": "GPT-5.1",
+        "reasoning": true
       },
       {
-        id: "gpt-5.4",
-        name: "GPT-5.4",
-        reasoning: true,
+        "id": "gpt-5.2",
+        "name": "GPT-5.2",
+        "reasoning": true
       },
       {
-        id: "gpt-5.4-mini",
-        name: "GPT-5.4 Mini",
-        reasoning: true,
+        "id": "gpt-5.4",
+        "name": "GPT-5.4",
+        "reasoning": true
       },
       {
-        id: "grok-code-fast-1",
-        name: "Grok Code Fast 1",
-        reasoning: true,
+        "id": "gpt-5.4-mini",
+        "name": "GPT-5.4 Mini",
+        "reasoning": true
       },
-    ],
+      {
+        "id": "grok-code-fast-1",
+        "name": "Grok Code Fast 1",
+        "reasoning": true
+      }
+    ]
+  },
+  "kimi": {
+    "defaultModel": "kimi-k2.6",
+    "models": [
+      {
+        "id": "kimi-k2-0711-preview",
+        "name": "Kimi K2 0711",
+        "reasoning": false
+      },
+      {
+        "id": "kimi-k2-0905-preview",
+        "name": "Kimi K2 0905",
+        "reasoning": false
+      },
+      {
+        "id": "kimi-k2-turbo-preview",
+        "name": "Kimi K2 Turbo",
+        "reasoning": false
+      },
+      {
+        "id": "kimi-k2-thinking",
+        "name": "Kimi K2 Thinking",
+        "reasoning": true
+      },
+      {
+        "id": "kimi-k2-thinking-turbo",
+        "name": "Kimi K2 Thinking Turbo",
+        "reasoning": true
+      },
+      {
+        "id": "kimi-k2.5",
+        "name": "Kimi K2.5",
+        "reasoning": true
+      }
+    ]
   },
   "kimi-coding": {
-    defaultModel: "k2p6",
-    models: [
+    "defaultModel": "k2p6",
+    "models": [
       {
-        id: "k2p5",
-        name: "Kimi K2.5",
-        reasoning: true,
+        "id": "k2p5",
+        "name": "Kimi K2.5",
+        "reasoning": true
       },
       {
-        id: "k2p6",
-        name: "Kimi K2.6",
-        reasoning: true,
+        "id": "k2p6",
+        "name": "Kimi K2.6",
+        "reasoning": true
       },
       {
-        id: "kimi-k2-thinking",
-        name: "Kimi K2 Thinking",
-        reasoning: true,
-      },
-    ],
+        "id": "kimi-k2-thinking",
+        "name": "Kimi K2 Thinking",
+        "reasoning": true
+      }
+    ]
   },
-  zai: {
-    defaultModel: "glm-5.1",
-    models: [
+  "zai": {
+    "defaultModel": "glm-5.1",
+    "models": [
       {
-        id: "glm-4.5",
-        name: "GLM-4.5",
-        reasoning: true,
+        "id": "glm-4.5",
+        "name": "GLM-4.5",
+        "reasoning": true
       },
       {
-        id: "glm-4.5-air",
-        name: "GLM-4.5-Air",
-        reasoning: true,
+        "id": "glm-4.5-air",
+        "name": "GLM-4.5-Air",
+        "reasoning": true
       },
       {
-        id: "glm-4.5-flash",
-        name: "GLM-4.5-Flash",
-        reasoning: true,
+        "id": "glm-4.5-flash",
+        "name": "GLM-4.5-Flash",
+        "reasoning": true
       },
       {
-        id: "glm-4.5v",
-        name: "GLM-4.5V",
-        reasoning: true,
+        "id": "glm-4.5v",
+        "name": "GLM-4.5V",
+        "reasoning": true
       },
       {
-        id: "glm-4.6",
-        name: "GLM-4.6",
-        reasoning: true,
+        "id": "glm-4.6",
+        "name": "GLM-4.6",
+        "reasoning": true
       },
       {
-        id: "glm-4.6v",
-        name: "GLM-4.6V",
-        reasoning: true,
+        "id": "glm-4.6v",
+        "name": "GLM-4.6V",
+        "reasoning": true
       },
       {
-        id: "glm-4.7",
-        name: "GLM-4.7",
-        reasoning: true,
+        "id": "glm-4.7",
+        "name": "GLM-4.7",
+        "reasoning": true
       },
       {
-        id: "glm-4.7-flash",
-        name: "GLM-4.7-Flash",
-        reasoning: true,
+        "id": "glm-4.7-flash",
+        "name": "GLM-4.7-Flash",
+        "reasoning": true
       },
       {
-        id: "glm-4.7-flashx",
-        name: "GLM-4.7-FlashX",
-        reasoning: true,
+        "id": "glm-4.7-flashx",
+        "name": "GLM-4.7-FlashX",
+        "reasoning": true
       },
       {
-        id: "glm-5",
-        name: "GLM-5",
-        reasoning: true,
+        "id": "glm-5",
+        "name": "GLM-5",
+        "reasoning": true
       },
       {
-        id: "glm-5-turbo",
-        name: "GLM-5-Turbo",
-        reasoning: true,
+        "id": "glm-5-turbo",
+        "name": "GLM-5-Turbo",
+        "reasoning": true
       },
       {
-        id: "glm-5.1",
-        name: "GLM-5.1",
-        reasoning: true,
+        "id": "glm-5.1",
+        "name": "GLM-5.1",
+        "reasoning": true
       },
       {
-        id: "glm-5v-turbo",
-        name: "glm-5v-turbo",
-        reasoning: true,
-      },
-    ],
+        "id": "glm-5v-turbo",
+        "name": "glm-5v-turbo",
+        "reasoning": true
+      }
+    ]
   },
   "zai-coding": {
-    defaultModel: "glm-5.1",
-    models: [
+    "defaultModel": "glm-5.1",
+    "models": [
       {
-        id: "glm-4.5",
-        name: "GLM-4.5",
-        reasoning: true,
+        "id": "glm-4.5",
+        "name": "GLM-4.5",
+        "reasoning": true
       },
       {
-        id: "glm-4.5-air",
-        name: "GLM-4.5-Air",
-        reasoning: true,
+        "id": "glm-4.5-air",
+        "name": "GLM-4.5-Air",
+        "reasoning": true
       },
       {
-        id: "glm-4.5-flash",
-        name: "GLM-4.5-Flash",
-        reasoning: true,
+        "id": "glm-4.5-flash",
+        "name": "GLM-4.5-Flash",
+        "reasoning": true
       },
       {
-        id: "glm-4.5v",
-        name: "GLM-4.5V",
-        reasoning: true,
+        "id": "glm-4.5v",
+        "name": "GLM-4.5V",
+        "reasoning": true
       },
       {
-        id: "glm-4.6",
-        name: "GLM-4.6",
-        reasoning: true,
+        "id": "glm-4.6",
+        "name": "GLM-4.6",
+        "reasoning": true
       },
       {
-        id: "glm-4.6v",
-        name: "GLM-4.6V",
-        reasoning: true,
+        "id": "glm-4.6v",
+        "name": "GLM-4.6V",
+        "reasoning": true
       },
       {
-        id: "glm-4.7",
-        name: "GLM-4.7",
-        reasoning: true,
+        "id": "glm-4.7",
+        "name": "GLM-4.7",
+        "reasoning": true
       },
       {
-        id: "glm-4.7-flash",
-        name: "GLM-4.7-Flash",
-        reasoning: true,
+        "id": "glm-4.7-flash",
+        "name": "GLM-4.7-Flash",
+        "reasoning": true
       },
       {
-        id: "glm-4.7-flashx",
-        name: "GLM-4.7-FlashX",
-        reasoning: true,
+        "id": "glm-4.7-flashx",
+        "name": "GLM-4.7-FlashX",
+        "reasoning": true
       },
       {
-        id: "glm-5",
-        name: "GLM-5",
-        reasoning: true,
+        "id": "glm-5",
+        "name": "GLM-5",
+        "reasoning": true
       },
       {
-        id: "glm-5-turbo",
-        name: "GLM-5-Turbo",
-        reasoning: true,
+        "id": "glm-5-turbo",
+        "name": "GLM-5-Turbo",
+        "reasoning": true
       },
       {
-        id: "glm-5.1",
-        name: "GLM-5.1",
-        reasoning: true,
+        "id": "glm-5.1",
+        "name": "GLM-5.1",
+        "reasoning": true
       },
       {
-        id: "glm-5v-turbo",
-        name: "glm-5v-turbo",
-        reasoning: true,
-      },
-    ],
-  },
+        "id": "glm-5v-turbo",
+        "name": "glm-5v-turbo",
+        "reasoning": true
+      }
+    ]
+  }
 } as const;

--- a/src/shared/models.generated.ts
+++ b/src/shared/models.generated.ts
@@ -490,11 +490,16 @@ export const GENERATED_MODELS: Record<string, ProviderModels> = {
     ],
   },
   "kimi-coding": {
-    defaultModel: "k2p5",
+    defaultModel: "k2p6",
     models: [
       {
         id: "k2p5",
         name: "Kimi K2.5",
+        reasoning: true,
+      },
+      {
+        id: "k2p6",
+        name: "Kimi K2.6",
         reasoning: true,
       },
       {

--- a/src/store/__tests__/index.test.ts
+++ b/src/store/__tests__/index.test.ts
@@ -325,6 +325,20 @@ describe("AppStore", () => {
       expect(s.maxTokens).toBe(DEFAULT_MAX_TOKENS);
     });
 
+    it("未設定の kimi / kimi-coding に切り替えたときは K2.6 系の既定値にフォールバックする", () => {
+      useStore.getState().setSettings({
+        model: "claude-opus-4-1",
+        reasoningLevel: "high",
+        maxTokens: 32768,
+      });
+
+      useStore.getState().setSettings({ provider: "kimi" });
+      expect(useStore.getState().settings.model).toBe("kimi-k2.6");
+
+      useStore.getState().setSettings({ provider: "kimi-coding" });
+      expect(useStore.getState().settings.model).toBe("k2p6");
+    });
+
     it("空文字 model を保存した provider へ戻っても default model を使う", () => {
       useStore.getState().setSettings({ provider: "openai", model: "gpt-4.1" });
       useStore.getState().setSettings({ provider: "anthropic" });


### PR DESCRIPTION
## Summary
- add `kimi-k2.6` as the default/fallback model for the `kimi` provider
- add `k2p6` as the default/generated model for the `kimi-coding` provider
- add regression tests for provider switching and persisted-settings fallback behavior

## Notes
- `kimi-k2.6` was confirmed from Kimi's official docs
- `k2p6` is reflected based on the project's source of truth for `kimi-coding` (`models.dev/api.json`)

## Testing
- pnpm exec vitest run src/shared/__tests__/constants.test.ts src/store/__tests__/index.test.ts src/features/settings/__tests__/persistence.test.ts
