### PR TITLE
fix(prompt): tighten skill activation rules and add extractor cautions

### DIFF
--- a/src/features/ai/__tests__/system-prompt-v2.test.ts
+++ b/src/features/ai/__tests__/system-prompt-v2.test.ts
@@ -541,8 +541,10 @@ describe("skill instruction activation level", () => {
     const section = generateSkillsSectionForLoop([skill], new Set());
 
     expect(section).toContain("Guidance (contextual):");
-    expect(section).toContain("- repo 全体の分析では API / bgFetch を優先すること。");
-    expect(section).toContain("- DOM extractor は可視範囲の補助取得に限定する。");
+    expect(section).toContain("  > repo 全体の分析では API / bgFetch を優先すること。");
+    expect(section).toContain("  > DOM extractor は可視範囲の補助取得に限定する。");
+    // Non-bullet prefix keeps Guidance visually distinct from extractor APIs.
+    expect(section).not.toContain("- repo 全体の分析では");
     // Content after the blank line (next paragraph) is still not injected.
     expect(section).not.toContain("次のセクションに書かれた詳細");
   });
@@ -565,5 +567,113 @@ describe("skill instruction activation level", () => {
     expect(section).toContain("  Guidance: repo 全体の分析では");
     expect(section).not.toContain("Guidance (contextual):");
     expect(section).not.toContain("- DOM extractor は可視範囲");
+  });
+
+  it("renders a mixed skill (extractors + contextual guidance) without merging the Guidance lines into the extractor bullets", () => {
+    const extractor = {
+      id: "getFileList",
+      name: "Get File List",
+      description: "リポジトリ内のファイル一覧を取得する",
+      code: "function () { return []; }",
+      outputSchema: "string[]",
+    };
+    const mixed: SkillMatch = {
+      skill: {
+        id: "gh-repo",
+        name: "GitHub Repo",
+        description: "GitHub リポジトリの分析",
+        matchers: { hosts: ["github.com"], paths: ["/*/*/tree/**"] },
+        version: "0.2.0",
+        extractors: [extractor],
+        instructionsMarkdown:
+          "repo 全体の分析では API / bgFetch を優先すること。\nDOM extractor は可視範囲の補助取得に限定する。",
+      },
+      availableExtractors: [extractor],
+      confidence: 100,
+      activationLevel: "contextual",
+    };
+
+    const section = generateSkillsSectionForLoop([mixed], new Set());
+
+    expect(section).toContain("Guidance (contextual):");
+    // Guidance uses '  > ' so it doesn't visually merge with '-' extractor bullets.
+    expect(section).toContain("  > repo 全体の分析では API / bgFetch を優先すること。");
+    expect(section).toContain("- getFileList(): string[] — リポジトリ内のファイル一覧を取得する");
+    // Guidance body must not be rendered as an extractor-style bullet.
+    expect(section).not.toContain("- repo 全体の分析では");
+    expect(section).not.toContain("- DOM extractor は可視範囲");
+  });
+
+  it("attaches extractor-scoped cautions parsed from `## Extractor: <id>` blocks to the matching extractor bullet", () => {
+    const extractor = {
+      id: "getVisibleFileList",
+      name: "Get Visible File List",
+      description: "現在表示中のファイルの一覧",
+      code: "function () { return []; }",
+      outputSchema: "string[]",
+    };
+    const skill: SkillMatch = {
+      skill: {
+        id: "gh-repo",
+        name: "GitHub Repo",
+        description: "GitHub リポジトリの分析",
+        matchers: { hosts: ["github.com"], paths: ["/*/*/tree/**"] },
+        version: "0.2.0",
+        extractors: [extractor],
+        instructionsMarkdown: [
+          "repo 分析では API / bgFetch を優先すること。",
+          "",
+          "## Extractor: getVisibleFileList",
+          "この extractor は可視範囲のみを返す。tree 全体ではない。",
+        ].join("\n"),
+      },
+      availableExtractors: [extractor],
+      confidence: 100,
+      activationLevel: "contextual",
+    };
+
+    const section = generateSkillsSectionForLoop([skill], new Set());
+
+    expect(section).toContain(
+      "  Caution: この extractor は可視範囲のみを返す。tree 全体ではない。",
+    );
+    // Top-level Guidance must not duplicate extractor-scoped content: Guidance
+    // body uses "  > " and extractor caution uses "  Caution: ", so the phrase
+    // must never appear under the "  > " prefix.
+    expect(section).not.toContain("  > この extractor は可視範囲のみを返す");
+  });
+
+  it("does not attach a caution when an `## Extractor:` block references an unknown extractor", () => {
+    const extractor = {
+      id: "getTitle",
+      name: "Get Title",
+      description: "ページタイトルを取得する",
+      code: "function () { return document.title; }",
+      outputSchema: "string",
+    };
+    const skill: SkillMatch = {
+      skill: {
+        id: "gh-repo",
+        name: "GitHub Repo",
+        description: "desc",
+        matchers: { hosts: ["github.com"], paths: ["/*/*/tree/**"] },
+        version: "0.2.0",
+        extractors: [extractor],
+        instructionsMarkdown: [
+          "repo 分析では API を優先すること。",
+          "",
+          "## Extractor: missingExtractor",
+          "このセクションはどの extractor にも紐付かない。",
+        ].join("\n"),
+      },
+      availableExtractors: [extractor],
+      confidence: 100,
+      activationLevel: "contextual",
+    };
+
+    const section = generateSkillsSectionForLoop([skill], new Set());
+
+    expect(section).not.toContain("Caution:");
+    expect(section).not.toContain("このセクションはどの extractor にも紐付かない");
   });
 });

