### PR TITLE
feat(skill): add instruction layer to skill types, parser, and renderer

### DIFF
--- a/src/features/tools/skills/__tests__/skill-parser.test.ts
+++ b/src/features/tools/skills/__tests__/skill-parser.test.ts
@@ -474,4 +474,163 @@ paths:
       expect(result.errors).toContain("Missing or empty 'hosts' array in frontmatter");
     });
   });
+
+  describe("instruction layer", () => {
+    it("# Instructions だけの skill を instructionsMarkdown 付きでパースできる", () => {
+      const markdown = `---
+id: github-guidance
+name: GitHub Guidance
+scope: global
+version: 0.1.0
+---
+
+# Instructions
+
+GitHub では task に応じて API / DOM のどれが最適かを先に判断すること。
+`;
+      const result = parseSkillMarkdown(markdown);
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      expect(result.skill.extractors).toHaveLength(0);
+      expect(result.skill.instructionsMarkdown).toContain("GitHub では task に応じて");
+      expect(result.skill.instructionsMarkdown?.endsWith("\n")).toBe(false);
+    });
+
+    it("# Instructions と # Extractors が両方ある skill をパースできる", () => {
+      const markdown = `---
+id: github-repo-analyzer
+name: GitHub Repo Analyzer
+scope: global
+version: 0.2.0
+---
+
+# Instructions
+
+## Always
+GitHub pages may have CSP limitations.
+
+## Task: Repository Analysis
+repo 全体の分析では DOM extractor を万能手段として扱わない。
+
+# Extractors
+
+## Get Visible File List
+<!-- extractor-id: getVisibleFileList -->
+<!-- output-schema: { files: string[] } -->
+現在表示中のファイル一覧だけを取得する。
+
+\`\`\`js
+function () {
+  return { files: [] };
+}
+\`\`\`
+`;
+      const result = parseSkillMarkdown(markdown);
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      expect(result.skill.extractors).toHaveLength(1);
+      expect(result.skill.extractors[0].id).toBe("getVisibleFileList");
+      expect(result.skill.instructionsMarkdown).toContain("GitHub pages may have CSP limitations.");
+      expect(result.skill.instructionsMarkdown).toContain("repo 全体の分析では");
+      // Instructions セクションに Extractors 見出しの中身が混入していないこと
+      expect(result.skill.instructionsMarkdown).not.toContain("getVisibleFileList");
+    });
+
+    it("旧形式 (section marker なし) の skill には instructionsMarkdown が付かない", () => {
+      const markdown = `---
+id: youtube
+name: YouTube
+hosts:
+  - youtube.com
+---
+
+## videoInfo
+
+タイトルを取得する。
+
+\`\`\`js
+return { title: document.title };
+\`\`\`
+`;
+      const result = parseSkillMarkdown(markdown);
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      expect(result.skill.instructionsMarkdown).toBeUndefined();
+      expect(result.skill.extractors).toHaveLength(1);
+    });
+
+    it("instruction も extractor も空ならエラー", () => {
+      const markdown = `---
+id: empty-skill
+name: Empty Skill
+scope: global
+---
+
+# Instructions
+
+# Extractors
+`;
+      const result = parseSkillMarkdown(markdown);
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+
+      expect(result.errors.join(" ")).toMatch(/either an '# Instructions'/);
+    });
+
+    it("コードブロック内の # Instructions は section marker として扱わない", () => {
+      const markdown = `---
+id: yt
+name: YT
+hosts:
+  - youtube.com
+---
+
+## sample
+
+\`\`\`js
+// # Instructions should not be a section here
+return document.title;
+\`\`\`
+`;
+      const result = parseSkillMarkdown(markdown);
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      expect(result.skill.extractors).toHaveLength(1);
+      expect(result.skill.instructionsMarkdown).toBeUndefined();
+    });
+
+    it("## Instructions は section marker として扱わない (top-level のみ認識)", () => {
+      const markdown = `---
+id: yt
+name: YT
+hosts:
+  - youtube.com
+---
+
+## Instructions
+
+\`\`\`js
+return { note: "this heading should be treated as an extractor heading" };
+\`\`\`
+`;
+      const result = parseSkillMarkdown(markdown);
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      // '## Instructions' は top-level section marker ではなく extractor heading として扱われる
+      expect(result.skill.extractors).toHaveLength(1);
+      expect(result.skill.extractors[0].id).toBe("instructions");
+      expect(result.skill.instructionsMarkdown).toBeUndefined();
+    });
+  });
 });

