### PR TITLE
feat(prompt): surface skill instruction summaries in system prompt

### DIFF
--- a/src/features/ai/__tests__/system-prompt-v2.test.ts
+++ b/src/features/ai/__tests__/system-prompt-v2.test.ts
@@ -192,7 +192,7 @@ describe("generateSkillsSectionForLoop / shownSkillIds diff rendering", () => {
     expect(section).toContain("github-ext():");
   });
 
-  it("getActiveSkillIds returns only skills with available extractors", () => {
+  it("getActiveSkillIds returns only skills that are visible in the prompt", () => {
     const withExt = makeSkillMatch("yt", "YouTube");
     const noExt: SkillMatch = {
       ...withExt,
@@ -201,6 +201,24 @@ describe("generateSkillsSectionForLoop / shownSkillIds diff rendering", () => {
     };
     const ids = getActiveSkillIds([withExt, noExt]);
     expect(ids).toEqual(["yt"]);
+  });
+
+  it("getActiveSkillIds includes instruction-only skills", () => {
+    const withExt = makeSkillMatch("yt", "YouTube");
+    const instructionOnly: SkillMatch = {
+      ...withExt,
+      skill: {
+        ...withExt.skill,
+        id: "guidance",
+        name: "Guidance",
+        extractors: [],
+        instructionsMarkdown: "Use API over DOM when possible.",
+      },
+      availableExtractors: [],
+    };
+    const ids = getActiveSkillIds([withExt, instructionOnly]);
+    expect(ids).toEqual(expect.arrayContaining(["yt", "guidance"]));
+    expect(ids).toHaveLength(2);
   });
 
   it("getSystemPromptV2 with shownSkillIds renders short format for seen skill", () => {
@@ -254,5 +272,177 @@ describe("generateVisitedUrlsSection", () => {
     });
     expect(prompt).toContain("## Current Session: Visited URLs");
     expect(prompt).toContain("https://example.com");
+  });
+});
+
+describe("skill instruction layer in prompt", () => {
+  function makeExtractorSkill(id: string, name: string, scope?: "global"): SkillMatch {
+    const extractor = {
+      id: `${id}-ext`,
+      name: "Extractor",
+      description: "Gets data",
+      code: "function() {}",
+      outputSchema: "string",
+    };
+    return {
+      skill: {
+        id,
+        name,
+        description: `${name} description`,
+        matchers: scope ? { hosts: [] } : { hosts: [`${id}.com`] },
+        version: "0.0.0",
+        scope,
+        extractors: [extractor],
+      },
+      availableExtractors: [extractor],
+      confidence: 80,
+    };
+  }
+
+  function makeInstructionOnlySkill(
+    id: string,
+    name: string,
+    instructionsMarkdown: string,
+    scope: "global" | undefined = "global",
+  ): SkillMatch {
+    return {
+      skill: {
+        id,
+        name,
+        description: `${name} description`,
+        matchers: scope === "global" ? { hosts: [] } : { hosts: [`${id}.com`] },
+        version: "0.0.0",
+        scope,
+        extractors: [],
+        instructionsMarkdown,
+      },
+      availableExtractors: [],
+      confidence: 100,
+    };
+  }
+
+  it("keeps extractor-only skills free of the Guidance line", () => {
+    const section = generateSkillsSectionForLoop([makeExtractorSkill("yt", "YouTube")], new Set());
+    expect(section).not.toContain("Guidance:");
+    expect(section).toContain("yt-ext():");
+    expect(section).toContain("browserjs");
+  });
+
+  it("renders an instruction-only skill without extractor bullets or browserjs example", () => {
+    const skill = makeInstructionOnlySkill(
+      "github-guidance",
+      "GitHub Guidance",
+      "Use API / bgFetch over DOM for repo analysis tasks.",
+    );
+    const section = generateSkillsSectionForLoop([skill], new Set());
+    expect(section).toContain("**GitHub Guidance**");
+    expect(section).toContain("Guidance: Use API / bgFetch over DOM for repo analysis tasks.");
+    expect(section).not.toContain("browserjs");
+    expect(section).not.toMatch(/^-\s+\w+\(\):/m);
+  });
+
+  it("renders a mixed skill with both extractor metadata and a Guidance line", () => {
+    const extractor = {
+      id: "getTitle",
+      name: "Get Title",
+      description: "Returns the page title",
+      code: "function () { return document.title; }",
+      outputSchema: "string",
+    };
+    const mixed: SkillMatch = {
+      skill: {
+        id: "github-repo",
+        name: "GitHub Repo",
+        description: "Analysis helpers for GitHub repositories",
+        matchers: { hosts: ["github.com"] },
+        version: "0.2.0",
+        extractors: [extractor],
+        instructionsMarkdown:
+          "Prefer static API retrieval before relying on DOM extractors for repo analysis.",
+      },
+      availableExtractors: [extractor],
+      confidence: 100,
+    };
+    const section = generateSkillsSectionForLoop([mixed], new Set());
+    expect(section).toContain("**GitHub Repo**");
+    expect(section).toContain("- getTitle(): string — Returns the page title");
+    expect(section).toContain("browserjs");
+    expect(section).toContain("Guidance: Prefer static API retrieval");
+  });
+
+  it("does not inject the full instruction markdown into the prompt", () => {
+    const longBody = [
+      "## Always",
+      "First body line: keep this short.",
+      "",
+      "## Task: Repository Analysis",
+      "Another multi-line section describing how to proceed for repo analysis tasks.",
+      "More detail that should never appear in the prompt verbatim.",
+    ].join("\n");
+    const skill = makeInstructionOnlySkill("github-long", "GitHub Long", longBody);
+    const section = generateSkillsSectionForLoop([skill], new Set());
+    // The first non-heading body line becomes the passive summary.
+    expect(section).toContain("Guidance: First body line: keep this short.");
+    // Headings and subsequent sections must not leak into the prompt.
+    expect(section).not.toContain("## Always");
+    expect(section).not.toContain("## Task: Repository Analysis");
+    expect(section).not.toContain("Another multi-line section");
+    expect(section).not.toContain("More detail that should never appear");
+  });
+
+  it("truncates overlong first-line summaries with an ellipsis", () => {
+    const long = "x".repeat(200);
+    const skill = makeInstructionOnlySkill("long", "Long", long);
+    const section = generateSkillsSectionForLoop([skill], new Set());
+    const guidanceLine = section.split("\n").find((line) => line.startsWith("Guidance:"));
+    expect(guidanceLine).toBeDefined();
+    if (!guidanceLine) return;
+    expect(guidanceLine.endsWith("…")).toBe(true);
+    // "Guidance: " + up to 120 chars.
+    expect(guidanceLine.length).toBeLessThanOrEqual("Guidance: ".length + 120);
+  });
+
+  it("skips markdown heading lines when summarizing", () => {
+    const body = "## Always\n\nThe actual guidance body is on this line.";
+    const skill = makeInstructionOnlySkill("heading-first", "Heading First", body);
+    const section = generateSkillsSectionForLoop([skill], new Set());
+    expect(section).toContain("Guidance: The actual guidance body is on this line.");
+  });
+
+  it("strips leading list markers when summarizing", () => {
+    const body = "- First bullet point with guidance.";
+    const skill = makeInstructionOnlySkill("list-first", "List First", body);
+    const section = generateSkillsSectionForLoop([skill], new Set());
+    expect(section).toContain("Guidance: First bullet point with guidance.");
+  });
+
+  it("also surfaces Guidance in short format for already-seen skills", () => {
+    const skill = makeInstructionOnlySkill("seen", "Seen", "Some passive guidance line.");
+    const section = generateSkillsSectionForLoop([skill], new Set(["seen"]));
+    expect(section).toContain("- Seen (id: seen):");
+    expect(section).toContain("Guidance: Some passive guidance line.");
+  });
+
+  it("includes instruction-only global skills in the Global skills section", () => {
+    const skill = makeInstructionOnlySkill(
+      "github-guidance",
+      "GitHub Guidance",
+      "General guidance.",
+    );
+    const prompt = getSystemPromptV2({ includeSkills: true, skills: [skill] });
+    expect(prompt).toContain("Skills: Global");
+    expect(prompt).toContain("**GitHub Guidance**");
+    expect(prompt).toContain("Guidance: General guidance.");
+  });
+
+  it("still omits the skills section when no skill carries extractors or instructions", () => {
+    const skill: SkillMatch = {
+      ...makeExtractorSkill("empty", "Empty"),
+      availableExtractors: [],
+    };
+    skill.skill = { ...skill.skill, instructionsMarkdown: undefined, extractors: [] };
+    const prompt = getSystemPromptV2({ includeSkills: true, skills: [skill] });
+    expect(prompt).not.toContain("Skills: Site-Specific Extraction");
+    expect(prompt).not.toContain("Skills: Global");
   });
 });

--- a/src/features/ai/system-prompt-v2.ts
+++ b/src/features/ai/system-prompt-v2.ts
@@ -23,7 +23,6 @@ export interface SystemPromptOptions {
   enableBgFetch?: boolean;
 }
 
-
 // TOOL_PHILOSOPHY は prompt cache 対象に載せるため system prompt 側へ移動。
 // REPL description 側には COMMON_PATTERNS / AVAILABLE_FUNCTIONS のみを残す。
 const BASE_PROMPT = [CORE_IDENTITY, TOOL_PHILOSOPHY, SECURITY_BOUNDARY, COMPLETION_PRINCIPLE].join(
@@ -38,11 +37,40 @@ function formatWindowSkillCall(skillId: string, extractorId: string): string {
   return `window${formatPropertyAccess(skillId)}${formatPropertyAccess(extractorId)}()`;
 }
 
+const INSTRUCTION_SUMMARY_MAX_LEN = 120;
+
+function hasInstructions(match: SkillMatch): boolean {
+  return (match.skill.instructionsMarkdown ?? "").trim().length > 0;
+}
+
+function isPromptVisibleSkill(match: SkillMatch): boolean {
+  return match.availableExtractors.length > 0 || hasInstructions(match);
+}
+
+/**
+ * instructionsMarkdown の先頭本文から 1 行のサマリを作る。
+ * 見出し / 空行 / リスト記号は除去し、INSTRUCTION_SUMMARY_MAX_LEN で打ち切る。
+ * 本文を全文注入しない passive activation を初期実装として採用する。
+ */
+function summarizeInstructions(instructionsMarkdown: string | undefined): string | null {
+  if (!instructionsMarkdown) return null;
+  for (const raw of instructionsMarkdown.split("\n")) {
+    const line = raw.trim();
+    if (line.length === 0) continue;
+    if (/^#{1,6}\s/.test(line)) continue;
+    const cleaned = line.replace(/^[-*+]\s+/, "").trim();
+    if (cleaned.length === 0) continue;
+    if (cleaned.length <= INSTRUCTION_SUMMARY_MAX_LEN) return cleaned;
+    return `${cleaned.slice(0, INSTRUCTION_SUMMARY_MAX_LEN - 1)}…`;
+  }
+  return null;
+}
+
 function generateSkillsSection(
   skills: SkillMatch[],
   shownSkillIds: ReadonlySet<string> = new Set(),
 ): string {
-  const active = skills.filter((m) => m.availableExtractors.length > 0);
+  const active = skills.filter(isPromptVisibleSkill);
 
   if (active.length === 0) {
     return "";
@@ -84,10 +112,14 @@ function renderSkillEntries(
 
   for (const match of skills) {
     const { skill, availableExtractors } = match;
+    const guidanceSummary = summarizeInstructions(skill.instructionsMarkdown);
 
     if (shownSkillIds.has(skill.id)) {
       // Short format for already-seen skills
       lines.push(`- ${skill.name} (id: ${skill.id}): ${skill.description}`);
+      if (guidanceSummary) {
+        lines.push(`  Guidance: ${guidanceSummary}`);
+      }
       lines.push("");
       continue;
     }
@@ -96,20 +128,25 @@ function renderSkillEntries(
     const target = skill.scope === "global" ? "any page" : skill.matchers.hosts.join(", ");
     lines.push(`**${skill.name}** (id: ${skill.id}, ${target})`);
     lines.push(skill.description);
-    lines.push("");
-
-    for (const ext of availableExtractors) {
-      lines.push(`- ${ext.id}(): ${ext.outputSchema} — ${ext.description}`);
+    if (guidanceSummary) {
+      lines.push(`Guidance: ${guidanceSummary}`);
     }
+    lines.push("");
 
-    lines.push("");
-    lines.push("Call skill extractors from browserjs() via the runtime-injected window object:");
-    lines.push("```javascript");
-    lines.push(
-      `const info = await browserjs(() => ${formatWindowSkillCall(skill.id, availableExtractors[0].id)});`,
-    );
-    lines.push("```");
-    lines.push("");
+    if (availableExtractors.length > 0) {
+      for (const ext of availableExtractors) {
+        lines.push(`- ${ext.id}(): ${ext.outputSchema} — ${ext.description}`);
+      }
+
+      lines.push("");
+      lines.push("Call skill extractors from browserjs() via the runtime-injected window object:");
+      lines.push("```javascript");
+      lines.push(
+        `const info = await browserjs(() => ${formatWindowSkillCall(skill.id, availableExtractors[0].id)});`,
+      );
+      lines.push("```");
+      lines.push("");
+    }
   }
 
   return lines.join("\n");
@@ -140,10 +177,12 @@ export function getSystemPromptV2(options: SystemPromptOptions): string {
 
 /**
  * Extract skill IDs from the active skills that will be sent in the prompt.
+ * Includes instruction-only skills so that their passive guidance is tracked
+ * across turns by the shownSkillIds mechanism.
  * Used by agent-loop to track which skills have been shown to the AI.
  */
 export function getActiveSkillIds(skills: SkillMatch[]): string[] {
-  return skills.filter((m) => m.availableExtractors.length > 0).map((m) => m.skill.id);
+  return skills.filter(isPromptVisibleSkill).map((m) => m.skill.id);
 }
 
 /**


### PR DESCRIPTION
Closes #161

## Summary
- skill に `instructionsMarkdown` がある場合、system prompt に **1 行の "Guidance:" サマリ**を追加。本文の全文注入はしない (passive activation)
- サマリは instruction 本文の最初の非見出し行をリスト記号を剥がして 120 文字で打ち切り
- **instruction-only skill** を prompt visibility に含めるよう `getActiveSkillIds` と skills section のフィルタを更新。extractor が空でも AI に表示される
- instruction-only skill には extractor bullets も `browserjs()` 呼び出し例も出さない (誤って関数呼び出しと解釈されないよう)
- **extractor-only skill は旧出力と bit-identical** (Guidance 行なし・browserjs 例あり)
- shown skill 短縮表示でも Guidance は出す (既読スキルの passive hint 維持)

## Scope out / follow-up
- path / DOM / intent に応じた contextual / active activation は Issue 4 (issue #162) で対応
- 現時点では「skill が match したら 1 行出す」passive レベルのみ
- built-in skill 側は既存 YouTube/Google 等で instructions が無いので prompt 出力は現状維持

## Test plan
- [x] \`npx vitest run\` 全 1125 テスト green (+11)
- [x] \`npx vp check\` (format + lint) 変更ファイル通過
- [x] \`npx vp lint\` リポジトリ全体 0 warnings / 0 errors
- [x] prompt テスト追加: extractor-only / instruction-only / mixed / 長文切り詰め / 見出しスキップ / リスト記号剥がし / shown short 形式 / global skills section / 空 skill で section 出さない / `getActiveSkillIds` が instruction-only を含む

🤖 Generated with [Claude Code](https://claude.com/claude-code)