### PR TITLE
perf(chat): ストリーミング中の全件再レンダーを解消

### DIFF
--- a/src/features/chat/ChatArea.tsx
+++ b/src/features/chat/ChatArea.tsx
@@ -126,9 +126,17 @@ export function ChatArea({ onSend }: { onSend?: (text: string) => void }) {
         }}
       >
         <Stack gap="xs" p="sm">
-          {messages.map((msg, i) => (
-            <MessageBubble key={msg.id} msg={msg} isLast={i === messages.length - 1} />
-          ))}
+          {messages.map((msg, i) => {
+            const isLast = i === messages.length - 1;
+            return (
+              <MessageBubble
+                key={msg.id}
+                msg={msg}
+                isLast={isLast}
+                isStreaming={isLast ? isStreaming : undefined}
+              />
+            );
+          })}
           {isStreaming && <StreamingIndicator />}
         </Stack>
       </div>

--- a/src/features/chat/ChatBubble.tsx
+++ b/src/features/chat/ChatBubble.tsx
@@ -14,7 +14,6 @@ import { useDisclosure } from "@mantine/hooks";
 import { motion } from "framer-motion";
 import { Bot, Brain, Check, ChevronDown, ChevronRight, Copy, Wrench, User } from "lucide-react";
 import type { ChatMessage, ToolCallInfo } from "@/ports/session-types";
-import { useStore } from "@/store/index";
 import { messageStyles, type StyledRole } from "./theme";
 import { MarkdownContent } from "@/shared/ui/MarkdownContent";
 import { ToolCallBlock } from "./ToolCallBlock";
@@ -108,12 +107,19 @@ function ToolCallGroup({ toolCalls }: { toolCalls: ToolCallInfo[] }) {
   );
 }
 