--- a/src/shared/__tests__/skill-markdown.test.ts
+++ b/src/shared/__tests__/skill-markdown.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from "vitest";
+import { renderSkillMarkdown } from "../skill-markdown";
+import { parseSkillMarkdown } from "../skill-parser";
+import type { Skill } from "../skill-types";
+
+function roundTrip(skill: Skill): Skill {
+  const markdown = renderSkillMarkdown(skill);
+  const parsed = parseSkillMarkdown(markdown);
+  if (!parsed.ok) {
+    throw new Error(`Failed to re-parse rendered markdown: ${parsed.errors.join("; ")}`);
+  }
+  return parsed.skill;
+}
+
+const extractorsOnlySkill: Skill = {
+  id: "youtube",
+  name: "YouTube",
+  description: "YouTube動画ページの情報抽出",
+  scope: "site",
+  matchers: { hosts: ["youtube.com"], paths: ["/watch"] },
+  extractors: [
+    {
+      id: "videoInfo",
+      name: "videoInfo",
+      description: "タイトルを取得する。",
+      outputSchema: "{ title: string }",
+      code: "function () {\n  return { title: document.title };\n}",
+    },
+  ],
+  version: "0.1.0",
+};
+
+const instructionsOnlySkill: Skill = {
+  id: "github-guidance",
+  name: "GitHub Guidance",
+  description: "GitHub に関する軽い guidance",
+  scope: "global",
+  matchers: { hosts: [] },
+  extractors: [],
+  version: "0.1.0",
+  instructionsMarkdown:
+    "GitHub では task に応じて API / DOM のどれが最適かを先に判断すること。\n\n## Always\nrepo 分析でない限り過剰適用しない。",
+};
+
+const mixedSkill: Skill = {
+  id: "github-repo-analyzer",
+  name: "GitHub Repo Analyzer",
+  description: "GitHub リポジトリ分析支援",
+  scope: "global",
+  matchers: { hosts: [] },
+  extractors: [
+    {
+      id: "getVisibleFileList",
+      name: "Get Visible File List",
+      description: "現在表示中のファイル一覧だけを取得する。",
+      outputSchema: "{ files: string[] }",
+      code: "function () {\n  return { files: [] };\n}",
+    },
+  ],
+  version: "0.2.0",
+  instructionsMarkdown:
+    "## Always\nGitHub pages may have CSP limitations.\n\n## Task: Repository Analysis\nrepo 全体の分析では DOM extractor を万能手段として扱わない。",
+};
+
+describe("renderSkillMarkdown", () => {
+  it("extractors-only skill は旧形式互換 (# Instructions / # Extractors 見出しを出さない)", () => {
+    const markdown = renderSkillMarkdown(extractorsOnlySkill);
+    expect(markdown).not.toMatch(/^# Instructions$/m);
+    expect(markdown).not.toMatch(/^# Extractors$/m);
+    expect(markdown).toContain("## videoInfo");
+  });
+
+  it("instructions-only skill は # Instructions セクションを出し、# Extractors を出さない", () => {
+    const markdown = renderSkillMarkdown(instructionsOnlySkill);
+    expect(markdown).toMatch(/^# Instructions$/m);
+    expect(markdown).not.toMatch(/^# Extractors$/m);
+    expect(markdown).toContain("GitHub では task に応じて");
+  });
+
+  it("mixed skill は # Instructions を # Extractors より先に出す", () => {
+    const markdown = renderSkillMarkdown(mixedSkill);
+    const instructionsAt = markdown.indexOf("# Instructions");
+    const extractorsAt = markdown.indexOf("# Extractors");
+    expect(instructionsAt).toBeGreaterThanOrEqual(0);
+    expect(extractorsAt).toBeGreaterThan(instructionsAt);
+  });
+});
+
+describe("skill markdown round-trip", () => {
+  it("extractors-only skill を round-trip できる", () => {
+    const restored = roundTrip(extractorsOnlySkill);
+    expect(restored.id).toBe(extractorsOnlySkill.id);
+    expect(restored.extractors).toHaveLength(1);
+    expect(restored.extractors[0].id).toBe("videoInfo");
+    expect(restored.extractors[0].code).toBe(extractorsOnlySkill.extractors[0].code);
+    expect(restored.instructionsMarkdown).toBeUndefined();
+  });
+
+  it("instructions-only skill を round-trip できる", () => {
+    const restored = roundTrip(instructionsOnlySkill);
+    expect(restored.id).toBe(instructionsOnlySkill.id);
+    expect(restored.extractors).toHaveLength(0);
+    expect(restored.instructionsMarkdown?.trim()).toBe(
+      instructionsOnlySkill.instructionsMarkdown?.trim(),
+    );
+  });
+
+  it("mixed skill を round-trip できる (instructions と extractors の両方が保存される)", () => {
+    const restored = roundTrip(mixedSkill);
+    expect(restored.extractors).toHaveLength(1);
+    expect(restored.extractors[0].id).toBe("getVisibleFileList");
+    expect(restored.extractors[0].outputSchema).toBe("{ files: string[] }");
+    expect(restored.instructionsMarkdown).toContain("GitHub pages may have CSP limitations.");
+    expect(restored.instructionsMarkdown).toContain("repo 全体の分析では");
+  });
+
+  it("旧形式の markdown (section marker なし) は現行 renderer で extractors-only として round-trip できる", () => {
+    const legacyMarkdown = `---
+id: youtube
+name: YouTube
+description: YouTube動画ページの情報抽出
+hosts:
+  - youtube.com
+paths:
+  - /watch
+version: 0.1.0
+---
+
+## videoInfo
+<!-- extractor-id: videoInfo -->
+<!-- output-schema: { title: string } -->
+タイトルを取得する。
+\`\`\`js
+function () {
+  return { title: document.title };
+}
+\`\`\`
+`;
+    const parsed = parseSkillMarkdown(legacyMarkdown);
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) return;
+
+    const rendered = renderSkillMarkdown(parsed.skill);
+    expect(rendered).not.toMatch(/^# Instructions$/m);
+    expect(rendered).not.toMatch(/^# Extractors$/m);
+
+    const restored = parseSkillMarkdown(rendered);
+    expect(restored.ok).toBe(true);
+    if (!restored.ok) return;
+    expect(restored.skill.extractors).toHaveLength(1);
+    expect(restored.skill.extractors[0].id).toBe("videoInfo");
+    expect(restored.skill.instructionsMarkdown).toBeUndefined();
+  });
+});

--- a/src/shared/skill-markdown.ts
+++ b/src/shared/skill-markdown.ts
@@ -45,7 +45,11 @@ export function renderSkillMarkdown(skill: Skill): string {
 
   frontmatter.push(`version: ${skill.version}`, "---", "");
 
-  const sections = skill.extractors.flatMap((extractor) => [
+  const instructionsMarkdown = skill.instructionsMarkdown?.trim() ?? "";
+  const hasInstructions = instructionsMarkdown.length > 0;
+  const hasExtractors = skill.extractors.length > 0;
+
+  const extractorLines = skill.extractors.flatMap((extractor) => [
     `## ${extractor.name}`,
     `<!-- extractor-id: ${extractor.id} -->`,
     `<!-- output-schema: ${extractor.outputSchema} -->`,
@@ -56,5 +60,16 @@ export function renderSkillMarkdown(skill: Skill): string {
     "",
   ]);
 
-  return [...frontmatter, ...sections].join("\n").trimEnd();
+  const bodyLines: string[] = [];
+
+  if (hasInstructions) {
+    bodyLines.push("# Instructions", "", instructionsMarkdown, "");
+    if (hasExtractors) {
+      bodyLines.push("# Extractors", "");
+    }
+  }
+
+  bodyLines.push(...extractorLines);
+
+  return [...frontmatter, ...bodyLines].join("\n").trimEnd();
 }

--- a/src/shared/skill-parser.ts
+++ b/src/shared/skill-parser.ts
@@ -1,5 +1,8 @@
 import type { Skill, SkillParseResult } from "./skill-types";
 
+const INSTRUCTIONS_HEADING = /^#\s+Instructions\s*$/;
+const EXTRACTORS_HEADING = /^#\s+Extractors\s*$/;
+
 interface ParsedFrontmatter {
   version?: string;
   scope?: string;
@@ -37,10 +40,23 @@ export function parseSkillMarkdown(markdown: string): SkillParseResult {
     return { ok: false, errors };
   }
 
-  const extractors = extractExtractors(body);
+  const { instructionsBody, extractorsBody, hasInstructionsSection, hasExtractorsSection } =
+    splitInstructionsAndExtractors(body);
 
-  if (extractors.length === 0) {
-    errors.push("At least one extractor (## heading + ```js code block) is required");
+  const extractors = extractExtractors(extractorsBody);
+  const instructionsMarkdown = hasInstructionsSection ? instructionsBody.trim() : "";
+
+  const hasInstructions = instructionsMarkdown.length > 0;
+  const hasAnySectionMarker = hasInstructionsSection || hasExtractorsSection;
+
+  if (!hasAnySectionMarker) {
+    if (extractors.length === 0) {
+      errors.push("At least one extractor (## heading + ```js code block) is required");
+    }
+  } else if (!hasInstructions && extractors.length === 0) {
+    errors.push(
+      "Skill must contain either an '# Instructions' section with content or at least one extractor under '# Extractors'",
+    );
   }
 
   for (const ext of extractors) {
@@ -73,7 +89,86 @@ export function parseSkillMarkdown(markdown: string): SkillParseResult {
     })),
   };
 
+  if (hasInstructions) {
+    skill.instructionsMarkdown = instructionsMarkdown;
+  }
+
   return { ok: true, skill };
+}
+
+interface SplitBody {
+  instructionsBody: string;
+  extractorsBody: string;
+  hasInstructionsSection: boolean;
+  hasExtractorsSection: boolean;
+}
+
+/**
+ * 本文を `# Instructions` / `# Extractors` で分割する。
+ * いずれも存在しない場合、本文全体を extractorsBody として返し (旧形式 fallback)、
+ * 両フラグは false になる。コードブロック内の `#` 行は section marker とみなさない。
+ */
+function splitInstructionsAndExtractors(body: string): SplitBody {
+  const lines = body.split("\n");
+  let instructionsIndex = -1;
+  let extractorsIndex = -1;
+  let inCodeBlock = false;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (/^\s*```/.test(line)) {
+      inCodeBlock = !inCodeBlock;
+      continue;
+    }
+    if (inCodeBlock) continue;
+
+    if (instructionsIndex === -1 && INSTRUCTIONS_HEADING.test(line)) {
+      instructionsIndex = i;
+      continue;
+    }
+    if (extractorsIndex === -1 && EXTRACTORS_HEADING.test(line)) {
+      extractorsIndex = i;
+    }
+  }
+
+  const hasInstructionsSection = instructionsIndex !== -1;
+  const hasExtractorsSection = extractorsIndex !== -1;
+
+  if (!hasInstructionsSection && !hasExtractorsSection) {
+    return {
+      instructionsBody: "",
+      extractorsBody: body,
+      hasInstructionsSection: false,
+      hasExtractorsSection: false,
+    };
+  }
+
+  const sliceLines = (start: number, end: number): string =>
+    lines.slice(start, end === -1 ? lines.length : end).join("\n");
+
+  let instructionsBody = "";
+  let extractorsBody = "";
+
+  if (hasInstructionsSection && hasExtractorsSection) {
+    if (instructionsIndex < extractorsIndex) {
+      instructionsBody = sliceLines(instructionsIndex + 1, extractorsIndex);
+      extractorsBody = sliceLines(extractorsIndex + 1, -1);
+    } else {
+      extractorsBody = sliceLines(extractorsIndex + 1, instructionsIndex);
+      instructionsBody = sliceLines(instructionsIndex + 1, -1);
+    }
+  } else if (hasInstructionsSection) {
+    instructionsBody = sliceLines(instructionsIndex + 1, -1);
+  } else {
+    extractorsBody = sliceLines(extractorsIndex + 1, -1);
+  }
+
+  return {
+    instructionsBody,
+    extractorsBody,
+    hasInstructionsSection,
+    hasExtractorsSection,
+  };
 }
 
 function extractFrontmatter(

--- a/src/shared/skill-types.ts
+++ b/src/shared/skill-types.ts
@@ -9,6 +9,7 @@ export interface Skill {
   version: string;
   scope?: SkillScope;
   metadata?: SkillMetadata;
+  instructionsMarkdown?: string;
 }
 
 export interface SkillMetadata {


### PR DESCRIPTION
Closes #159

## Summary
- `Skill` に `instructionsMarkdown?` を追加し、instruction layer の最小表現を導入
- parser が top-level `# Instructions` / `# Extractors` を section marker として認識。どちらも無い場合は旧形式 fallback
- renderer が instructions-only / extractors-only / mixed の 3 形態を round-trip 可能に
- extractors-only skill の markdown 出力は従来と bit-identical (built-in の再保存で差分なし)

## Scope out / follow-up
- **Runtime / validation は本 PR では変更しない**。`validateSkillDefinition` は引き続き extractors 必須のため、instruction-only skill は parse 成功するが loader で reject される (設計通り、Issue 2 で解放予定)
- レビューで判明した残課題 (順序逆転時の正規化、instruction 本文に top-level marker が書かれた場合の round-trip 破壊など) は Issue 2 の validator で warn/reject を足して対処する想定

## Test plan
- [x] `npx vitest run` 全 1098 テスト green
- [x] `npx vp check --no-fmt` (lint + typecheck) 通過
- [x] 変更ファイルは `vp check` (format + lint) 通過
- [x] parser テスト追加: instruction-only / mixed / 旧形式保持 / 両方空 reject / コードブロック内 `#` 無視 / `##` は marker 扱いしない
- [x] renderer テスト追加 (`src/shared/__tests__/skill-markdown.test.ts`): 3 形態 × render + round-trip、旧形式 round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)