### PR TITLE
feat(prompt): separate skill match from instruction activation

### DIFF
--- a/src/features/ai/__tests__/system-prompt-v2.test.ts
+++ b/src/features/ai/__tests__/system-prompt-v2.test.ts
@@ -491,3 +491,79 @@ describe("skill instruction layer in prompt", () => {
     expect(ids).toEqual(["ok"]);
   });
 });
+
+describe("skill instruction activation level", () => {
+  function makeGuidanceSkill(
+    id: string,
+    name: string,
+    activationLevel: "passive" | "contextual",
+    instructionsMarkdown: string,
+    scope: "global" | undefined = undefined,
+  ): SkillMatch {
+    return {
+      skill: {
+        id,
+        name,
+        description: `${name} description`,
+        matchers: scope === "global" ? { hosts: [] } : { hosts: [`${id}.com`] },
+        version: "0.0.0",
+        scope,
+        extractors: [],
+        instructionsMarkdown,
+      },
+      availableExtractors: [],
+      confidence: 80,
+      activationLevel,
+    };
+  }
+
+  const guidanceBody = [
+    "repo 全体の分析では API / bgFetch を優先すること。",
+    "DOM extractor は可視範囲の補助取得に限定する。",
+    "",
+    "次のセクションに書かれた詳細はここには載せない。",
+  ].join("\n");
+
+  it("renders passive-level skill as a single short Guidance line", () => {
+    const skill = makeGuidanceSkill("gh", "GitHub", "passive", guidanceBody);
+    const section = generateSkillsSectionForLoop([skill], new Set());
+
+    expect(section).toMatch(/^Guidance:\s+/m);
+    expect(section).not.toContain("Guidance (contextual):");
+    // The second body line must not leak into the passive rendering.
+    expect(section).not.toContain("DOM extractor は可視範囲");
+    // Content after the blank line is definitely kept out.
+    expect(section).not.toContain("次のセクションに書かれた詳細");
+  });
+
+  it("renders contextual-level skill with the Guidance (contextual) header and multi-line body", () => {
+    const skill = makeGuidanceSkill("gh-tree", "GitHub Tree", "contextual", guidanceBody);
+    const section = generateSkillsSectionForLoop([skill], new Set());
+
+    expect(section).toContain("Guidance (contextual):");
+    expect(section).toContain("- repo 全体の分析では API / bgFetch を優先すること。");
+    expect(section).toContain("- DOM extractor は可視範囲の補助取得に限定する。");
+    // Content after the blank line (next paragraph) is still not injected.
+    expect(section).not.toContain("次のセクションに書かれた詳細");
+  });
+
+  it("treats missing activationLevel as passive by default", () => {
+    const skill = makeGuidanceSkill("legacy", "Legacy", "passive", guidanceBody);
+    // Strip the activation level to simulate older matches.
+    const legacyMatch: SkillMatch = { ...skill, activationLevel: undefined };
+    const section = generateSkillsSectionForLoop([legacyMatch], new Set());
+
+    expect(section).toMatch(/^Guidance:\s+/m);
+    expect(section).not.toContain("Guidance (contextual):");
+  });
+
+  it("short format for already-seen skills keeps a single Guidance line regardless of level", () => {
+    const skill = makeGuidanceSkill("gh-tree", "GitHub Tree", "contextual", guidanceBody);
+    const section = generateSkillsSectionForLoop([skill], new Set(["gh-tree"]));
+
+    expect(section).toContain("- GitHub Tree (id: gh-tree):");
+    expect(section).toContain("  Guidance: repo 全体の分析では");
+    expect(section).not.toContain("Guidance (contextual):");
+    expect(section).not.toContain("- DOM extractor は可視範囲");
+  });
+});

--- a/src/features/ai/system-prompt-v2.ts
+++ b/src/features/ai/system-prompt-v2.ts
@@ -38,6 +38,7 @@ function formatWindowSkillCall(skillId: string, extractorId: string): string {
 }
 
 const INSTRUCTION_SUMMARY_MAX_LEN = 120;
