### PR TITLE
chore(models): regenerate models list (add gpt-5.5, kimi-k2.6)

### DIFF
--- a/src/shared/models.generated.ts
+++ b/src/shared/models.generated.ts
@@ -258,6 +258,11 @@ export const GENERATED_MODELS: Record<string, ProviderModels> = {
         "reasoning": true
       },
       {
+        "id": "gpt-5.5",
+        "name": "GPT-5.5",
+        "reasoning": true
+      },
+      {
         "id": "o1",
         "name": "o1",
         "reasoning": true
@@ -525,6 +530,11 @@ export const GENERATED_MODELS: Record<string, ProviderModels> = {
       {
         "id": "kimi-k2.5",
         "name": "Kimi K2.5",
+        "reasoning": true
+      },
+      {
+        "id": "kimi-k2.6",
+        "name": "Kimi K2.6",
         "reasoning": true
       }
     ]


### PR DESCRIPTION
## Summary
- `npm run generate-models` で `models.dev/api.json` から再生成
- OpenAI `gpt-5.5` と Kimi `kimi-k2.6` が追加された (共に reasoning 対応)
- `src/shared/models.generated.ts` のみ変更。`constants.ts` は `GENERATED_MODELS` を参照するので手動編集不要

## Test plan
- [ ] サイドパネルの設定でプロバイダー選択時に `gpt-5.5` / `kimi-k2.6` が表示されることを確認
- [ ] 既存のデフォルトモデル (`gpt-5.4` 等) で動作リグレッションがないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)