### PR TITLE
fix(prompt): skip code fences and hide unsummarizable instruction skills

### DIFF
--- a/src/features/ai/__tests__/system-prompt-v2.test.ts
+++ b/src/features/ai/__tests__/system-prompt-v2.test.ts
@@ -445,4 +445,49 @@ describe("skill instruction layer in prompt", () => {
     expect(prompt).not.toContain("Skills: Site-Specific Extraction");
     expect(prompt).not.toContain("Skills: Global");
   });
+
+  it("skips fenced code blocks when summarizing instructions", () => {
+    const body = [
+      "```js",
+      "// 書式例をまず示す",
+      "function () { return { files: [] }; }",
+      "```",
+      "",
+      "repo 分析では API / bgFetch を優先すること。",
+    ].join("\n");
+    const skill = makeInstructionOnlySkill("github-repo", "GitHub Repo", body);
+    const section = generateSkillsSectionForLoop([skill], new Set());
+
+    expect(section).toContain("Guidance: repo 分析では API / bgFetch を優先すること。");
+    // Code fence markers and code content must not appear in the prompt.
+    expect(section).not.toContain("```js");
+    expect(section).not.toContain("function () { return { files: [] }; }");
+    // And the opening fence must not have been picked up as the Guidance line.
+    expect(section).not.toMatch(/^Guidance:\s*```/m);
+  });
+
+  it("hides instruction-only skills whose body is only headings (no summarizable content)", () => {
+    const body = ["## Always", "", "## Task: Repository Analysis"].join("\n");
+    const skill = makeInstructionOnlySkill("headings-only", "Headings Only", body);
+    const prompt = getSystemPromptV2({ includeSkills: true, skills: [skill] });
+
+    expect(prompt).not.toContain("Skills: Global");
+    expect(prompt).not.toContain("**Headings Only**");
+    expect(prompt).not.toContain("Headings Only description");
+  });
+
+  it("hides instruction-only skills whose body is only a code block", () => {
+    const body = ["```js", "// nothing useful for the AI here", "```"].join("\n");
+    const skill = makeInstructionOnlySkill("fenced-only", "Fenced Only", body);
+    const prompt = getSystemPromptV2({ includeSkills: true, skills: [skill] });
+
+    expect(prompt).not.toContain("**Fenced Only**");
+  });
+
+  it("excludes unsummarizable instruction-only skills from getActiveSkillIds", () => {
+    const summarizable = makeInstructionOnlySkill("ok", "Ok", "Good guidance.");
+    const headingsOnly = makeInstructionOnlySkill("headings", "Headings", "## One\n## Two");
+    const ids = getActiveSkillIds([summarizable, headingsOnly]);
+    expect(ids).toEqual(["ok"]);
+  });
 });

--- a/src/features/ai/system-prompt-v2.ts
+++ b/src/features/ai/system-prompt-v2.ts
@@ -39,22 +39,28 @@ function formatWindowSkillCall(skillId: string, extractorId: string): string {
 
 const INSTRUCTION_SUMMARY_MAX_LEN = 120;
 
-function hasInstructions(match: SkillMatch): boolean {
-  return (match.skill.instructionsMarkdown ?? "").trim().length > 0;
-}
-
 function isPromptVisibleSkill(match: SkillMatch): boolean {
-  return match.availableExtractors.length > 0 || hasInstructions(match);
+  if (match.availableExtractors.length > 0) return true;
+  // instructions があっても summarize 可能な本文が無ければ prompt には出さない。
+  // 例: 見出しだけ / コードフェンスだけの instructions は AI にとってノイズにしかならない。
+  return summarizeInstructions(match.skill.instructionsMarkdown) !== null;
 }
 
 /**
  * instructionsMarkdown の先頭本文から 1 行のサマリを作る。
- * 見出し / 空行 / リスト記号は除去し、INSTRUCTION_SUMMARY_MAX_LEN で打ち切る。
+ * 見出し / 空行 / リスト記号 / コードフェンス内は除去し、
+ * INSTRUCTION_SUMMARY_MAX_LEN で打ち切る。
  * 本文を全文注入しない passive activation を初期実装として採用する。
  */
 function summarizeInstructions(instructionsMarkdown: string | undefined): string | null {
   if (!instructionsMarkdown) return null;
+  let inFence = false;
   for (const raw of instructionsMarkdown.split("\n")) {
+    if (/^\s*```/.test(raw)) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) continue;
     const line = raw.trim();
     if (line.length === 0) continue;
     if (/^#{1,6}\s/.test(line)) continue;


### PR DESCRIPTION
Follow-up to #161 to close two edge cases flagged in the review.

## Summary
1. **コードフェンス tracking 追加**: `summarizeInstructions` が instructions 本文のコードフェンス開始行 (\`\`\`\`\`\`js\`\`\` 等) を passive Guidance として拾ってしまう問題を修正。parser と同じ方式で fence を toggle し、内部行を無視する
2. **summary が null の skill は prompt から隠す**: 見出しのみ / コードフェンスのみの instructions を持つ skill が、名前と description だけ出て guidance も extractor も無い「空の skill エントリ」として prompt に残る問題を修正。`isPromptVisibleSkill` を「summary が生成できるか」ベースに変更

どちらも extractor-only skill の出力には影響しない純粋な additive fix。

## Test plan
- [x] \`npx vitest run\` 全 1129 テスト green (+4)
- [x] \`npx vp check\` (format + lint) 変更ファイル通過
- [x] \`npx vp lint\` リポジトリ全体 0 warnings / 0 errors
- [x] 追加テスト: fenced-code-first instructions の summary / headings-only で hidden / fenced-only で hidden / \`getActiveSkillIds\` が unsummarizable skill を除外

🤖 Generated with [Claude Code](https://claude.com/claude-code)