### PR TITLE
fix(skill): close two debts flagged in the 5-issue overall review

### DIFF
--- a/src/features/ai/__tests__/system-prompt-v2.test.ts
+++ b/src/features/ai/__tests__/system-prompt-v2.test.ts
@@ -643,6 +643,41 @@ describe("skill instruction activation level", () => {
     expect(section).not.toContain("  > この extractor は可視範囲のみを返す");
   });
 
+  it("treats `## Extractor:` inside a fenced code block as documentation, not as an extractor-scoped section", () => {
+    // instruction body が skill 書式の例としてコードフェンス内に
+    // `## Extractor: <id>` を書いている場合、section marker として扱ってはいけない。
+    // fence 無しで section marker 扱いすると、fence 以降の本文ごと
+    // `stripExtractorSections` で削除され、Guidance の要約から本文が失われる。
+    const skill: SkillMatch = {
+      skill: {
+        id: "doc-skill",
+        name: "Doc Skill",
+        description: "instructions with a fenced example referencing ## Extractor:",
+        matchers: { hosts: ["example.com"], paths: ["/docs/**"] },
+        version: "0.1.0",
+        extractors: [],
+        instructionsMarkdown: [
+          "まず docstring を優先して読む。",
+          "```md",
+          "## Extractor: example",
+          "これは書式例で extractor ではない。",
+          "```",
+          "fence の後ろの本文もちゃんと読まれる必要がある。",
+        ].join("\n"),
+      },
+      availableExtractors: [],
+      confidence: 100,
+      activationLevel: "contextual",
+    };
+
+    const section = generateSkillsSectionForLoop([skill], new Set());
+    // fence の前の本文と後ろの本文の両方が contextual paragraph に残るべき。
+    expect(section).toContain("まず docstring を優先して読む。");
+    expect(section).toContain("fence の後ろの本文もちゃんと読まれる必要がある。");
+    // fence 内の `## Extractor: example` 自体は body iterator が fence 内を skip するため出ない。
+    expect(section).not.toContain("## Extractor: example");
+  });
+
   it("does not attach a caution when an `## Extractor:` block references an unknown extractor", () => {
     const extractor = {
       id: "getTitle",

--- a/src/features/ai/system-prompt-v2.ts
+++ b/src/features/ai/system-prompt-v2.ts
@@ -1,3 +1,4 @@
+import { iterateAllMarkdownLines, iterateMarkdownBody } from "@/shared/markdown-section";
 import type { SkillMatch } from "@/shared/skill-types";
 import {
   CORE_IDENTITY,
@@ -53,20 +54,13 @@ function isPromptVisibleSkill(match: SkillMatch): boolean {
  */
 function collectBodyLines(instructionsMarkdown: string): string[] {
   const out: string[] = [];
-  let inFence = false;
-  for (const raw of instructionsMarkdown.split("\n")) {
-    if (/^\s*```/.test(raw)) {
-      inFence = !inFence;
-      continue;
-    }
-    if (inFence) continue;
-    const line = raw.trim();
-    if (line.length === 0) {
+  for (const line of iterateMarkdownBody(instructionsMarkdown)) {
+    if (line.isBlank) {
       out.push("");
       continue;
     }
-    if (/^#{1,6}\s/.test(line)) continue;
-    const cleaned = line.replace(/^[-*+]\s+/, "").trim();
+    if (line.isHeading) continue;
+    const cleaned = line.trimmed.replace(/^[-*+]\s+/, "").trim();
     if (cleaned.length === 0) continue;
     out.push(cleaned);
   }
@@ -98,13 +92,22 @@ function summarizeInstructions(instructionsMarkdown: string | undefined): string
  * extractor-scoped section (`## Extractor: <id>`) を markdown から除去する。
  * 次の `##` 見出しが来るまで、あるいは最後まで読み飛ばす。
  * contextual 要約が extractor 専用 caution を取り込まないようにするため。
+ *
+ * fence 内部の `## Extractor:` は section marker ではなくコード中のテキストなので
+ * 除去対象から外す (例: instruction でスキル書式の例を示しているケース)。
  */
 function stripExtractorSections(instructionsMarkdown: string): string {
-  const lines = instructionsMarkdown.split("\n");
   const out: string[] = [];
   let inExtractorBlock = false;
-  for (const raw of lines) {
-    const trimmed = raw.trim();
+  for (const { raw, trimmed, inFence, isFenceMarker } of iterateAllMarkdownLines(
+    instructionsMarkdown,
+  )) {
+    // fence marker / 内部は常に保持し、section 判定には使わない。
+    if (isFenceMarker || inFence) {
+      inExtractorBlock = false;
+      out.push(raw);
+      continue;
+    }
     const isExtractorHeading = /^##\s+Extractor:\s+.+$/.test(trimmed);
     const isOtherHeading = !isExtractorHeading && /^##\s+/.test(trimmed);
     if (isExtractorHeading) {
@@ -150,8 +153,6 @@ function extractExtractorCautions(instructionsMarkdown: string | undefined): Map
   const result = new Map<string, string>();
   if (!instructionsMarkdown) return result;
 
-  const lines = instructionsMarkdown.split("\n");
-  let inFence = false;
   let currentId: string | null = null;
   let currentBody: string[] = [];
 
@@ -166,32 +167,25 @@ function extractExtractorCautions(instructionsMarkdown: string | undefined): Map
     currentBody = [];
   };
 
-  for (const raw of lines) {
-    if (/^\s*```/.test(raw)) {
-      inFence = !inFence;
-      continue;
-    }
-    if (inFence) continue;
-
-    const trimmed = raw.trim();
-    const extractorMatch = /^##\s+Extractor:\s*(.+?)\s*$/.exec(trimmed);
+  for (const line of iterateMarkdownBody(instructionsMarkdown)) {
+    const extractorMatch = /^##\s+Extractor:\s*(.+?)\s*$/.exec(line.trimmed);
     if (extractorMatch) {
       finalize();
       currentId = extractorMatch[1];
       continue;
     }
-    if (/^#{1,6}\s/.test(trimmed)) {
+    if (line.isHeading) {
       // Any other heading terminates the current extractor block.
       finalize();
       continue;
     }
 
     if (currentId === null) continue;
-    if (trimmed.length === 0) {
+    if (line.isBlank) {
       if (currentBody.length > 0) currentBody.push("");
       continue;
     }
-    const cleaned = trimmed.replace(/^[-*+]\s+/, "").trim();
+    const cleaned = line.trimmed.replace(/^[-*+]\s+/, "").trim();
     if (cleaned.length > 0) currentBody.push(cleaned);
   }
   finalize();

--- a/src/features/tools/skills/__tests__/registry.test.ts
+++ b/src/features/tools/skills/__tests__/registry.test.ts
@@ -408,5 +408,21 @@ describe("findMatchingSkills with confidence", () => {
       expect(matches).toHaveLength(1);
       expect(matches[0].activationLevel).toBe("contextual");
     });
+
+    it("catch-all と specific の混在でも、実際に match したのが catch-all だけなら passive のまま", () => {
+      // GitHub の issue ページは `/**` だけがマッチし、`/*/*/tree/**` はマッチしない。
+      // 「skill の paths に specific なものが 1 つでもあれば contextual」
+      // だと repo-analysis guidance が issue タスクで過剰発火する。
+      const registry = new SkillRegistry();
+      const skill = createTestSkill({
+        id: "mixed-paths",
+        matchers: { hosts: ["github.com"], paths: ["/**", "/*/*/tree/**"] },
+      });
+      registry.register(skill);
+
+      const matches = registry.findMatchingSkills("https://github.com/owner/repo/issues/123");
+      expect(matches).toHaveLength(1);
+      expect(matches[0].activationLevel).toBe("passive");
+    });
   });
 });

--- a/src/shared/__tests__/markdown-section.test.ts
+++ b/src/shared/__tests__/markdown-section.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import {
+  isFenceMarkerLine,
+  iterateAllMarkdownLines,
+  iterateMarkdownBody,
+} from "../markdown-section";
+
+describe("isFenceMarkerLine", () => {
+  it("matches plain ``` and language-tagged fences", () => {
+    expect(isFenceMarkerLine("```")).toBe(true);
+    expect(isFenceMarkerLine("```js")).toBe(true);
+    expect(isFenceMarkerLine("```md")).toBe(true);
+  });
+
+  it("tolerates leading whitespace", () => {
+    expect(isFenceMarkerLine("  ```")).toBe(true);
+  });
+
+  it("does not match text that merely contains backticks", () => {
+    expect(isFenceMarkerLine("use `foo` to call")).toBe(false);
+    expect(isFenceMarkerLine("text then ``` inline")).toBe(false);
+  });
+});
+
+describe("iterateMarkdownBody", () => {
+  it("skips lines inside fenced code blocks", () => {
+    const md = ["body before", "```js", "codeLine1()", "codeLine2()", "```", "body after"].join(
+      "\n",
+    );
+    const lines = Array.from(iterateMarkdownBody(md)).map((l) => l.trimmed);
+    expect(lines).toEqual(["body before", "body after"]);
+  });
+
+  it("emits blank lines so callers can detect paragraph breaks", () => {
+    const md = "first\n\nsecond";
+    const lines = Array.from(iterateMarkdownBody(md));
+    expect(lines.map((l) => ({ trimmed: l.trimmed, isBlank: l.isBlank }))).toEqual([
+      { trimmed: "first", isBlank: false },
+      { trimmed: "", isBlank: true },
+      { trimmed: "second", isBlank: false },
+    ]);
+  });
+
+  it("flags markdown headings with the correct level", () => {
+    const md = "# h1\n## h2\n### h3\nbody";
+    const lines = Array.from(iterateMarkdownBody(md));
+    expect(lines.map((l) => ({ level: l.headingLevel, isHeading: l.isHeading }))).toEqual([
+      { level: 1, isHeading: true },
+      { level: 2, isHeading: true },
+      { level: 3, isHeading: true },
+      { level: 0, isHeading: false },
+    ]);
+  });
+
+  it("does not flag text starting with # but no space as a heading", () => {
+    const md = "#notAHeading\n# realHeading";
+    const lines = Array.from(iterateMarkdownBody(md));
+    expect(lines[0].isHeading).toBe(false);
+    expect(lines[1].isHeading).toBe(true);
+  });
+});
+
+describe("iterateAllMarkdownLines", () => {
+  it("yields every line including fence markers and fenced content with inFence flags", () => {
+    const md = ["outer", "```", "inner", "```", "tail"].join("\n");
+    const events = Array.from(iterateAllMarkdownLines(md)).map((l) => ({
+      raw: l.raw,
+      inFence: l.inFence,
+      isFenceMarker: l.isFenceMarker,
+    }));
+
+    expect(events).toEqual([
+      { raw: "outer", inFence: false, isFenceMarker: false },
+      { raw: "```", inFence: false, isFenceMarker: true },
+      { raw: "inner", inFence: true, isFenceMarker: false },
+      { raw: "```", inFence: true, isFenceMarker: true },
+      { raw: "tail", inFence: false, isFenceMarker: false },
+    ]);
+  });
+});

--- a/src/shared/markdown-section.ts
+++ b/src/shared/markdown-section.ts
@@ -1,0 +1,77 @@
+/**
+ * fence-aware な markdown line 走査ユーティリティ。
+ *
+ * skill の instructionsMarkdown を扱う際、`# Instructions` / `# Extractors` のような
+ * top-level marker や `## Extractor:` block を検出したいが、fenced code block
+ * (\`\`\`...\`\`\`) 内に同じ見出し文字列が書かれても marker として扱ってはいけない。
+ * この fence tracking を複数箇所で個別実装するとずれが生まれるため、
+ * 共通の走査インターフェースに集約する。
+ */
+
+/** ``` で始まる code fence の開閉行かどうかを判定する。 */
+export function isFenceMarkerLine(raw: string): boolean {
+  return /^\s*```/.test(raw);
+}
+
+export interface MarkdownBodyLine {
+  /** 元の文字列 (trim 前)。 */
+  raw: string;
+  /** trim() 済みの文字列。 */
+  trimmed: string;
+  /** 空行 (trim 後に長さ 0) かどうか。 */
+  isBlank: boolean;
+  /** `# ` 始まりの見出しかどうか。 */
+  isHeading: boolean;
+  /** 見出しレベル (1-6)。非見出しは 0。 */
+  headingLevel: number;
+}
+
+/**
+ * fenced code block を読み飛ばしながら markdown 本文を 1 行ずつ yield する。
+ * fence marker 行自体も yield しない。空行は `isBlank: true` で yield するので、
+ * 呼び出し側で paragraph 区切りとして利用できる。
+ */
+export function* iterateMarkdownBody(markdown: string): Generator<MarkdownBodyLine> {
+  let inFence = false;
+  for (const raw of markdown.split("\n")) {
+    if (isFenceMarkerLine(raw)) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) continue;
+    const trimmed = raw.trim();
+    const headingMatch = /^(#{1,6})\s/.exec(trimmed);
+    yield {
+      raw,
+      trimmed,
+      isBlank: trimmed.length === 0,
+      isHeading: headingMatch !== null,
+      headingLevel: headingMatch ? headingMatch[1].length : 0,
+    };
+  }
+}
+
+export interface MarkdownLineWithFence {
+  raw: string;
+  trimmed: string;
+  inFence: boolean;
+  isFenceMarker: boolean;
+}
+
+/**
+ * fence marker 行や fence 内部も含めて全行を yield する。
+ * 出力 markdown を再構築する caller (例: セクション除去) 向け。
+ */
+export function* iterateAllMarkdownLines(markdown: string): Generator<MarkdownLineWithFence> {
+  let inFence = false;
+  for (const raw of markdown.split("\n")) {
+    const isFenceMarker = isFenceMarkerLine(raw);
+    yield {
+      raw,
+      trimmed: raw.trim(),
+      inFence,
+      isFenceMarker,
+    };
+    if (isFenceMarker) inFence = !inFence;
+  }
+}

--- a/src/shared/skill-parser.ts
+++ b/src/shared/skill-parser.ts
@@ -1,3 +1,4 @@
+import { iterateAllMarkdownLines } from "./markdown-section";
 import type { Skill, SkillParseResult } from "./skill-types";
 
 const INSTRUCTIONS_HEADING = /^#\s+Instructions\s*$/;
@@ -112,21 +113,17 @@ function splitInstructionsAndExtractors(body: string): SplitBody {
   const lines = body.split("\n");
   let instructionsIndex = -1;
   let extractorsIndex = -1;
-  let inCodeBlock = false;
 
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
-    if (/^\s*```/.test(line)) {
-      inCodeBlock = !inCodeBlock;
-      continue;
-    }
-    if (inCodeBlock) continue;
+  let i = -1;
+  for (const { raw, inFence, isFenceMarker } of iterateAllMarkdownLines(body)) {
+    i++;
+    if (isFenceMarker || inFence) continue;
 
-    if (instructionsIndex === -1 && INSTRUCTIONS_HEADING.test(line)) {
+    if (instructionsIndex === -1 && INSTRUCTIONS_HEADING.test(raw)) {
       instructionsIndex = i;
       continue;
     }
-    if (extractorsIndex === -1 && EXTRACTORS_HEADING.test(line)) {
+    if (extractorsIndex === -1 && EXTRACTORS_HEADING.test(raw)) {
       extractorsIndex = i;
     }
   }

--- a/src/shared/skill-registry.ts
+++ b/src/shared/skill-registry.ts
@@ -134,34 +134,35 @@ export class SkillRegistry {
 
     return Array.from(this.skills.values())
       .filter((skill) => skill.scope !== "global")
-      .filter((skill) => {
+      .map((skill): SkillMatch | null => {
         const hostMatch = skill.matchers.hosts.some(
           (pattern) => hostname === pattern || hostname.endsWith(`.${pattern}`),
         );
-        if (!hostMatch) return false;
+        if (!hostMatch) return null;
 
-        if (skill.matchers.paths) {
-          const pathMatch = skill.matchers.paths.some((pattern) => matchPath(pathname, pattern));
-          if (!pathMatch) return false;
+        // Compute activation from the patterns that actually matched the URL,
+        // not from the skill's whole path list. Otherwise a catch-all such as
+        // "/**" mixed with a specific pattern would always escalate to
+        // contextual even on URLs where only "/**" was the reason for match.
+        let activationLevel: "passive" | "contextual" = "passive";
+        if (skill.matchers.paths !== undefined) {
+          const matchedPatterns = skill.matchers.paths.filter((pattern) =>
+            matchPath(pathname, pattern),
+          );
+          if (matchedPatterns.length === 0) return null;
+          if (matchedPatterns.some(isSpecificPathPattern)) {
+            activationLevel = "contextual";
+          }
         }
 
-        return true;
-      })
-      .map((skill): SkillMatch => {
-        // Specific path-scoped skills narrow the match beyond a broad host, so
-        // instruction guidance is task-relevant enough for contextual activation.
-        // Host-only skills, or skills whose paths are all catch-alls like "/"
-        // or "/**", stay passive so we don't over-fire task-specific guidance
-        // on unrelated pages (e.g. repo-analysis guidance on a GitHub
-        // issue-comment task).
-        const hasSpecificPath = (skill.matchers.paths ?? []).some(isSpecificPathPattern);
         return {
           skill,
           availableExtractors: skill.extractors,
           confidence: this.calculateConfidence(skill, url, domSnapshot),
-          activationLevel: hasSpecificPath ? "contextual" : "passive",
+          activationLevel,
         };
       })
+      .filter((match): match is SkillMatch => match !== null)
       .filter((match) => match.confidence >= minConfidence)
       .sort((a, b) => b.confidence - a.confidence);
   }

--- a/src/shared/skill-validation.ts
+++ b/src/shared/skill-validation.ts
@@ -1,3 +1,4 @@
+import { iterateAllMarkdownLines } from "./markdown-section";
 import type { Skill } from "./skill-types";
 
 export interface ValidationError {
@@ -435,15 +436,9 @@ function collectSkillStructureErrors(skill: Skill): ValidationError[] {
 }
 
 function instructionsContainTopLevelSectionMarker(instructions: string): boolean {
-  const lines = instructions.split("\n");
-  let inFence = false;
-  for (const line of lines) {
-    if (/^\s*```/.test(line)) {
-      inFence = !inFence;
-      continue;
-    }
-    if (inFence) continue;
-    if (/^#\s+(Instructions|Extractors)\s*$/.test(line)) {
+  for (const { raw, inFence, isFenceMarker } of iterateAllMarkdownLines(instructions)) {
+    if (isFenceMarker || inFence) continue;
+    if (/^#\s+(Instructions|Extractors)\s*$/.test(raw)) {
       return true;
     }
   }


### PR DESCRIPTION
全 5 issue (159-163) 完了後の総合レビューで指摘した 2 つの正しさ上の負債 + 関連リファクタ。

## Summary

### 1. Registry: catch-all + specific path の activation 誤判定 (#162 レビュー)
\`findMatchingSkills\` は \`paths.some(isSpecific)\` で activation を決めていたため、catch-all と specific pattern が混在する skill で **実際にマッチした pattern が catch-all だけの URL でも contextual に昇格**していた。URL ごとにマッチした pattern だけを対象に判定するよう修正。
- \`paths: ["/**", "/*/*/tree/**"]\` な skill が \`/issues/123\` にマッチ → \`/**\` だけマッチ → passive ✓
- 同 skill が \`/owner/repo/tree/main\` にマッチ → 両方マッチ → specific ありなので contextual ✓

### 2. Prompt: \`stripExtractorSections\` の fence 無対応 (全体レビュー)
top-level Guidance から \`## Extractor: <id>\` セクションを除去するヘルパが fence tracking を持たず、**instruction 本文内の fenced code block に \`## Extractor:\` 行が書かれているだけで、fence 以降の本文が section 扱いで削除**されていた。fence-aware にして fenced content は素通しするよう修正。

### 3. リファクタ: fence tracking の 5 箇所重複を解消
parser / validator / prompt (body 走査, extractor strip, extractor caution) の 5 箇所が独立に fence tracking を書いていた。\`src/shared/markdown-section.ts\` に集約:
- \`iterateMarkdownBody(md)\`: fence skip + 見出しフラグ付きの body iterator
- \`iterateAllMarkdownLines(md)\`: fence 状態付きで全行を保持 (書き換える caller 用)
- \`isFenceMarkerLine(line)\`

\`stripExtractorSections\` もこれに乗り換え、副次的に #2 の fence バグが解消。

## Test plan
- [x] \`npx vitest run\` 全 1157 テスト green (+8)
- [x] \`npx vp check\` (format + lint) 変更ファイル通過
- [x] \`npx vp lint\` リポジトリ全体 0 warnings / 0 errors
- [x] Registry 回帰テスト追加 (catch-all のみマッチで passive)
- [x] Prompt 回帰テスト追加 (fenced \`## Extractor:\` で周辺本文が残る)
- [x] \`markdown-section.test.ts\` 新規 (fence 判定・body iteration・heading フラグ・全行 iteration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)