--- a/src/features/ai/system-prompt-v2.ts
+++ b/src/features/ai/system-prompt-v2.ts
@@ -48,69 +48,154 @@ function isPromptVisibleSkill(match: SkillMatch): boolean {
 }
 
 /**
- * 本文行かどうか。見出し / 空行 / コードフェンスは本文ではない。
- * 共通の fence tracking を closure で持つため、反復ごとに状態が進む。
+ * 本文行を行配列として返す。見出し / コードフェンス内はスキップ。
+ * 空行は paragraph 区切りとして空文字で保持する。
  */
-function makeBodyLineIterator(instructionsMarkdown: string): Generator<string, void, unknown> {
-  return (function* () {
-    let inFence = false;
-    for (const raw of instructionsMarkdown.split("\n")) {
-      if (/^\s*```/.test(raw)) {
-        inFence = !inFence;
-        continue;
-      }
-      if (inFence) continue;
-      const line = raw.trim();
-      if (line.length === 0) {
-        // 空行は paragraph 区切りとしても使いたいので yield する
-        yield "";
-        continue;
-      }
-      if (/^#{1,6}\s/.test(line)) continue;
-      const cleaned = line.replace(/^[-*+]\s+/, "").trim();
-      if (cleaned.length === 0) continue;
-      yield cleaned;
+function collectBodyLines(instructionsMarkdown: string): string[] {
+  const out: string[] = [];
+  let inFence = false;
+  for (const raw of instructionsMarkdown.split("\n")) {
+    if (/^\s*```/.test(raw)) {
+      inFence = !inFence;
+      continue;
     }
-  })();
+    if (inFence) continue;
+    const line = raw.trim();
+    if (line.length === 0) {
+      out.push("");
+      continue;
+    }
+    if (/^#{1,6}\s/.test(line)) continue;
+    const cleaned = line.replace(/^[-*+]\s+/, "").trim();
+    if (cleaned.length === 0) continue;
+    out.push(cleaned);
+  }
+  return out;
+}
+
+function clampSummaryLength(line: string): string {
+  if (line.length <= INSTRUCTION_SUMMARY_MAX_LEN) return line;
+  return `${line.slice(0, INSTRUCTION_SUMMARY_MAX_LEN - 1)}…`;
 }
 
 /**
  * instructionsMarkdown の先頭本文から 1 行のサマリを作る (passive activation)。
  * 見出し / 空行 / リスト記号 / コードフェンス内は除去し、
  * INSTRUCTION_SUMMARY_MAX_LEN で打ち切る。
+ * extractor 専用 caution は extractor bullet 側で扱うので summary には含めない。
  */
 function summarizeInstructions(instructionsMarkdown: string | undefined): string | null {
   if (!instructionsMarkdown) return null;
-  for (const line of makeBodyLineIterator(instructionsMarkdown)) {
+  const topLevel = stripExtractorSections(instructionsMarkdown);
+  for (const line of collectBodyLines(topLevel)) {
     if (line === "") continue;
-    if (line.length <= INSTRUCTION_SUMMARY_MAX_LEN) return line;
-    return `${line.slice(0, INSTRUCTION_SUMMARY_MAX_LEN - 1)}…`;
+    return clampSummaryLength(line);
   }
   return null;
 }
 
 /**
+ * extractor-scoped section (`## Extractor: <id>`) を markdown から除去する。
+ * 次の `##` 見出しが来るまで、あるいは最後まで読み飛ばす。
+ * contextual 要約が extractor 専用 caution を取り込まないようにするため。
+ */
+function stripExtractorSections(instructionsMarkdown: string): string {
+  const lines = instructionsMarkdown.split("\n");
+  const out: string[] = [];
+  let inExtractorBlock = false;
+  for (const raw of lines) {
+    const trimmed = raw.trim();
+    const isExtractorHeading = /^##\s+Extractor:\s+.+$/.test(trimmed);
+    const isOtherHeading = !isExtractorHeading && /^##\s+/.test(trimmed);
+    if (isExtractorHeading) {
+      inExtractorBlock = true;
+      continue;
+    }
+    if (isOtherHeading) {
+      inExtractorBlock = false;
+    }
+    if (inExtractorBlock) continue;
+    out.push(raw);
+  }
+  return out.join("\n");
+}
+
+/**
  * contextual activation 用に先頭パラグラフ (連続本文行の塊) を返す。
  * 最大 CONTEXTUAL_PARAGRAPH_MAX_LINES 行まで。全文注入は避ける。
+ * extractor 専用 caution は extractor bullet 側で扱うのでここには含めない。
  */
-function contextualInstructionParagraph(instructionsMarkdown: string | undefined): string[] | null {
-  if (!instructionsMarkdown) return null;
+function contextualInstructionParagraph(instructionsMarkdown: string): string[] {
+  const topLevel = stripExtractorSections(instructionsMarkdown);
   const collected: string[] = [];
   let started = false;
-  for (const line of makeBodyLineIterator(instructionsMarkdown)) {
+  for (const line of collectBodyLines(topLevel)) {
     if (line === "") {
-      if (started) break; // 最初のパラグラフ終了
+      if (started) break;
       continue;
     }
     started = true;
-    if (line.length <= INSTRUCTION_SUMMARY_MAX_LEN) {
-      collected.push(line);
-    } else {
-      collected.push(`${line.slice(0, INSTRUCTION_SUMMARY_MAX_LEN - 1)}…`);
-    }
+    collected.push(clampSummaryLength(line));
     if (collected.length >= CONTEXTUAL_PARAGRAPH_MAX_LINES) break;
   }
-  return collected.length > 0 ? collected : null;
+  return collected;
+}
+
+/**
+ * `## Extractor: <id>` ブロック直下の本文を extractor ごとに抽出する。
+ * extractor ID をキーに、本文の 1 行目 (passive summary と同じ切り詰め) を値として返す。
+ * 他のセクションがあるまで本文を読む。全文注入はしない (1 行に要約)。
+ */
+function extractExtractorCautions(instructionsMarkdown: string | undefined): Map<string, string> {
+  const result = new Map<string, string>();
+  if (!instructionsMarkdown) return result;
+
+  const lines = instructionsMarkdown.split("\n");
+  let inFence = false;
+  let currentId: string | null = null;
+  let currentBody: string[] = [];
+
+  const finalize = () => {
+    if (!currentId) return;
+    for (const body of currentBody) {
+      if (body === "") continue;
+      result.set(currentId, clampSummaryLength(body));
+      break;
+    }
+    currentId = null;
+    currentBody = [];
+  };
+
+  for (const raw of lines) {
+    if (/^\s*```/.test(raw)) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) continue;
+
+    const trimmed = raw.trim();
+    const extractorMatch = /^##\s+Extractor:\s*(.+?)\s*$/.exec(trimmed);
+    if (extractorMatch) {
+      finalize();
+      currentId = extractorMatch[1];
+      continue;
+    }
+    if (/^#{1,6}\s/.test(trimmed)) {
+      // Any other heading terminates the current extractor block.
+      finalize();
+      continue;
+    }
+
+    if (currentId === null) continue;
+    if (trimmed.length === 0) {
+      if (currentBody.length > 0) currentBody.push("");
+      continue;
+    }
+    const cleaned = trimmed.replace(/^[-*+]\s+/, "").trim();
+    if (cleaned.length > 0) currentBody.push(cleaned);
+  }
+  finalize();
+  return result;
 }
 
 function generateSkillsSection(
@@ -160,7 +245,9 @@ function renderSkillEntries(
   for (const match of skills) {
     const { skill, availableExtractors } = match;
     const activationLevel = match.activationLevel ?? "passive";
-    const guidanceSummary = summarizeInstructions(skill.instructionsMarkdown);
+    const instructionsMarkdown = skill.instructionsMarkdown;
+    const guidanceSummary = summarizeInstructions(instructionsMarkdown);
+    const extractorCautions = extractExtractorCautions(instructionsMarkdown);
 
     if (shownSkillIds.has(skill.id)) {
       // Short format for already-seen skills.
@@ -179,13 +266,13 @@ function renderSkillEntries(
     lines.push(skill.description);
 
     if (guidanceSummary) {
-      if (activationLevel === "contextual") {
-        const paragraph = contextualInstructionParagraph(skill.instructionsMarkdown) ?? [
-          guidanceSummary,
-        ];
+      // Use a non-bullet prefix so Guidance lines do not visually blend with
+      // the extractor API bullets below (both used "- " previously).
+      if (activationLevel === "contextual" && instructionsMarkdown !== undefined) {
+        const paragraph = contextualInstructionParagraph(instructionsMarkdown);
         lines.push("Guidance (contextual):");
-        for (const bodyLine of paragraph) {
-          lines.push(`- ${bodyLine}`);
+        for (const bodyLine of paragraph.length > 0 ? paragraph : [guidanceSummary]) {
+          lines.push(`  > ${bodyLine}`);
         }
       } else {
         lines.push(`Guidance: ${guidanceSummary}`);
@@ -195,7 +282,11 @@ function renderSkillEntries(
 
     if (availableExtractors.length > 0) {
       for (const ext of availableExtractors) {
+        const caution = extractorCautions.get(ext.id);
         lines.push(`- ${ext.id}(): ${ext.outputSchema} — ${ext.description}`);
+        if (caution) {
+          lines.push(`  Caution: ${caution}`);
+        }
       }
 
       lines.push("");

--- a/src/features/tools/skills/__tests__/registry.test.ts
+++ b/src/features/tools/skills/__tests__/registry.test.ts
@@ -369,5 +369,44 @@ describe("findMatchingSkills with confidence", () => {
       expect(matches).toHaveLength(1);
       expect(matches[0].activationLevel).toBe("passive");
     });
+
+    it("catch-all の paths (/**) しか持たない skill は passive のままにする", () => {
+      const registry = new SkillRegistry();
+      const skill = createTestSkill({
+        id: "broad-skill",
+        matchers: { hosts: ["example.com"], paths: ["/**"] },
+      });
+      registry.register(skill);
+
+      const matches = registry.findMatchingSkills("https://example.com/anywhere");
+      expect(matches).toHaveLength(1);
+      expect(matches[0].activationLevel).toBe("passive");
+    });
+
+    it("ルート / のみの paths も passive として扱う", () => {
+      const registry = new SkillRegistry();
+      const skill = createTestSkill({
+        id: "root-only",
+        matchers: { hosts: ["example.com"], paths: ["/"] },
+      });
+      registry.register(skill);
+
+      const matches = registry.findMatchingSkills("https://example.com/anywhere");
+      expect(matches).toHaveLength(1);
+      expect(matches[0].activationLevel).toBe("passive");
+    });
+
+    it("catch-all と specific path が混在するときは specific path があれば contextual に昇格", () => {
+      const registry = new SkillRegistry();
+      const skill = createTestSkill({
+        id: "mixed-paths",
+        matchers: { hosts: ["github.com"], paths: ["/**", "/*/*/tree/**"] },
+      });
+      registry.register(skill);
+
+      const matches = registry.findMatchingSkills("https://github.com/owner/repo/tree/main");
+      expect(matches).toHaveLength(1);
+      expect(matches[0].activationLevel).toBe("contextual");
+    });
   });
 });

--- a/src/shared/skill-registry.ts
+++ b/src/shared/skill-registry.ts
@@ -148,19 +148,31 @@ export class SkillRegistry {
         return true;
       })
       .map((skill): SkillMatch => {
-        // Path-scoped skills narrow the match beyond a broad host, so instruction
-        // guidance is task-relevant enough for contextual activation.
-        // Host-only skills stay passive to avoid over-firing on unrelated pages
-        // (e.g. repo-analysis guidance on a GitHub issue-comment task).
-        const pathMatched = skill.matchers.paths !== undefined && skill.matchers.paths.length > 0;
+        // Specific path-scoped skills narrow the match beyond a broad host, so
+        // instruction guidance is task-relevant enough for contextual activation.
+        // Host-only skills, or skills whose paths are all catch-alls like "/"
+        // or "/**", stay passive so we don't over-fire task-specific guidance
+        // on unrelated pages (e.g. repo-analysis guidance on a GitHub
+        // issue-comment task).
+        const hasSpecificPath = (skill.matchers.paths ?? []).some(isSpecificPathPattern);
         return {
           skill,
           availableExtractors: skill.extractors,
           confidence: this.calculateConfidence(skill, url, domSnapshot),
-          activationLevel: pathMatched ? "contextual" : "passive",
+          activationLevel: hasSpecificPath ? "contextual" : "passive",
         };
       })
       .filter((match) => match.confidence >= minConfidence)
       .sort((a, b) => b.confidence - a.confidence);
   }
+}
+
+// A path pattern is "specific" if it contains at least one non-wildcard
+// segment (for example `/repos/` or a segment like `tree`). Purely wildcard
+// patterns such as `/`, a single wildcard segment, or double-wildcard match
+// every page on the host and give no more information than the host itself.
+function isSpecificPathPattern(pattern: string): boolean {
+  const segments = pattern.split("/").filter((seg) => seg.length > 0);
+  if (segments.length === 0) return false;
+  return segments.some((seg) => !/^\*+$/.test(seg));
 }


### PR DESCRIPTION
Follow-up to #162 to close gaps flagged in the review.

## Summary
1. **Extractor-relevance activation を実装** (最大の穴): `instructionsMarkdown` に含まれる \`## Extractor: <id>\` ブロックを parse し、対応する extractor bullet の下に \`Caution: ...\` を付加。未知の id は無視するので orphan block は prompt に出ない
2. **catch-all path を passive に降格**: \`matchers.paths\` が \`/\`, \`/*\`, \`/**\` のような全マッチパターンだけだと contextual に昇格しない。少なくとも 1 つは specific なセグメント (\`/repos/\`, \`tree\` 等) が必要
3. **Guidance の bullet prefix を \`- \` から \`  > \` に変更**: extractor API bullet (\`- fn(): type — desc\`) と視覚的に衝突しないようにする
4. **リファクタ**: \`makeBodyLineIterator\` (Generator) → \`collectBodyLines\` (plain \`string[]\`) に置換、\`clampSummaryLength\` helper 抽出、dead fallback 削除、\`pathMatched\` → \`hasSpecificPath\` に改名。\`summarizeInstructions\` / \`contextualInstructionParagraph\` は top-level guidance から \`## Extractor:\` ブロックを除外

## Test plan
- [x] \`npx vitest run\` 全 1143 テスト green (+6)
- [x] \`npx vp check\` (format + lint) 変更ファイル通過
- [x] \`npx vp lint\` リポジトリ全体 0 warnings / 0 errors
- [x] Prompt テスト: mixed skill の bullet 衝突防止 / extractor caution 付加 / 未知 id で caution なし
- [x] Registry テスト: catch-all \`/\` / \`/**\` で passive / specific mixed で contextual 昇格

🤖 Generated with [Claude Code](https://claude.com/claude-code)