### PR TITLE
chore(skill): document instruction layer in tool def and add recovery tips

### DIFF
--- a/src/features/tools/__tests__/skill.test.ts
+++ b/src/features/tools/__tests__/skill.test.ts
@@ -90,6 +90,13 @@ describe("skill tool", () => {
       expect(skillToolDef.description).toContain("custom skill としては保存されません");
     });
 
+    it("documents the instruction layer and its validation rules", () => {
+      expect(skillToolDef.description).toContain("instructionsMarkdown");
+      expect(skillToolDef.description).toContain("Instructions layer");
+      expect(skillToolDef.description).toContain("instructionsMarkdown か extractors");
+      expect(skillToolDef.description).toContain("bgFetch()");
+    });
+
     it("returns a tool error for malformed skill arguments", async () => {
       const storage = new InMemoryStorage();
       const registry = new SkillRegistry();
@@ -830,6 +837,148 @@ describe("skill tool", () => {
       const loadedRegistry = await loadSkillRegistry(storage);
       const matches = loadedRegistry.getAvailableSkills("https://example.com/article");
       expect(matches.some((match) => match.skill.id === "approved-draft-skill")).toBe(true);
+    });
+
+    it("approved instruction-only drafts round-trip through storage with instructions preserved", async () => {
+      const storage = new InMemoryStorage();
+      const registry = new SkillRegistry();
+
+      const instructionsBody =
+        "このサイトでは API / bgFetch を優先すること。DOM extractor は可視範囲の補助取得に限定する。";
+
+      const createResult = await executeCreateSkillDraft(storage, registry, {
+        name: "Instructions Only Draft",
+        description: "AI 向けガイダンスのみを提供する global skill",
+        scope: "global",
+        matchers: { hosts: [] },
+        extractors: [],
+        instructionsMarkdown: instructionsBody,
+      });
+
+      expect(createResult.ok).toBe(true);
+      if (!createResult.ok) return;
+      expect(createResult.value.validation.status).not.toBe("reject");
+
+      const drafts = (await storage.get<StoredSkillDraft[]>("sitesurf_skill_drafts")) ?? [];
+      const approval = approveSkillDraft([], drafts, createResult.value.draftId);
+      expect(approval.ok).toBe(true);
+      if (!approval.ok) return;
+
+      await saveCustomSkills(storage, approval.updatedSkills);
+      await storage.set("sitesurf_skill_drafts", approval.remainingDrafts);
+
+      const loadedRegistry = await loadSkillRegistry(storage);
+      const loaded = loadedRegistry.get("instructions-only-draft");
+      expect(loaded).toBeDefined();
+      expect(loaded?.extractors).toHaveLength(0);
+      expect(loaded?.instructionsMarkdown).toContain("API / bgFetch を優先");
+    });
+
+    it("approved mixed drafts preserve both instructions and extractors across storage", async () => {
+      const storage = new InMemoryStorage();
+      const registry = new SkillRegistry();
+
+      const createResult = await executeCreateSkillDraft(storage, registry, {
+        name: "Mixed Draft",
+        description: "Instructions と extractors を両方持つ site-scoped skill",
+        scope: "site",
+        matchers: { hosts: ["example.com"] },
+        extractors: [
+          {
+            id: "getTitle",
+            name: "Get Title",
+            description: "ページタイトルを取得する",
+            code: "function () { return document.title; }",
+            outputSchema: "string",
+          },
+        ],
+        instructionsMarkdown: "## Always\nこのサイトでは extractor を万能手段として扱わない。",
+      });
+
+      expect(createResult.ok).toBe(true);
+      if (!createResult.ok) return;
+
+      const drafts = (await storage.get<StoredSkillDraft[]>("sitesurf_skill_drafts")) ?? [];
+      const approval = approveSkillDraft([], drafts, createResult.value.draftId);
+      expect(approval.ok).toBe(true);
+      if (!approval.ok) return;
+
+      await saveCustomSkills(storage, approval.updatedSkills);
+
+      const loadedRegistry = await loadSkillRegistry(storage);
+      const loaded = loadedRegistry.get("mixed-draft");
+      expect(loaded).toBeDefined();
+      expect(loaded?.extractors).toHaveLength(1);
+      expect(loaded?.extractors[0].id).toBe("getTitle");
+      expect(loaded?.instructionsMarkdown).toContain("extractor を万能手段として扱わない");
+    });
+
+    it("provides a suggestedFix when a draft has neither instructions nor extractors", async () => {
+      const storage = new InMemoryStorage();
+      const registry = new SkillRegistry();
+
+      const result = await executeCreateSkillDraft(storage, registry, {
+        name: "Empty",
+        description: "Neither instructions nor extractors",
+        scope: "global",
+        matchers: { hosts: [] },
+        extractors: [],
+      });
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      expect(result.value.validation.status).toBe("reject");
+      expect(result.value.suggestedFixes.join(" ")).toContain(
+        "instructionsMarkdown（AI 向けガイダンス）か extractors",
+      );
+    });
+
+    it("provides a suggestedFix for bgFetch() usage warning in extractor code", async () => {
+      const storage = new InMemoryStorage();
+      const registry = new SkillRegistry();
+
+      const result = await executeCreateSkillDraft(storage, registry, {
+        name: "bgFetch Draft",
+        description: "Extractor that incorrectly tries to call bgFetch",
+        scope: "site",
+        matchers: { hosts: ["example.com"] },
+        extractors: [
+          {
+            id: "loader",
+            name: "Loader",
+            description: "Tries to load via bgFetch from page context",
+            code: 'function () { return bgFetch("https://example.com/api"); }',
+            outputSchema: "object",
+          },
+        ],
+      });
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      expect(result.value.validation.status).toBe("warning");
+      expect(result.value.suggestedFixes.join(" ")).toContain("bg_fetch ツール");
+    });
+
+    it("provides a suggestedFix when instructionsMarkdown embeds a top-level marker", async () => {
+      const storage = new InMemoryStorage();
+      const registry = new SkillRegistry();
+
+      const result = await executeCreateSkillDraft(storage, registry, {
+        name: "Broken Instructions",
+        description: "Instruction body embeds a top-level # Instructions heading",
+        scope: "global",
+        matchers: { hosts: [] },
+        extractors: [],
+        instructionsMarkdown: "intro\n\n# Instructions\n\nmore content",
+      });
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      expect(result.value.validation.status).toBe("reject");
+      expect(result.value.suggestedFixes.join(" ")).toContain("コードフェンス");
     });
   });
 

