### PR TITLE
chore(release): v0.1.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sitesurf",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "AIと一緒にWebページを操作するChrome拡張機能",
   "license": "MIT",
   "type": "module",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "SiteSurf",
   "description": "AIと一緒にWebページを操作するChrome拡張",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "action": {
     "default_title": "SiteSurfを開く",
     "default_icon": {


### PR DESCRIPTION
v0.1.7 → v0.1.8 のリリース版上げ。

## ハイライト: Skill Instruction Layer

通常の agent skill のような **AI 向けガイダンス** を Skill に持たせられるようにした。`instructions-only` / `extractors-only` / `instructions + extractors` の 3 形態を許容する。

### 新機能
- **instruction-only skill**: extractor が無くても guidance だけで成立する skill を登録可能 (例: `public/skills/github-guidance.md`)
- **activation 分離**: `SkillMatch` が passive / contextual の activation level を持ち、host-only match は passive、specific path match は contextual に昇格。catch-all (\`/\`, \`/**\` 等) は passive に降格
- **extractor-scoped caution**: `## Extractor: <id>` ブロックを parse し、該当 extractor bullet の下に `Caution:` 行を付加
- **role-based prompt セクション**: `# Skills: Extractors` (callable) と `# Skills: Guidance` (instruction-only) に分割。AI に skill を「呼ぶもの」と「守るもの」として区別させる
- **`Apply:` ラベル**: 旧 `Guidance:` / `Guidance (contextual):` を action verb `Apply:` に統一
- **skill tool の拡張**: `create_draft` / `update_draft` に `instructionsMarkdown` を受け渡し可能。`buildSuggestedFixes` が新しいエラー/警告に対応
- **bgFetch() warning**: extractor code 内の `bgFetch(` を quality warning として検出 (page context からは呼び出せないため)

### 設計ドキュメント / ADR
- `docs/design/skill-instructions-layer.md` (設計書)
- `docs/decisions/008-skill-instruction-layer.md` (ADR)
- `docs/design/system-prompt.md` / `skill-system.md` 更新

### 関連 PR
- **Skill instruction layer (コア機能)**: #164 (docs), #165 (parser), #166 / #167 (validation + recovery), #168 / #169 (prompt summary + fence/visibility fix), #170 / #171 (activation + cautions), #172 (editor + built-in + docs), #173 (path bug fix + fence consolidation), #174 (ADR 008), #178 (per-turn detection), #179 (Apply label + role split)
- **その他**: #157 (Kimi K2.6 models), #158 (chat streaming memoization)

### フォローアップ予定 (v0.1.8 後の future work)
- #175: DOM-based contextual activation
- #176: active-level activation via intentHints
- #177: structured `instructionBlocks` migration

## Test plan
- [x] package.json / public/manifest.json の version 更新
- [x] 全テスト pass (1164/1164)
- [x] vp lint 0 warnings / 0 errors
- [x] 本ブランチ merge 後、`v0.1.8` タグを push → release.yml が dist.zip 付きで GitHub Release を自動作成

🤖 Generated with [Claude Code](https://claude.com/claude-code)