### PR TITLE
fix(skill): teach per-turn skill detection message about instruction layer

### DIFF
--- a/src/features/ai/system-prompt-v2.ts
+++ b/src/features/ai/system-prompt-v2.ts
@@ -1,4 +1,8 @@
-import { iterateAllMarkdownLines, iterateMarkdownBody } from "@/shared/markdown-section";
+import {
+  contextualInstructionParagraph,
+  extractExtractorCautions,
+  summarizeInstructions,
+} from "@/shared/skill-instructions";
 import type { SkillMatch } from "@/shared/skill-types";
 import {
   CORE_IDENTITY,
@@ -38,158 +42,11 @@ function formatWindowSkillCall(skillId: string, extractorId: string): string {
   return `window${formatPropertyAccess(skillId)}${formatPropertyAccess(extractorId)}()`;
 }
 
-const INSTRUCTION_SUMMARY_MAX_LEN = 120;
-const CONTEXTUAL_PARAGRAPH_MAX_LINES = 4;
-
 function isPromptVisibleSkill(match: SkillMatch): boolean {
   if (match.availableExtractors.length > 0) return true;
   // instructions があっても summarize 可能な本文が無ければ prompt には出さない。
   // 例: 見出しだけ / コードフェンスだけの instructions は AI にとってノイズにしかならない。
   return summarizeInstructions(match.skill.instructionsMarkdown) !== null;
-}
-
-/**
- * 本文行を行配列として返す。見出し / コードフェンス内はスキップ。
- * 空行は paragraph 区切りとして空文字で保持する。
- */
-function collectBodyLines(instructionsMarkdown: string): string[] {
-  const out: string[] = [];
-  for (const line of iterateMarkdownBody(instructionsMarkdown)) {
-    if (line.isBlank) {
-      out.push("");
-      continue;
-    }
-    if (line.isHeading) continue;
-    const cleaned = line.trimmed.replace(/^[-*+]\s+/, "").trim();
-    if (cleaned.length === 0) continue;
-    out.push(cleaned);
-  }
-  return out;
-}
-
-function clampSummaryLength(line: string): string {
-  if (line.length <= INSTRUCTION_SUMMARY_MAX_LEN) return line;
-  return `${line.slice(0, INSTRUCTION_SUMMARY_MAX_LEN - 1)}…`;
-}
-
-/**
- * instructionsMarkdown の先頭本文から 1 行のサマリを作る (passive activation)。
- * 見出し / 空行 / リスト記号 / コードフェンス内は除去し、
- * INSTRUCTION_SUMMARY_MAX_LEN で打ち切る。
- * extractor 専用 caution は extractor bullet 側で扱うので summary には含めない。
- */
-function summarizeInstructions(instructionsMarkdown: string | undefined): string | null {
-  if (!instructionsMarkdown) return null;
-  const topLevel = stripExtractorSections(instructionsMarkdown);
-  for (const line of collectBodyLines(topLevel)) {
-    if (line === "") continue;
-    return clampSummaryLength(line);
-  }
-  return null;
-}
-
-/**
- * extractor-scoped section (`## Extractor: <id>`) を markdown から除去する。
- * 次の `##` 見出しが来るまで、あるいは最後まで読み飛ばす。
- * contextual 要約が extractor 専用 caution を取り込まないようにするため。
- *
- * fence 内部の `## Extractor:` は section marker ではなくコード中のテキストなので
- * 除去対象から外す (例: instruction でスキル書式の例を示しているケース)。
- */
-function stripExtractorSections(instructionsMarkdown: string): string {
-  const out: string[] = [];
-  let inExtractorBlock = false;
-  for (const { raw, trimmed, inFence, isFenceMarker } of iterateAllMarkdownLines(
-    instructionsMarkdown,
-  )) {
-    // fence marker / 内部は常に保持し、section 判定には使わない。
-    if (isFenceMarker || inFence) {
-      inExtractorBlock = false;
-      out.push(raw);
-      continue;
-    }
-    const isExtractorHeading = /^##\s+Extractor:\s+.+$/.test(trimmed);
-    const isOtherHeading = !isExtractorHeading && /^##\s+/.test(trimmed);
-    if (isExtractorHeading) {
-      inExtractorBlock = true;
-      continue;
-    }
-    if (isOtherHeading) {
-      inExtractorBlock = false;
-    }
-    if (inExtractorBlock) continue;
-    out.push(raw);
-  }
-  return out.join("\n");
-}
-
-/**
- * contextual activation 用に先頭パラグラフ (連続本文行の塊) を返す。
- * 最大 CONTEXTUAL_PARAGRAPH_MAX_LINES 行まで。全文注入は避ける。
- * extractor 専用 caution は extractor bullet 側で扱うのでここには含めない。
- */
-function contextualInstructionParagraph(instructionsMarkdown: string): string[] {
-  const topLevel = stripExtractorSections(instructionsMarkdown);
-  const collected: string[] = [];
-  let started = false;
-  for (const line of collectBodyLines(topLevel)) {
-    if (line === "") {
-      if (started) break;
-      continue;
-    }
-    started = true;
-    collected.push(clampSummaryLength(line));
-    if (collected.length >= CONTEXTUAL_PARAGRAPH_MAX_LINES) break;
-  }
-  return collected;
-}
-
-/**
- * `## Extractor: <id>` ブロック直下の本文を extractor ごとに抽出する。
- * extractor ID をキーに、本文の 1 行目 (passive summary と同じ切り詰め) を値として返す。
- * 他のセクションがあるまで本文を読む。全文注入はしない (1 行に要約)。
- */
-function extractExtractorCautions(instructionsMarkdown: string | undefined): Map<string, string> {
-  const result = new Map<string, string>();
-  if (!instructionsMarkdown) return result;
-
-  let currentId: string | null = null;
-  let currentBody: string[] = [];
-
-  const finalize = () => {
-    if (!currentId) return;
-    for (const body of currentBody) {
-      if (body === "") continue;
-      result.set(currentId, clampSummaryLength(body));
-      break;
-    }
-    currentId = null;
-    currentBody = [];
-  };
-
-  for (const line of iterateMarkdownBody(instructionsMarkdown)) {
-    const extractorMatch = /^##\s+Extractor:\s*(.+?)\s*$/.exec(line.trimmed);
-    if (extractorMatch) {
-      finalize();
-      currentId = extractorMatch[1];
-      continue;
-    }
-    if (line.isHeading) {
-      // Any other heading terminates the current extractor block.
-      finalize();
-      continue;
-    }
-
-    if (currentId === null) continue;
-    if (line.isBlank) {
-      if (currentBody.length > 0) currentBody.push("");
-      continue;
-    }
-    const cleaned = line.trimmed.replace(/^[-*+]\s+/, "").trim();
-    if (cleaned.length > 0) currentBody.push(cleaned);
-  }
-  finalize();
-  return result;
 }
 
 function generateSkillsSection(

--- a/src/orchestration/__tests__/skill-detector.test.ts
+++ b/src/orchestration/__tests__/skill-detector.test.ts
@@ -3,6 +3,14 @@ import { describe, expect, it } from "vitest";
 import { buildSkillDetectionMessage } from "../skill-detector";
 import type { SkillMatch } from "@/features/tools/skills";
 
+function getText(message: ReturnType<typeof buildSkillDetectionMessage>): string {
+  expect(message).not.toBeNull();
+  const part = message?.content[0];
+  expect(part?.type).toBe("text");
+  if (part?.type !== "text") throw new Error("unreachable");
+  return part.text;
+}
+
 describe("buildSkillDetectionMessage", () => {
   it("guides the model to call runtime-injected skill extractors", () => {
     const matches: SkillMatch[] = [
@@ -37,14 +45,164 @@ describe("buildSkillDetectionMessage", () => {
     ];
 
     const message = buildSkillDetectionMessage(matches);
+    const text = getText(message);
 
-    expect(message).not.toBeNull();
-    const text = message?.content[0];
-    expect(text?.type).toBe("text");
-    if (text?.type !== "text") return;
+    expect(text).not.toContain("browserjs(new Function(code))");
+    expect(text).not.toContain("new Function(`return (${code})`)()");
+    expect(text).toContain("window.youtube.getVideoInfo()");
+  });
 
-    expect(text.text).not.toContain("browserjs(new Function(code))");
-    expect(text.text).not.toContain("new Function(`return (${code})`)()");
-    expect(text.text).toContain("window.youtube.getVideoInfo()");
+  it("surfaces a Guidance line and omits the browserjs() tail for an instruction-only skill", () => {
+    const instructionsOnlyMatch: SkillMatch = {
+      skill: {
+        id: "github-guidance",
+        name: "GitHub Guidance",
+        description: "GitHub 向け guidance",
+        matchers: { hosts: ["github.com"] },
+        version: "0.1.0",
+        extractors: [],
+        instructionsMarkdown: "GitHub では task に応じて API / bgFetch を優先すること。",
+      },
+      availableExtractors: [],
+      confidence: 85,
+    };
+
+    const message = buildSkillDetectionMessage([instructionsOnlyMatch]);
+    const text = getText(message);
+
+    expect(text).toContain('Skill "GitHub Guidance" (id: github-guidance, site-specific)');
+    expect(text).toContain("Guidance: GitHub では task に応じて API / bgFetch を優先すること。");
+    // instruction-only なので extractor bullet も browserjs() ヒントも不要。
+    expect(text).not.toMatch(/^ {2}- github-guidance\./m);
+    expect(text).not.toContain("browserjs(");
+    expect(text).not.toContain("window.youtube.getVideoInfo()");
+  });
+
+  it("includes both extractor bullets and a Guidance line for a mixed skill", () => {
+    const mixedMatch: SkillMatch = {
+      skill: {
+        id: "gh-repo",
+        name: "GitHub Repo",
+        description: "GitHub リポジトリ分析",
+        matchers: { hosts: ["github.com"], paths: ["/*/*/tree/**"] },
+        version: "0.2.0",
+        extractors: [
+          {
+            id: "getTitle",
+            name: "Get Title",
+            description: "ページタイトルを取得",
+            code: "function () { return document.title; }",
+            outputSchema: "string",
+          },
+        ],
+        instructionsMarkdown: "repo 全体の分析では API / bgFetch を優先すること。",
+      },
+      availableExtractors: [
+        {
+          id: "getTitle",
+          name: "Get Title",
+          description: "ページタイトルを取得",
+          code: "function () { return document.title; }",
+          outputSchema: "string",
+        },
+      ],
+      confidence: 100,
+      activationLevel: "contextual",
+    };
+
+    const message = buildSkillDetectionMessage([mixedMatch]);
+    const text = getText(message);
+
+    expect(text).toContain("  - gh-repo.getTitle: ページタイトルを取得");
+    expect(text).toContain("Guidance: repo 全体の分析では API / bgFetch を優先すること。");
+    // extractor があるので browserjs() ヒントは出す。
+    expect(text).toContain("browserjs(");
+  });
+
+  it("drops skills that have neither extractors nor summarizable instructions", () => {
+    const noExtractorsNoGuidance: SkillMatch = {
+      skill: {
+        id: "empty-skill",
+        name: "Empty Skill",
+        description: "nothing useful",
+        matchers: { hosts: ["example.com"] },
+        version: "0.1.0",
+        extractors: [],
+        instructionsMarkdown: "## heading only\n## another heading",
+      },
+      availableExtractors: [],
+      confidence: 80,
+    };
+
+    const message = buildSkillDetectionMessage([noExtractorsNoGuidance]);
+    expect(message).toBeNull();
+  });
+
+  it("returns null when the only matches are unsummarizable instruction-only skills", () => {
+    const headingsOnly: SkillMatch = {
+      skill: {
+        id: "headings-only",
+        name: "Headings Only",
+        description: "heading only",
+        matchers: { hosts: ["example.com"] },
+        version: "0.1.0",
+        extractors: [],
+        instructionsMarkdown: "## a\n## b\n## c",
+      },
+      availableExtractors: [],
+      confidence: 80,
+    };
+
+    expect(buildSkillDetectionMessage([headingsOnly])).toBeNull();
+  });
+
+  it("emits browserjs() tail only when at least one listed skill has extractors", () => {
+    const extractorMatch: SkillMatch = {
+      skill: {
+        id: "yt",
+        name: "YT",
+        description: "yt",
+        matchers: { hosts: ["youtube.com"] },
+        version: "1.0.0",
+        extractors: [
+          {
+            id: "get",
+            name: "Get",
+            description: "get",
+            code: "function () { return 1; }",
+            outputSchema: "number",
+          },
+        ],
+      },
+      availableExtractors: [
+        {
+          id: "get",
+          name: "Get",
+          description: "get",
+          code: "function () { return 1; }",
+          outputSchema: "number",
+        },
+      ],
+      confidence: 100,
+    };
+    const instructionsOnly: SkillMatch = {
+      skill: {
+        id: "guide",
+        name: "Guide",
+        description: "guide",
+        matchers: { hosts: ["example.com"] },
+        version: "0.1.0",
+        extractors: [],
+        instructionsMarkdown: "使い方の一行ガイダンス。",
+      },
+      availableExtractors: [],
+      confidence: 80,
+    };
+
+    const textMixed = getText(buildSkillDetectionMessage([instructionsOnly, extractorMatch]));
+    expect(textMixed).toContain("browserjs(");
+
+    const textInstructionOnly = getText(buildSkillDetectionMessage([instructionsOnly]));
+    expect(textInstructionOnly).not.toContain("browserjs(");
   });
 });

--- a/src/orchestration/skill-detector.ts
+++ b/src/orchestration/skill-detector.ts
@@ -1,28 +1,57 @@
 import type { SkillMatch } from "@/shared/skill-types";
 import type { AIMessage, UserMessage } from "@/ports/ai-provider";
+import { summarizeInstructions } from "@/shared/skill-instructions";
 
 export type SkillDetectionMessage = UserMessage;
 export const SKILL_DETECTION_PREFIX = "[System: Skills available now]";
 
+/**
+ * ターン直前に AI へ差し込む skill detection メッセージを作る。
+ * instruction-only / extractors-only / mixed の 3 形態を尊重するため、
+ * - extractor が無い skill は extractor bullet を出さず Guidance だけを出す
+ * - extractor も summarize 可能な instruction も無い skill は丸ごと除外する
+ * - すべての listed skill が extractor を持たないときは "browserjs() で呼べ" の
+ *   トレーリングヒントを省略する (instruction-only では misleading)
+ */
 export function buildSkillDetectionMessage(
   matches: readonly SkillMatch[],
 ): SkillDetectionMessage | null {
   if (matches.length === 0) return null;
 
-  const lines = matches.map((m) => {
-    const extractors = m.availableExtractors
-      .map((e) => `  - ${m.skill.id}.${e.id}: ${e.description}`)
-      .join("\n");
-    const scope = m.skill.scope === "global" ? "global (any page)" : "site-specific";
-    return `Skill "${m.skill.name}" (id: ${m.skill.id}, ${scope}):\n${extractors}`;
+  const visible = matches.filter((match) => {
+    if (match.availableExtractors.length > 0) return true;
+    return summarizeInstructions(match.skill.instructionsMarkdown) !== null;
   });
+
+  if (visible.length === 0) return null;
+
+  const lines = visible.map((m) => {
+    const scope = m.skill.scope === "global" ? "global (any page)" : "site-specific";
+    const parts: string[] = [`Skill "${m.skill.name}" (id: ${m.skill.id}, ${scope}):`];
+
+    for (const ext of m.availableExtractors) {
+      parts.push(`  - ${m.skill.id}.${ext.id}: ${ext.description}`);
+    }
+
+    const guidance = summarizeInstructions(m.skill.instructionsMarkdown);
+    if (guidance) {
+      parts.push(`  Guidance: ${guidance}`);
+    }
+
+    return parts.join("\n");
+  });
+
+  const hasAnyExtractor = visible.some((m) => m.availableExtractors.length > 0);
+  const callHint = hasAnyExtractor
+    ? "\n\nCall matching skill extractors directly inside `browserjs()` via the runtime-injected window object, for example: `browserjs(() => window.youtube.getVideoInfo())`."
+    : "";
 
   return {
     role: "user",
     content: [
       {
         type: "text",
-        text: `${SKILL_DETECTION_PREFIX}\n\n${lines.join("\n\n")}\n\nCall matching skill extractors directly inside \`browserjs()\` via the runtime-injected window object, for example: \`browserjs(() => window.youtube.getVideoInfo())\`.`,
+        text: `${SKILL_DETECTION_PREFIX}\n\n${lines.join("\n\n")}${callHint}`,
       },
     ],
   };

--- a/src/shared/skill-instructions.ts
+++ b/src/shared/skill-instructions.ts
@@ -1,0 +1,155 @@
+/**
+ * Skill の `instructionsMarkdown` から prompt / user-message に出す要約や
+ * extractor-scoped caution を取り出すためのユーティリティ群。
+ *
+ * ここの関数はすべて純粋関数で runtime には副作用を持たない。
+ * system prompt 側と orchestration 側 (skill-detector) で同じロジックを
+ * 共有するため shared に置く。
+ */
+
+import { iterateAllMarkdownLines, iterateMarkdownBody } from "./markdown-section";
+
+export const INSTRUCTION_SUMMARY_MAX_LEN = 120;
+export const CONTEXTUAL_PARAGRAPH_MAX_LINES = 4;
+
+/**
+ * 本文行を行配列として返す。見出し / コードフェンス内はスキップ。
+ * 空行は paragraph 区切りとして空文字で保持する。
+ */
+function collectBodyLines(instructionsMarkdown: string): string[] {
+  const out: string[] = [];
+  for (const line of iterateMarkdownBody(instructionsMarkdown)) {
+    if (line.isBlank) {
+      out.push("");
+      continue;
+    }
+    if (line.isHeading) continue;
+    const cleaned = line.trimmed.replace(/^[-*+]\s+/, "").trim();
+    if (cleaned.length === 0) continue;
+    out.push(cleaned);
+  }
+  return out;
+}
+
+export function clampSummaryLength(line: string): string {
+  if (line.length <= INSTRUCTION_SUMMARY_MAX_LEN) return line;
+  return `${line.slice(0, INSTRUCTION_SUMMARY_MAX_LEN - 1)}…`;
+}
+
+/**
+ * extractor-scoped section (`## Extractor: <id>`) を markdown から除去する。
+ * 次の `##` 見出しが来るまで、あるいは最後まで読み飛ばす。
+ * 上位の passive / contextual summary が extractor 専用 caution を取り込まない
+ * ようにするため。fence 内部は section marker とみなさない。
+ */
+export function stripExtractorSections(instructionsMarkdown: string): string {
+  const out: string[] = [];
+  let inExtractorBlock = false;
+  for (const { raw, trimmed, inFence, isFenceMarker } of iterateAllMarkdownLines(
+    instructionsMarkdown,
+  )) {
+    if (isFenceMarker || inFence) {
+      inExtractorBlock = false;
+      out.push(raw);
+      continue;
+    }
+    const isExtractorHeading = /^##\s+Extractor:\s+.+$/.test(trimmed);
+    const isOtherHeading = !isExtractorHeading && /^##\s+/.test(trimmed);
+    if (isExtractorHeading) {
+      inExtractorBlock = true;
+      continue;
+    }
+    if (isOtherHeading) {
+      inExtractorBlock = false;
+    }
+    if (inExtractorBlock) continue;
+    out.push(raw);
+  }
+  return out.join("\n");
+}
+
+/**
+ * instructionsMarkdown の先頭本文から 1 行のサマリを作る (passive activation)。
+ * 見出し / 空行 / リスト記号 / コードフェンス内は除去し、
+ * INSTRUCTION_SUMMARY_MAX_LEN で打ち切る。
+ * extractor 専用 caution は extractor bullet 側で扱うので summary には含めない。
+ */
+export function summarizeInstructions(instructionsMarkdown: string | undefined): string | null {
+  if (!instructionsMarkdown) return null;
+  const topLevel = stripExtractorSections(instructionsMarkdown);
+  for (const line of collectBodyLines(topLevel)) {
+    if (line === "") continue;
+    return clampSummaryLength(line);
+  }
+  return null;
+}
+
+/**
+ * contextual activation 用に先頭パラグラフ (連続本文行の塊) を返す。
+ * 最大 CONTEXTUAL_PARAGRAPH_MAX_LINES 行まで。全文注入は避ける。
+ * extractor 専用 caution は extractor bullet 側で扱うのでここには含めない。
+ */
+export function contextualInstructionParagraph(instructionsMarkdown: string): string[] {
+  const topLevel = stripExtractorSections(instructionsMarkdown);
+  const collected: string[] = [];
+  let started = false;
+  for (const line of collectBodyLines(topLevel)) {
+    if (line === "") {
+      if (started) break;
+      continue;
+    }
+    started = true;
+    collected.push(clampSummaryLength(line));
+    if (collected.length >= CONTEXTUAL_PARAGRAPH_MAX_LINES) break;
+  }
+  return collected;
+}
+
+/**
+ * `## Extractor: <id>` ブロック直下の本文を extractor ごとに抽出する。
+ * extractor ID をキーに、本文の 1 行目 (passive summary と同じ切り詰め) を値として返す。
+ * 他のセクションがあるまで本文を読む。全文注入はしない (1 行に要約)。
+ */
+export function extractExtractorCautions(
+  instructionsMarkdown: string | undefined,
+): Map<string, string> {
+  const result = new Map<string, string>();
+  if (!instructionsMarkdown) return result;
+
+  let currentId: string | null = null;
+  let currentBody: string[] = [];
+
+  const finalize = () => {
+    if (!currentId) return;
+    for (const body of currentBody) {
+      if (body === "") continue;
+      result.set(currentId, clampSummaryLength(body));
+      break;
+    }
+    currentId = null;
+    currentBody = [];
+  };
+
+  for (const line of iterateMarkdownBody(instructionsMarkdown)) {
+    const extractorMatch = /^##\s+Extractor:\s*(.+?)\s*$/.exec(line.trimmed);
+    if (extractorMatch) {
+      finalize();
+      currentId = extractorMatch[1];
+      continue;
+    }
+    if (line.isHeading) {
+      finalize();
+      continue;
+    }
+
+    if (currentId === null) continue;
+    if (line.isBlank) {
+      if (currentBody.length > 0) currentBody.push("");
+      continue;
+    }
+    const cleaned = line.trimmed.replace(/^[-*+]\s+/, "").trim();
+    if (cleaned.length > 0) currentBody.push(cleaned);
+  }
+  finalize();
+  return result;
+}


### PR DESCRIPTION
## 報告された症状
AI 側から「instruction-only スキル (github-guidance) が読み込まれていない」「\`window[\"github-guidance\"]\` 経由で呼べる関数が無いので手動でガイダンスを適用した」というレポート。

## 原因
Registry は skill を正しくロードしており、system prompt の Skills section (#168) も Guidance を出せていた。**問題は毎ターン前に差し込まれる \`[System: Skills available now]\` user message** (\`buildSkillDetectionMessage\`) 側。ここが Issue #168 の instruction layer 対応から取り残されていて、instruction-only skill に対して:

\`\`\`
Skill "GitHub Guidance" (id: github-guidance, site-specific):

Call matching skill extractors directly inside \`browserjs()\` via the runtime-injected window object ...
\`\`\`

と出力していた。extractor bullet は空、instructionsMarkdown は一切含まれず、末尾の "browserjs() で呼べ" が misleading。AI が「extractor 無しのスキル」と判定してガイダンスを失うのは自然な結果。

## 修正
- \`buildSkillDetectionMessage\`:
  - extractor も summary 可能な instruction も無い skill はメッセージから除外
  - \`instructionsMarkdown\` に summary があれば \`Guidance: <summary>\` 行を追加 (passive 相当、120 文字キャップ)
  - listed skill に extractor が 1 つも無ければ末尾の browserjs() ヒントを出さない

## リファクタ
summarize 系の helper (\`summarizeInstructions\` / \`contextualInstructionParagraph\` / \`extractExtractorCautions\` / \`stripExtractorSections\` 等) を \`src/features/ai/system-prompt-v2.ts\` から \`src/shared/skill-instructions.ts\` に移動。system prompt (features 層) と skill-detector (orchestration 層) が同じ shared helper を使う構造に。system-prompt-v2 の振る舞いは不変 (import 経由に差し替えただけ)。

## Test plan
- [x] \`npx vitest run\` 全 1162 テスト green (+5)
- [x] \`npx vp check\` (format + lint) 変更ファイル通過
- [x] \`npx vp lint\` リポジトリ全体 0 warnings / 0 errors
- [x] skill-detector テスト追加: instruction-only / mixed / headings-only dropped / browserjs-tail toggle
- [x] 既存 youtube extractor-only テストは互換維持

🤖 Generated with [Claude Code](https://claude.com/claude-code)