--- a/src/features/tools/skill.ts
+++ b/src/features/tools/skill.ts
@@ -150,6 +150,12 @@ export const skillToolDef: ToolDefinition = {
   name: "skill",
   description: `サイト固有の自動化ライブラリ（Skill）を管理するツール。
 
+Skill には 2 つのレイヤーがある:
+- **Instructions layer**: AI 向けのサイトスコープのガイダンス（markdown）
+- **Extractors layer**: ページコンテキストで実行される site-specific な関数
+
+どちらか一方だけ、または両方を持てる。instructions-only / extractors-only / mixed の 3 形態を許容する。
+
 ## アクション
 
 ### 1. list - スキル一覧
@@ -167,6 +173,7 @@ call skill({ action: "get", id: "youtube-extractor", includeLibraryCode: true })
 
 ### 3. create - スキル作成
 新しいスキルを作成する。IDは一意である必要がある。
+instructionsMarkdown を渡すと AI 向けガイダンスも保存できる（extractors と同居・instruction-only どちらも可）。
 
 call skill({
   action: "create",
@@ -176,6 +183,7 @@ call skill({
     description: "説明文",
     matchers: { hosts: ["example.com"] },
     version: "0.0.0",
+    instructionsMarkdown: "このサイトでは API / bgFetch を優先すること。",
     extractors: [{
       id: "getTitle",
       name: "タイトル取得",
@@ -225,6 +233,7 @@ call skill({ action: "list_drafts" })
 ### 8. create_draft - スキル下書き作成
 チャットから Skill の下書きを作成する。下書きとして保存されるが、custom skill としては保存されません。
 validation 結果を返し、Settings の下書き一覧で内容を確認したうえで明示承認した時だけ custom skill に反映される。
+instructionsMarkdown を渡すと instruction-only または mixed な下書きにできる（extractors 空でも可）。
 
 call skill({
   action: "create_draft",
@@ -233,6 +242,7 @@ call skill({
     description: "説明文",
     scope: "site",
     matchers: { hosts: ["example.com"] },
+    instructionsMarkdown: "このサイトでは...",
     extractors: [{
       id: "getTitle",
       name: "タイトル取得",
@@ -263,14 +273,17 @@ call skill({ action: "delete_draft", id: "draft-id" })
 - code 内で **ナビゲーション操作は禁止**: window.location, location.href=, location.assign(), location.replace(), location.reload(), history.pushState(), history.replaceState()
 - code 内で **危険な関数は禁止**: eval(), Function(), new Function(), setTimeout("string"), document.write(), .constructor.constructor(), .submit(), new Image()
 - scope が "site" のとき **matchers.hosts は必須**で1つ以上のホストが必要
+- **instructionsMarkdown か extractors のどちらか**は必須（両方空は reject）
 - 各 extractor に **id, name, description, code, outputSchema** はすべて必須
 - **括弧の対応が不一致**（(), [], {} のバランス）
+- instructionsMarkdown 内で **top-level の "# Instructions" / "# Extractors" 見出しは使用禁止**（markdown の round-trip を壊すため）。必要ならコードフェンス内に書く
 
 ### warning（承認可能だが品質向上のため推奨）
 - description が **10文字未満**だと警告 → 用途がわかる具体的な説明にする
 - outputSchema が "unknown" だと警告 → 返却値の型を具体的に記述する（例: "{ title: string, url: string }"）
 - code に **return 文がない**と警告 → 明示的に return で結果を返す
 - code 内の fetch(), XMLHttpRequest, WebSocket は警告（使用可能だが注意）
+- code 内の **bgFetch() は警告** → extractor は page context で実行されるため bgFetch helper にアクセスできない。bg_fetch が必要なら別の経路で呼び出す
 
 ### 自動補正
 - code が bare code（return document.title; など）の場合は自動的に function () { ... } でラップされる
@@ -1018,6 +1031,27 @@ function buildSuggestedFixes(validation: SkillDraftValidation): string[] {
     if (issue.message.includes("full function source")) {
       fixes.add(
         "extractor code は bare な文ではなく、`function () { ... }` か `async function () { ... }` の形で保存してください。",
+      );
+    }
+
+    if (issue.message.includes("must have instructions or at least one extractor")) {
+      fixes.add(
+        "instructionsMarkdown（AI 向けガイダンス）か extractors（関数）のどちらかを指定してください。両方空の Skill は保存できません。",
+      );
+    }
+
+    if (
+      issue.message.includes("instructionsMarkdown must not contain top-level") ||
+      issue.message.includes("top-level '# Instructions'")
+    ) {
+      fixes.add(
+        "instructionsMarkdown の本文から top-level の '# Instructions' / '# Extractors' 見出しを取り除いてください。説明で書式例を示したい場合はコードフェンス（```md ... ```）の中に書いてください。",
+      );
+    }
+
+    if (issue.message.includes("Not available in page context: bgFetch")) {
+      fixes.add(
+        "extractor code はページコンテキストで実行されるため bgFetch() は呼び出せません。ネットワークアクセスが必要なら extractor から外して bg_fetch ツールを利用してください。",
       );
     }
   }


### PR DESCRIPTION
Follow-up to #159 / #160 to close UX and coverage gaps flagged in the Issue #160 review.

## Summary
- **Tool description を更新** (`skillToolDef.description`): Instructions / Extractors の 2 レイヤーモデル、新しい validation rule (どちらか必須 / top-level marker 禁止)、`create` / `create_draft` の例に `instructionsMarkdown` を追加、warning 一覧に `bgFetch()` を追加。AI から instruction layer がちゃんと見えるようになる
- **`buildSuggestedFixes` 拡張**: 3 つの新メッセージに recovery tip を追加
  - `must have instructions or at least one extractor`
  - `instructionsMarkdown must not contain top-level '# Instructions' / '# Extractors'`
  - `Not available in page context: bgFetch()`
- **`approveSkillDraft` の integration test を追加**: instruction-only / mixed draft が `saveCustomSkills` → `loadSkillRegistry` 経由で instructions を失わないことを end-to-end で保証

## Why
Issue #160 のレビューで、実装は正しいが「AI が新機能を発見する手段がない」「エラー時の回復導線がない」「persistence パスの round-trip がテストされていない」ことを指摘。Issue 3/5 を待たずにこの PR で解消する。

## Test plan
- [x] \`npx vitest run\` 全 1114 テスト green (+6)
- [x] \`npx vp check\` (format + lint) 変更ファイル通過
- [x] \`npx vp lint\` リポジトリ全体 0 warnings / 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)