-export function ChatBubble({ msg, isLast }: { msg: ChatMessage; isLast?: boolean }) {
+export function ChatBubble({
+  msg,
+  isLast,
+  isStreaming,
+}: {
+  msg: ChatMessage;
+  isLast?: boolean;
+  isStreaming?: boolean;
+}) {
   const role = msg.role as StyledRole;
   const config = roleConfig[role as keyof typeof roleConfig];
   const style = messageStyles[role];
   const Icon = config.icon;
-  const isStreaming = useStore((s) => s.isStreaming);
   const isAssistant = role === "assistant";
 
   return (
@@ -157,7 +163,7 @@ export function ChatBubble({ msg, isLast }: { msg: ChatMessage; isLast?: boolean
         {msg.reasoning && (
           <ReasoningBlock
             text={msg.reasoning}
-            isThinking={isLast === true && isStreaming && !msg.content}
+            isThinking={isLast === true && isStreaming === true && !msg.content}
           />
         )}
 

--- a/src/features/chat/MessageBubble.tsx
+++ b/src/features/chat/MessageBubble.tsx
@@ -1,10 +1,19 @@
+import { memo } from "react";
 import type { ChatMessage } from "@/ports/session-types";
 import { ChatBubble } from "./ChatBubble";
 import { ErrorMessage } from "./ErrorMessage";
 import { NavigationBubble } from "./NavigationBubble";
 import { SystemMessage } from "./SystemMessage";
 
-export function MessageBubble({ msg, isLast }: { msg: ChatMessage; isLast?: boolean }) {
+export const MessageBubble = memo(function MessageBubble({
+  msg,
+  isLast,
+  isStreaming,
+}: {
+  msg: ChatMessage;
+  isLast?: boolean;
+  isStreaming?: boolean;
+}) {
   switch (msg.role) {
     case "navigation":
       return <NavigationBubble msg={msg} />;
@@ -13,6 +22,6 @@ export function MessageBubble({ msg, isLast }: { msg: ChatMessage; isLast?: bool
     case "error":
       return <ErrorMessage msg={msg} />;
     default:
-      return <ChatBubble msg={msg} isLast={isLast} />;
+      return <ChatBubble msg={msg} isLast={isLast} isStreaming={isStreaming} />;
   }
-}
+});

--- a/src/features/chat/chat-store.ts
+++ b/src/features/chat/chat-store.ts
@@ -43,6 +43,10 @@ export interface ChatSlice {
   resetShownSkillIds(): void;
 }
 
+// Invariant: mutating actions must only replace the reference of the message(s)
+// they actually change. Non-target messages must keep the same object reference
+// so React.memo on MessageBubble / MarkdownContent can skip re-renders during
+// streaming. `s.messages.map(m => ({ ...m }))` is forbidden.
 function findLastAssistantIndex(messages: ChatMessage[]): number {
   for (let i = messages.length - 1; i >= 0; i--) {
     if (messages[i].role === "assistant") return i;
@@ -167,30 +171,32 @@ export const createChatSlice: StateCreator<AppStore, [], [], ChatSlice> = (set, 
     }),
 
   appendToolInputDelta: (id, delta) =>
-    set((s) => ({
-      messages: s.messages.map((m) =>
-        m.toolCalls
-          ? {
-              ...m,
-              toolCalls: m.toolCalls.map((tc) =>
-                tc.id === id ? { ...tc, inputDelta: (tc.inputDelta ?? "") + delta } : tc,
-              ),
-            }
-          : m,
-      ),
-    })),
+    set((s) => {
+      const idx = findLastAssistantIndex(s.messages);
+      if (idx < 0) return s;
+      const target = s.messages[idx];
+      if (!target.toolCalls) return s;
+      const nextToolCalls = target.toolCalls.map((tc) =>
+        tc.id === id ? { ...tc, inputDelta: (tc.inputDelta ?? "") + delta } : tc,
+      );
+      if (nextToolCalls === target.toolCalls) return s;
+      const msgs = [...s.messages];
+      msgs[idx] = { ...target, toolCalls: nextToolCalls };
+      return { messages: msgs };
+    }),
 
   updateToolCallArgs: (id, args) =>
-    set((s) => ({
-      messages: s.messages.map((m) =>
-        m.toolCalls
-          ? {
-              ...m,
-              toolCalls: m.toolCalls.map((tc) => (tc.id === id ? { ...tc, args } : tc)),
-            }
-          : m,
-      ),
-    })),
+    set((s) => {
+      const idx = findLastAssistantIndex(s.messages);
+      if (idx < 0) return s;
+      const target = s.messages[idx];
+      if (!target.toolCalls) return s;
+      const nextToolCalls = target.toolCalls.map((tc) => (tc.id === id ? { ...tc, args } : tc));
+      if (nextToolCalls === target.toolCalls) return s;
+      const msgs = [...s.messages];
+      msgs[idx] = { ...target, toolCalls: nextToolCalls };
+      return { messages: msgs };
+    }),
 
   updateToolCallResult: (
     toolIdOrMsgId: string,
@@ -201,42 +207,43 @@ export const createChatSlice: StateCreator<AppStore, [], [], ChatSlice> = (set, 
     if (typeof resultOrToolId === "string") {
       const msgId = toolIdOrMsgId;
       const toolId = resultOrToolId;
-      set((s) => ({
-        messages: s.messages.map((m) => {
-          if (m.id !== msgId) return m;
-          return {
-            ...m,
-            toolCalls: m.toolCalls?.map((tc) =>
-              tc.id === toolId
-                ? { ...tc, result: resultStr, success, isRunning: false, inputDelta: undefined }
-                : tc,
-            ),
-          };
-        }),
-      }));
+      set((s) => {
+        const idx = s.messages.findIndex((m) => m.id === msgId);
+        if (idx < 0) return s;
+        const target = s.messages[idx];
+        if (!target.toolCalls) return s;
+        const nextToolCalls = target.toolCalls.map((tc) =>
+          tc.id === toolId
+            ? { ...tc, result: resultStr, success, isRunning: false, inputDelta: undefined }
+            : tc,
+        );
+        const msgs = [...s.messages];
+        msgs[idx] = { ...target, toolCalls: nextToolCalls };
+        return { messages: msgs };
+      });
     } else {
       const toolId = toolIdOrMsgId;
       const result = resultOrToolId;
-      set((s) => ({
-        messages: s.messages.map((m) =>
-          m.toolCalls
+      set((s) => {
+        const idx = findLastAssistantIndex(s.messages);
+        if (idx < 0) return s;
+        const target = s.messages[idx];
+        if (!target.toolCalls) return s;
+        const nextToolCalls = target.toolCalls.map((tc) =>
+          tc.id === toolId
             ? {
-                ...m,
-                toolCalls: m.toolCalls.map((tc) =>
-                  tc.id === toolId
-                    ? {
-                        ...tc,
-                        result: result.ok ? JSON.stringify(result.value) : result.error.message,
-                        success: result.ok,
-                        isRunning: false,
-                        inputDelta: undefined,
-                      }
-                    : tc,
-                ),
+                ...tc,
+                result: result.ok ? JSON.stringify(result.value) : result.error.message,
+                success: result.ok,
+                isRunning: false,
+                inputDelta: undefined,
               }
-            : m,
-        ),
-      }));
+            : tc,
+        );
+        const msgs = [...s.messages];
+        msgs[idx] = { ...target, toolCalls: nextToolCalls };
+        return { messages: msgs };
+      });
     }
   },
 

--- a/src/shared/ui/MarkdownContent.tsx
+++ b/src/shared/ui/MarkdownContent.tsx
@@ -1,3 +1,4 @@
+import { memo, useMemo } from "react";
 import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import {
@@ -23,9 +24,13 @@ function CodeBlock({ lang, children }: { lang: string; children: string }) {
   const headerBg = isDark ? "var(--mantine-color-dark-5)" : "var(--mantine-color-gray-3)";
   const bodyBg = isDark ? "var(--mantine-color-dark-6)" : "var(--mantine-color-gray-2)";
 
-  const highlighted = hljs.getLanguage(lang)
-    ? hljs.highlight(children, { language: lang, ignoreIllegals: true }).value
-    : null;
+  const highlighted = useMemo(
+    () =>
+      hljs.getLanguage(lang)
+        ? hljs.highlight(children, { language: lang, ignoreIllegals: true }).value
+        : null,
+    [lang, children],
+  );
 
   return (
     <Box
@@ -253,7 +258,7 @@ const components = {
   ),
 };
 
-export function MarkdownContent({ content }: { content: string }) {
+export const MarkdownContent = memo(function MarkdownContent({ content }: { content: string }) {
   return (
     <Box className="markdown-content">
       <Markdown remarkPlugins={[remarkGfm]} components={components}>
@@ -261,4 +266,4 @@ export function MarkdownContent({ content }: { content: string }) {
       </Markdown>
     </Box>
   );
-}
+});

--- a/src/store/__tests__/index.test.ts
+++ b/src/store/__tests__/index.test.ts
@@ -144,6 +144,106 @@ describe("AppStore", () => {
       expect(tc.result).toBe("Timed out");
     });
 
+    describe("参照保存の不変条件 (React.memo 最適化の前提)", () => {
+      it("appendDelta は末尾以外のメッセージ参照を維持する", () => {
+        useStore.getState().addUserMessage("first");
+        useStore.getState().startNewAssistantMessage();
+        const beforeMsgs = useStore.getState().messages;
+        const firstRef = beforeMsgs[0];
+
+        useStore.getState().appendDelta("hello");
+
+        const afterMsgs = useStore.getState().messages;
+        expect(afterMsgs[0]).toBe(firstRef);
+        expect(afterMsgs[1]).not.toBe(beforeMsgs[1]);
+      });
+
+      it("appendReasoning は末尾以外のメッセージ参照を維持する", () => {
+        useStore.getState().addUserMessage("first");
+        useStore.getState().startNewAssistantMessage();
+        const firstRef = useStore.getState().messages[0];
+
+        useStore.getState().appendReasoning("thinking...");
+
+        expect(useStore.getState().messages[0]).toBe(firstRef);
+      });
+
+      it("appendToolInputDelta は末尾以外のメッセージ参照を維持する", () => {
+        useStore.getState().startNewAssistantMessage();
+        useStore.getState().appendDelta("reply 1");
+        useStore.getState().addUserMessage("next");
+        useStore.getState().startNewAssistantMessage();
+        useStore.getState().addToolCall({
+          id: "tc1",
+          name: "test",
+          args: {},
+          isRunning: true,
+        });
+        const before = useStore.getState().messages;
+        const firstAssistantRef = before[0];
+        const userRef = before[1];
+
+        useStore.getState().appendToolInputDelta("tc1", '{"a":');
+
+        const after = useStore.getState().messages;
+        expect(after[0]).toBe(firstAssistantRef);
+        expect(after[1]).toBe(userRef);
+        expect(after[2]).not.toBe(before[2]);
+      });
+
+      it("updateToolCallArgs は末尾以外のメッセージ参照を維持する", () => {
+        useStore.getState().startNewAssistantMessage();
+        useStore.getState().addToolCall({
+          id: "old",
+          name: "prev",
+          args: {},
+          isRunning: false,
+        });
+        useStore.getState().addUserMessage("next");
+        useStore.getState().startNewAssistantMessage();
+        useStore.getState().addToolCall({
+          id: "tc1",
+          name: "curr",
+          args: {},
+          isRunning: true,
+        });
+        const before = useStore.getState().messages;
+
+        useStore.getState().updateToolCallArgs("tc1", { foo: "bar" });
+
+        const after = useStore.getState().messages;
+        expect(after[0]).toBe(before[0]);
+        expect(after[1]).toBe(before[1]);
+        expect(after[2]).not.toBe(before[2]);
+      });
+
+      it("updateToolCallResult は末尾以外のメッセージ参照を維持する", () => {
+        useStore.getState().startNewAssistantMessage();
+        useStore.getState().addToolCall({
+          id: "old",
+          name: "prev",
+          args: {},
+          isRunning: false,
+        });
+        useStore.getState().addUserMessage("next");
+        useStore.getState().startNewAssistantMessage();
+        useStore.getState().addToolCall({
+          id: "tc1",
+          name: "curr",
+          args: {},
+          isRunning: true,
+        });
+        const before = useStore.getState().messages;
+
+        useStore.getState().updateToolCallResult("tc1", ok("done"));
+
+        const after = useStore.getState().messages;
+        expect(after[0]).toBe(before[0]);
+        expect(after[1]).toBe(before[1]);
+        expect(after[2]).not.toBe(before[2]);
+      });
+    });
+
     it("addSystemMessage でシステムメッセージを追加する", () => {
       useStore.getState().addSystemMessage("system info");
       const msg = useStore.getState().messages[0];


### PR DESCRIPTION
## Summary

長い会話でAIが思考中(ストリーミング中)にチャットUIが重くなる問題を修正。

- `appendDelta` や tool 系 action が呼ばれるたびに `messages` 配列が再生成され、全 `MessageBubble` が再レンダー → 全 `MarkdownContent` (react-markdown + remark-gfm) の再パースと `hljs.highlight` の再ハイライトが線形に発生していた
- React.memo 化と store 側の局所更新化により、ストリーミング中に再レンダーされるのは**末尾 1 バブル + その MarkdownContent** のみになる

## Changes

- `MessageBubble` / `MarkdownContent` を `React.memo` で囲む
- `CodeBlock` 内の `hljs.highlight` を `useMemo` でキャッシュ
- `ChatBubble` の `useStore((s) => s.isStreaming)` を撤去し、末尾メッセージのみ props で `isStreaming` を受け取る形に変更
- `chat-store.ts` の `appendToolInputDelta` / `updateToolCallArgs` / `updateToolCallResult` を `s.messages.map(...)` から末尾局所更新に書き換え、非対象メッセージの参照を維持
- 「非対象メッセージの参照は変えない」不変条件を store のコメントとして明記
- 参照保存を担保するリグレッションテストを 5 件追加 (`src/store/__tests__/index.test.ts`)

## Test plan

- [x] `npx vitest run` → 全 1085 テスト pass (新規 5 件含む)
- [x] `npx tsc --noEmit` → エラーなし
- [x] `npx vp lint` 対象ファイル → warnings 0 / errors 0
- [ ] 実機確認: 長い会話(メッセージ 20+ 件)で AI ストリーミング中に UI がカクつかないこと
- [ ] 実機確認: コードブロック/テーブル/ツール呼び出しを含むメッセージで表示崩れが無いこと
- [ ] 実機確認: ストリーミング完了後、コピー/思考展開/ツールグループ展開が正常に動くこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)