+const CONTEXTUAL_PARAGRAPH_MAX_LINES = 4;
 
 function isPromptVisibleSkill(match: SkillMatch): boolean {
   if (match.availableExtractors.length > 0) return true;
@@ -47,29 +48,69 @@ function isPromptVisibleSkill(match: SkillMatch): boolean {
 }
 
 /**
- * instructionsMarkdown の先頭本文から 1 行のサマリを作る。
+ * 本文行かどうか。見出し / 空行 / コードフェンスは本文ではない。
+ * 共通の fence tracking を closure で持つため、反復ごとに状態が進む。
+ */
+function makeBodyLineIterator(instructionsMarkdown: string): Generator<string, void, unknown> {
+  return (function* () {
+    let inFence = false;
+    for (const raw of instructionsMarkdown.split("\n")) {
+      if (/^\s*```/.test(raw)) {
+        inFence = !inFence;
+        continue;
+      }
+      if (inFence) continue;
+      const line = raw.trim();
+      if (line.length === 0) {
+        // 空行は paragraph 区切りとしても使いたいので yield する
+        yield "";
+        continue;
+      }
+      if (/^#{1,6}\s/.test(line)) continue;
+      const cleaned = line.replace(/^[-*+]\s+/, "").trim();
+      if (cleaned.length === 0) continue;
+      yield cleaned;
+    }
+  })();
+}
+
+/**
+ * instructionsMarkdown の先頭本文から 1 行のサマリを作る (passive activation)。
  * 見出し / 空行 / リスト記号 / コードフェンス内は除去し、
  * INSTRUCTION_SUMMARY_MAX_LEN で打ち切る。
- * 本文を全文注入しない passive activation を初期実装として採用する。
  */
 function summarizeInstructions(instructionsMarkdown: string | undefined): string | null {
   if (!instructionsMarkdown) return null;
-  let inFence = false;
-  for (const raw of instructionsMarkdown.split("\n")) {
-    if (/^\s*```/.test(raw)) {
-      inFence = !inFence;
-      continue;
-    }
-    if (inFence) continue;
-    const line = raw.trim();
-    if (line.length === 0) continue;
-    if (/^#{1,6}\s/.test(line)) continue;
-    const cleaned = line.replace(/^[-*+]\s+/, "").trim();
-    if (cleaned.length === 0) continue;
-    if (cleaned.length <= INSTRUCTION_SUMMARY_MAX_LEN) return cleaned;
-    return `${cleaned.slice(0, INSTRUCTION_SUMMARY_MAX_LEN - 1)}…`;
+  for (const line of makeBodyLineIterator(instructionsMarkdown)) {
+    if (line === "") continue;
+    if (line.length <= INSTRUCTION_SUMMARY_MAX_LEN) return line;
+    return `${line.slice(0, INSTRUCTION_SUMMARY_MAX_LEN - 1)}…`;
   }
   return null;
+}
+
+/**
+ * contextual activation 用に先頭パラグラフ (連続本文行の塊) を返す。
+ * 最大 CONTEXTUAL_PARAGRAPH_MAX_LINES 行まで。全文注入は避ける。
+ */
+function contextualInstructionParagraph(instructionsMarkdown: string | undefined): string[] | null {
+  if (!instructionsMarkdown) return null;
+  const collected: string[] = [];
+  let started = false;
+  for (const line of makeBodyLineIterator(instructionsMarkdown)) {
+    if (line === "") {
+      if (started) break; // 最初のパラグラフ終了
+      continue;
+    }
+    started = true;
+    if (line.length <= INSTRUCTION_SUMMARY_MAX_LEN) {
+      collected.push(line);
+    } else {
+      collected.push(`${line.slice(0, INSTRUCTION_SUMMARY_MAX_LEN - 1)}…`);
+    }
+    if (collected.length >= CONTEXTUAL_PARAGRAPH_MAX_LINES) break;
+  }
+  return collected.length > 0 ? collected : null;
 }
 
 function generateSkillsSection(
@@ -118,10 +159,12 @@ function renderSkillEntries(
 
   for (const match of skills) {
     const { skill, availableExtractors } = match;
+    const activationLevel = match.activationLevel ?? "passive";
     const guidanceSummary = summarizeInstructions(skill.instructionsMarkdown);
 
     if (shownSkillIds.has(skill.id)) {
-      // Short format for already-seen skills
+      // Short format for already-seen skills.
+      // 既読 skill はトークン節約のため level に関わらず 1 行 Guidance に揃える。
       lines.push(`- ${skill.name} (id: ${skill.id}): ${skill.description}`);
       if (guidanceSummary) {
         lines.push(`  Guidance: ${guidanceSummary}`);
@@ -134,8 +177,19 @@ function renderSkillEntries(
     const target = skill.scope === "global" ? "any page" : skill.matchers.hosts.join(", ");
     lines.push(`**${skill.name}** (id: ${skill.id}, ${target})`);
     lines.push(skill.description);
+
     if (guidanceSummary) {
-      lines.push(`Guidance: ${guidanceSummary}`);
+      if (activationLevel === "contextual") {
+        const paragraph = contextualInstructionParagraph(skill.instructionsMarkdown) ?? [
+          guidanceSummary,
+        ];
+        lines.push("Guidance (contextual):");
+        for (const bodyLine of paragraph) {
+          lines.push(`- ${bodyLine}`);
+        }
+      } else {
+        lines.push(`Guidance: ${guidanceSummary}`);
+      }
     }
     lines.push("");
 

--- a/src/features/tools/skills/__tests__/registry.test.ts
+++ b/src/features/tools/skills/__tests__/registry.test.ts
@@ -311,4 +311,63 @@ describe("findMatchingSkills with confidence", () => {
 
     expect(withDom[0].confidence).toBeGreaterThan(withoutDom[0].confidence);
   });
+
+  describe("activation level", () => {
+    it("host-only match (no matchers.paths) は passive として返る", () => {
+      const registry = new SkillRegistry();
+      const skill = createTestSkill({
+        id: "github-broad",
+        matchers: { hosts: ["github.com"] },
+      });
+      registry.register(skill);
+
+      const matches = registry.findMatchingSkills("https://github.com/owner/repo");
+      expect(matches).toHaveLength(1);
+      expect(matches[0].activationLevel).toBe("passive");
+    });
+
+    it("paths が定義されている skill は path 一致時に contextual として返る", () => {
+      const registry = new SkillRegistry();
+      const skill = createTestSkill({
+        id: "github-tree",
+        matchers: { hosts: ["github.com"], paths: ["/*/*/tree/**"] },
+      });
+      registry.register(skill);
+
+      const matches = registry.findMatchingSkills("https://github.com/owner/repo/tree/main");
+      expect(matches).toHaveLength(1);
+      expect(matches[0].activationLevel).toBe("contextual");
+    });
+
+    it("同じ host-scoped skill に path 一致 / 不一致 の URL があると contextual / 非対象に分かれる", () => {
+      const registry = new SkillRegistry();
+      const treeSkill = createTestSkill({
+        id: "github-tree",
+        matchers: { hosts: ["github.com"], paths: ["/*/*/tree/**"] },
+      });
+      registry.register(treeSkill);
+
+      const onTree = registry.findMatchingSkills("https://github.com/owner/repo/tree/main");
+      const onIssue = registry.findMatchingSkills("https://github.com/owner/repo/issues/123");
+
+      expect(onTree.map((m) => m.skill.id)).toEqual(["github-tree"]);
+      expect(onTree[0].activationLevel).toBe("contextual");
+      // path が合わないと registry レベルで除外される → 過剰な activation を未然に防ぐ
+      expect(onIssue).toEqual([]);
+    });
+
+    it("global skill は常に passive として返る", () => {
+      const registry = new SkillRegistry();
+      const skill = createTestSkill({
+        id: "dom-mutation",
+        scope: "global",
+        matchers: { hosts: [] },
+      });
+      registry.register(skill);
+
+      const matches = registry.getGlobalSkills();
+      expect(matches).toHaveLength(1);
+      expect(matches[0].activationLevel).toBe("passive");
+    });
+  });
 });

--- a/src/shared/skill-registry.ts
+++ b/src/shared/skill-registry.ts
@@ -54,6 +54,9 @@ export class SkillRegistry {
         skill,
         availableExtractors: skill.extractors,
         confidence: 100,
+        // Global skills cover any page, so host alone is never a strong signal.
+        // Keep guidance passive until a stronger activation rule is added.
+        activationLevel: "passive" as const,
       }));
   }
 
@@ -144,11 +147,19 @@ export class SkillRegistry {
 
         return true;
       })
-      .map((skill) => ({
-        skill,
-        availableExtractors: skill.extractors,
-        confidence: this.calculateConfidence(skill, url, domSnapshot),
-      }))
+      .map((skill): SkillMatch => {
+        // Path-scoped skills narrow the match beyond a broad host, so instruction
+        // guidance is task-relevant enough for contextual activation.
+        // Host-only skills stay passive to avoid over-firing on unrelated pages
+        // (e.g. repo-analysis guidance on a GitHub issue-comment task).
+        const pathMatched = skill.matchers.paths !== undefined && skill.matchers.paths.length > 0;
+        return {
+          skill,
+          availableExtractors: skill.extractors,
+          confidence: this.calculateConfidence(skill, url, domSnapshot),
+          activationLevel: pathMatched ? "contextual" : "passive",
+        };
+      })
       .filter((match) => match.confidence >= minConfidence)
       .sort((a, b) => b.confidence - a.confidence);
   }

--- a/src/shared/skill-types.ts
+++ b/src/shared/skill-types.ts
@@ -42,10 +42,18 @@ export interface SkillExtractor {
   outputSchema: string;
 }
 
+/**
+ * Instruction activation level: どれだけ強く guidance を prompt に出すかを決める。
+ * - passive: skill が match しただけ (host-only / global)。ノイズを避けるため 1 行だけ出す
+ * - contextual: path 等が一致して skill が task に近い状況。より詳細な guidance を出す
+ */
+export type SkillActivationLevel = "passive" | "contextual";
+
 export interface SkillMatch {
   skill: Skill;
   availableExtractors: SkillExtractor[];
   confidence: number;
+  activationLevel?: SkillActivationLevel;
 }
 
 export interface SkillParseSuccess {


### PR DESCRIPTION
Closes #162

## Summary
Broad host matches で task-specific guidance が過剰発火する問題 (例: `github.com` にいるだけで repo-analysis guidance が毎回強く効く) を防ぐため、**skill match** と **instruction activation** を分離する。

- `SkillActivationLevel = "passive" | "contextual"` を追加し `SkillMatch` に持たせる
- Registry が match 時に level を割り当てる:
  - **global skill**: 常に `passive`
  - **site skill, `matchers.paths` あり (URL が path にマッチ)**: `contextual`
  - **site skill, host-only**: `passive`
  - path 不一致は従来通り `findMatchingSkills` で除外される
- Prompt 表示:
  - `passive`: 従来通り `Guidance: <1 行>`
  - `contextual`: `Guidance (contextual):` ヘッダ + 先頭パラグラフ (最大 4 行) を bullet で列挙
  - 既読 skill の短縮形式は level に関わらず 1 行 Guidance に揃える (token cost を安定させる)
- `summarizeInstructions` と `contextualInstructionParagraph` が同じ fence-aware body iterator を共有 → コードフェンス / 見出しの扱いが一貫

## Scope out
- DOM-indicator / extractor-scoped caution / intent hints は Issue 5 以降に回す
- `active` level および intent classification は現段階では未導入 (設計書通り lightweight スタート)

## Test plan
- [x] \`npx vitest run\` 全 1137 テスト green (+8)
- [x] \`npx vp check\` (format + lint) 変更ファイル通過
- [x] \`npx vp lint\` リポジトリ全体 0 warnings / 0 errors
- [x] Registry テスト: host-only passive / paths-matched contextual / path 不一致で除外 / global 常に passive
- [x] Prompt テスト: passive 1 行 / contextual 複数行 + ヘッダ / activationLevel 無しで passive fallback / 既読短縮形式は level に関わらず 1 行

🤖 Generated with [Claude Code](https://claude.com/claude-code)