### PR TITLE
feat(skill): allow instruction-only skills and warn on bgFetch in extractors

### DIFF
--- a/src/features/tools/__tests__/skill.test.ts
+++ b/src/features/tools/__tests__/skill.test.ts
@@ -331,12 +331,9 @@ describe("skill tool", () => {
       const storage = new InMemoryStorage();
       const registry = new SkillRegistry();
 
-      const result = await executeSkill(
-        storage,
-        registry,
-        undefined,
-        { action: "create" } as unknown as Parameters<typeof executeSkill>[3],
-      );
+      const result = await executeSkill(storage, registry, undefined, {
+        action: "create",
+      } as unknown as Parameters<typeof executeSkill>[3]);
 
       expect(result.ok).toBe(false);
       if (result.ok) return;
@@ -705,8 +702,52 @@ describe("skill tool", () => {
         expect.arrayContaining([
           "Skill name is required",
           "Skill matchers.hosts is required and must not be empty",
-          "Skill extractors is required and must have at least one extractor",
+          "Skill must have instructions or at least one extractor",
         ]),
+      );
+    });
+
+    it("accepts an instruction-only draft with no extractors", async () => {
+      const storage = new InMemoryStorage();
+      const registry = new SkillRegistry();
+
+      const result = await executeCreateSkillDraft(storage, registry, {
+        name: "GitHub Guidance",
+        description: "GitHub の task 選択に関する軽いガイダンス",
+        scope: "global",
+        matchers: { hosts: [] },
+        extractors: [],
+        instructionsMarkdown: "repo 分析でない限り repo-analysis guidance を過剰適用しないこと。",
+      });
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      const value = result.value as CreateSkillDraftResult;
+      expect(value.validation.status).not.toBe("reject");
+      expect(value.validation.errors).toHaveLength(0);
+      expect(value.normalizedSkill.instructionsMarkdown).toContain("repo 分析でない限り");
+    });
+
+    it("rejects a draft that has neither instructions nor extractors", async () => {
+      const storage = new InMemoryStorage();
+      const registry = new SkillRegistry();
+
+      const result = await executeCreateSkillDraft(storage, registry, {
+        name: "Empty Draft",
+        description: "A draft with no extractors and no instructions",
+        scope: "global",
+        matchers: { hosts: [] },
+        extractors: [],
+      });
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      const value = result.value as CreateSkillDraftResult;
+      expect(value.validation.status).toBe("reject");
+      expect(value.validation.errors.map((e) => e.message)).toEqual(
+        expect.arrayContaining(["Skill must have instructions or at least one extractor"]),
       );
     });
 
@@ -1277,12 +1318,10 @@ describe("skill tool", () => {
       const storage = new InMemoryStorage();
       const registry = new SkillRegistry();
 
-      const result = await executeSkill(
-        storage,
-        registry,
-        undefined,
-        { action: "update", id: "test-skill" } as unknown as Parameters<typeof executeSkill>[3],
-      );
+      const result = await executeSkill(storage, registry, undefined, {
+        action: "update",
+        id: "test-skill",
+      } as unknown as Parameters<typeof executeSkill>[3]);
 
       expect(result.ok).toBe(false);
       if (result.ok) return;
@@ -1465,12 +1504,10 @@ describe("skill tool", () => {
       const storage = new InMemoryStorage();
       const registry = new SkillRegistry();
 
-      const result = await executeSkill(
-        storage,
-        registry,
-        undefined,
-        { action: "patch", id: "test-skill" } as unknown as Parameters<typeof executeSkill>[3],
-      );
+      const result = await executeSkill(storage, registry, undefined, {
+        action: "patch",
+        id: "test-skill",
+      } as unknown as Parameters<typeof executeSkill>[3]);
 
       expect(result.ok).toBe(false);
       if (result.ok) return;
@@ -1481,16 +1518,11 @@ describe("skill tool", () => {
       const storage = new InMemoryStorage();
       const registry = new SkillRegistry();
 
-      const result = await executeSkill(
-        storage,
-        registry,
-        undefined,
-        {
-          action: "patch",
-          id: "test-skill",
-          patches: [] as unknown as SkillPatches,
-        } as unknown as Parameters<typeof executeSkill>[3],
-      );
+      const result = await executeSkill(storage, registry, undefined, {
+        action: "patch",
+        id: "test-skill",
+        patches: [] as unknown as SkillPatches,
+      } as unknown as Parameters<typeof executeSkill>[3]);
 
       expect(result.ok).toBe(false);
       if (result.ok) return;

--- a/src/features/tools/skill.ts
+++ b/src/features/tools/skill.ts
@@ -88,6 +88,7 @@ export interface CreateSkillDraftArgs {
   scope?: SkillScope;
   matchers: SkillMatchers;
   extractors: SkillExtractor[];
+  instructionsMarkdown?: string;
 }
 
 export interface CreateSkillDraftResult {
@@ -499,6 +500,7 @@ export async function executeUpdateSkillDraft(
       ? { ...existingSkill.matchers, ...args.updates.matchers }
       : existingSkill.matchers,
     extractors: args.updates.extractors ?? existingSkill.extractors,
+    instructionsMarkdown: args.updates.instructionsMarkdown ?? existingSkill.instructionsMarkdown,
   };
 
   const parsedArgs = parseCreateSkillDraftArgs(mergedArgs);
@@ -544,7 +546,7 @@ export async function executeDeleteSkillDraft(
   if (typeof args !== "object" || args === null) {
     return err({
       code: "tool_script_error",
-      message: "skill(action: \"delete_draft\") arguments must be an object",
+      message: 'skill(action: "delete_draft") arguments must be an object',
     });
   }
 
@@ -910,8 +912,9 @@ function validateSkill(skill: Skill): string | null {
 function normalizeDraftSkill(args: CreateSkillDraftArgs): Skill {
   const trimmedName = (args.name ?? "").trim();
   const generatedId = slugifySkillId(trimmedName || "skill-draft");
+  const instructions = (args.instructionsMarkdown ?? "").trim();
 
-  return {
+  const skill: Skill = {
     id: generatedId,
     name: trimmedName,
     description: (args.description ?? "").trim(),
@@ -931,6 +934,12 @@ function normalizeDraftSkill(args: CreateSkillDraftArgs): Skill {
       outputSchema: (extractor.outputSchema ?? "").trim(),
     })),
   };
+
+  if (instructions.length > 0) {
+    skill.instructionsMarkdown = instructions;
+  }
+
+  return skill;
 }
 
 function validateDraftAgainstRegistry(
@@ -1030,7 +1039,7 @@ function parseCreateSkillDraftArgs(
   args: CreateSkillDraftArgs,
 ): { ok: true; value: CreateSkillDraftArgs } | { ok: false; error: string } {
   if (typeof args !== "object" || args === null) {
-    return { ok: false, error: "skill(action: \"create_draft\") arguments must be an object" };
+    return { ok: false, error: 'skill(action: "create_draft") arguments must be an object' };
   }
 
   if (typeof args.name !== "string") {
@@ -1075,6 +1084,10 @@ function parseCreateSkillDraftArgs(
 
   if (!Array.isArray(args.extractors)) {
     return { ok: false, error: "extractors must be an array" };
+  }
+
+  if (args.instructionsMarkdown !== undefined && typeof args.instructionsMarkdown !== "string") {
+    return { ok: false, error: "instructionsMarkdown must be a string when provided" };
   }
 
   for (const extractor of args.extractors) {

--- a/src/shared/__tests__/skill-validation.test.ts
+++ b/src/shared/__tests__/skill-validation.test.ts
@@ -227,7 +227,7 @@ describe("validateSkillDraftDefinition", () => {
       expect.arrayContaining([
         "Skill name is required",
         "Skill matchers.hosts is required and must not be empty",
-        "Skill extractors is required and must have at least one extractor",
+        "Skill must have instructions or at least one extractor",
       ]),
     );
   });
@@ -248,7 +248,7 @@ describe("validateSkillDraftDefinition", () => {
     expect(result.errors.map((error) => error.message)).toEqual(
       expect.arrayContaining([
         "Skill matchers.hosts is required and must not be empty",
-        "Skill extractors is required and must have at least one extractor",
+        "Skill must have instructions or at least one extractor",
       ]),
     );
   });
@@ -267,7 +267,7 @@ describe("validateSkillDraftDefinition", () => {
     const result = validateSkillDefinition(malformedSkill);
     expect(result.valid).toBe(false);
     expect(result.errors.map((error) => error.message)).toContain(
-      "Skill extractors is required and must have at least one extractor",
+      "Skill must have instructions or at least one extractor",
     );
   });
 
@@ -397,5 +397,151 @@ describe("validateSkillDraftDefinition", () => {
     expect(result.errors.map((error) => error.message)).toContain(
       "Skill matchers.hosts is required and must not be empty",
     );
+  });
+});
+
+describe("instruction-only skills", () => {
+  it("accepts an instruction-only global skill with no extractors", () => {
+    const skill: Skill = {
+      id: "github-guidance",
+      name: "GitHub Guidance",
+      description: "GitHub でのタスク選択に関する軽いガイダンス",
+      scope: "global",
+      matchers: { hosts: [] },
+      extractors: [],
+      version: "0.1.0",
+      instructionsMarkdown: "repo 分析でない限り repo-analysis guidance を過剰適用しないこと。",
+    };
+
+    const result = validateSkillDefinition(skill);
+    expect(result.valid).toBe(true);
+  });
+
+  it("draft validation accepts an instruction-only skill as ok or warning", () => {
+    const skill: Skill = {
+      id: "github-guidance",
+      name: "GitHub Guidance",
+      description: "GitHub でのタスク選択に関する軽いガイダンス",
+      scope: "global",
+      matchers: { hosts: [] },
+      extractors: [],
+      version: "0.1.0",
+      instructionsMarkdown: "repo 分析でない限り repo-analysis guidance を過剰適用しないこと。",
+    };
+
+    const result = validateSkillDraftDefinition(skill);
+    expect(result.status).not.toBe("reject");
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it("rejects a skill that has neither instructions nor extractors", () => {
+    const skill: Skill = {
+      id: "empty-skill",
+      name: "Empty Skill",
+      description: "Neither instructions nor extractors",
+      scope: "global",
+      matchers: { hosts: [] },
+      extractors: [],
+      version: "0.1.0",
+    };
+
+    const result = validateSkillDefinition(skill);
+    expect(result.valid).toBe(false);
+    expect(result.errors.map((e) => e.message)).toContain(
+      "Skill must have instructions or at least one extractor",
+    );
+  });
+
+  it("rejects instructionsMarkdown that embeds top-level '# Instructions' markers", () => {
+    const skill: Skill = {
+      id: "broken-instructions",
+      name: "Broken Instructions",
+      description: "instructions contain a top-level # Instructions marker",
+      scope: "global",
+      matchers: { hosts: [] },
+      extractors: [],
+      version: "0.1.0",
+      instructionsMarkdown: "intro paragraph\n\n# Instructions\n\nmore content",
+    };
+
+    const result = validateSkillDefinition(skill);
+    expect(result.valid).toBe(false);
+    expect(result.errors.map((e) => e.message).join(" ")).toMatch(/top-level/);
+  });
+
+  it("allows '# Instructions' inside a fenced code block in instructionsMarkdown", () => {
+    const skill: Skill = {
+      id: "doc-instructions",
+      name: "Doc Instructions",
+      description: "Instructions that document the skill format via fenced code",
+      scope: "global",
+      matchers: { hosts: [] },
+      extractors: [],
+      version: "0.1.0",
+      instructionsMarkdown: "skill の書式例:\n\n```md\n# Instructions\n\nthis is an example\n```\n",
+    };
+
+    const result = validateSkillDefinition(skill);
+    expect(result.valid).toBe(true);
+  });
+});
+
+describe("bgFetch() usage warning", () => {
+  it("warns when extractor code calls bgFetch()", () => {
+    const result = validateSkillDraftDefinition(
+      createSkill({
+        extractors: [
+          {
+            id: "loader",
+            name: "Loader",
+            description: "Load data using bgFetch from the extractor context",
+            code: 'function () { return bgFetch("https://example.com/api"); }',
+            outputSchema: "object",
+          },
+        ],
+      }),
+    );
+
+    expect(result.status).toBe("warning");
+    expect(result.warnings.some((w) => w.message.includes("bgFetch"))).toBe(true);
+    expect(result.warnings.some((w) => w.message.includes("Not available in page context"))).toBe(
+      true,
+    );
+  });
+
+  it("does not warn when bgFetch appears as a method/property access (not a call)", () => {
+    const result = validateSkillDraftDefinition(
+      createSkill({
+        extractors: [
+          {
+            id: "loader",
+            name: "Loader",
+            description: "Returns a string that happens to mention bgFetch",
+            code: 'function () { return { note: "see docs about bgFetch in background" }; }',
+            outputSchema: "object",
+          },
+        ],
+      }),
+    );
+
+    expect(result.warnings.every((w) => !w.message.includes("bgFetch"))).toBe(true);
+  });
+
+  it("does not warn on property-style .bgFetch(", () => {
+    const result = validateSkillDraftDefinition(
+      createSkill({
+        extractors: [
+          {
+            id: "loader",
+            name: "Loader",
+            description: "References an unrelated api.bgFetch method on a user object",
+            code: 'function () { return window.customApi.bgFetch("x"); }',
+            outputSchema: "object",
+          },
+        ],
+      }),
+    );
+
+    expect(result.warnings.every((w) => !w.message.includes("bgFetch"))).toBe(true);
   });
 });

--- a/src/shared/skill-validation.ts
+++ b/src/shared/skill-validation.ts
@@ -149,6 +149,10 @@ const NAVIGATION_WARNING_PATTERNS: readonly { pattern: RegExp; description: stri
   { pattern: /(?<![\w.])navigate\s*\(/g, description: "navigate()" },
 ];
 
+const USAGE_WARNING_PATTERNS: readonly { pattern: RegExp; description: string }[] = [
+  { pattern: /(?<![\w.])bgFetch\s*\(/g, description: "bgFetch()" },
+];
+
 export function validateSkillCode(code: string): ValidationResult {
   const errors: ValidationError[] = [];
   const warnings: ValidationWarning[] = [];
@@ -159,6 +163,7 @@ export function validateSkillCode(code: string): ValidationResult {
   checkSecurityPatterns(sanitized, errors);
   checkSecurityWarningPatterns(sanitized, warnings);
   checkNavigationWarningPatterns(sanitized, warnings);
+  checkUsageWarningPatterns(sanitized, warnings);
 
   return { valid: errors.length === 0, errors, warnings };
 }
@@ -391,11 +396,21 @@ function collectSkillStructureErrors(skill: Skill): ValidationError[] {
   }
 
   const extractors = Array.isArray(skill.extractors) ? skill.extractors : [];
+  const instructions = safeTrim(skill.instructionsMarkdown);
+  const hasInstructions = instructions.length > 0;
 
-  if (extractors.length === 0) {
+  if (!hasInstructions && extractors.length === 0) {
     errors.push({
       type: "syntax",
-      message: "Skill extractors is required and must have at least one extractor",
+      message: "Skill must have instructions or at least one extractor",
+    });
+  }
+
+  if (hasInstructions && instructionsContainTopLevelSectionMarker(instructions)) {
+    errors.push({
+      type: "syntax",
+      message:
+        "instructionsMarkdown must not contain top-level '# Instructions' or '# Extractors' headings (they would break markdown round-trip)",
     });
   }
 
@@ -417,6 +432,22 @@ function collectSkillStructureErrors(skill: Skill): ValidationError[] {
   }
 
   return errors;
+}
+
+function instructionsContainTopLevelSectionMarker(instructions: string): boolean {
+  const lines = instructions.split("\n");
+  let inFence = false;
+  for (const line of lines) {
+    if (/^\s*```/.test(line)) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) continue;
+    if (/^#\s+(Instructions|Extractors)\s*$/.test(line)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 function safeTrim(value: unknown): string {
@@ -510,6 +541,12 @@ function checkNavigationWarningPatterns(code: string, warnings: ValidationWarnin
     "Potentially risky navigation",
     warnings,
   );
+}
+
+function checkUsageWarningPatterns(code: string, warnings: ValidationWarning[]): void {
+  // Extractor code is executed in the page context where helpers like bgFetch()
+  // are not injected. Warn so authors can switch to a runtime-appropriate API.
+  checkPatterns(code, USAGE_WARNING_PATTERNS, "quality", "Not available in page context", warnings);
 }
 
 function lineNumber(code: string, index: number): number {


### PR DESCRIPTION
Closes #160

## Summary
- バリデーションルールを "extractors 必須" から "instructions または extractors 必須" に変更。instruction-only skill が `validateSkillDefinition` / `validateSkillDraftDefinition` / SkillsEditor を通るようになる
- どちらも空の skill は引き続き reject (新メッセージ: `Skill must have instructions or at least one extractor`)
- `instructionsMarkdown` 内に top-level `# Instructions` / `# Extractors` が含まれると round-trip が壊れるため reject (fenced code block 内の marker は許容)
- extractor コードに `bgFetch(` を含む場合に quality warning を追加。extractor は page context で実行されるため bgFetch helper にアクセス不可
- `create_draft` / `update_draft` に `instructionsMarkdown` を受け渡せるようにし、AI が instruction-only draft を作れるようにした

## Scope out / follow-up
- Runtime (page context への extractor 注入) は変更なし
- SkillsEditor の UI コードは未変更 (既存の errors/warnings 描画パスで新メッセージがそのまま表示される)
- Issue 3 以降: system prompt への instruction summary 統合、activation ルール、built-in skill の instruction 化を予定

## Test plan
- [x] `npx vitest run` 全 1108 テスト green
- [x] `npx vp check` (format + lint) 変更ファイル通過
- [x] `npx vp lint` リポジトリ全体 0 warnings / 0 errors
- [x] validator テスト追加: instruction-only accepted / 両方空 reject / top-level marker guard / fenced code 内 marker 許容 / bgFetch warning / bgFetch 非呼び出し (property アクセス) で warn しない
- [x] tool テスト追加: instruction-only draft accepted / 両方空 draft rejected with new message
- [x] 既存テストのメッセージ期待値更新 (skill-validation.test.ts 3 箇所 + skill.test.ts 1 箇所)

🤖 Generated with [Claude Code](https://claude.com/claude-code)