### PR TITLE
fix(constants): restrict openai-codex models to Codex API allowlist

### DIFF
--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -59,7 +59,12 @@ export const PROVIDERS: Record<ProviderId, ProviderInfo> = {
     id: "openai-codex",
     name: "OpenAI (ChatGPT/Codex)",
     defaultModel: defaultFor("openai", "gpt-5.4"),
-    models: modelsFor("openai"),
+    // Codex API は openai 全モデルを受け付けない。pi-mono 参考の許可パターン:
+    // codex variants と gpt-5.x (および gpt-5.x-mini) のみ。
+    // o-series / gpt-4 / -chat-latest / -pro / -nano / 無印 gpt-5 は弾く。
+    models: modelsFor("openai").filter(
+      (id) => id.includes("codex") || /^gpt-5\.\d+(-mini)?$/.test(id),
+    ),
     authType: "oauth",
   },
   google: {


### PR DESCRIPTION
## Problem
PR #182 で `openai-codex` のモデル一覧を `modelsFor("openai")` に共通化したが、Codex API は openai 全モデルを受け付けず以下のエラーになる:

```json
{"detail":"The 'o4-mini' model is not supported when using Codex with a ChatGPT account."}
```

## Fix
旧 `CODEX_MODELS` (pi-mono 参考) の許可セットを **正規表現フィルタ** で復活:

```ts
models: modelsFor("openai").filter(
  (id) => id.includes("codex") || /^gpt-5\.\d+(-mini)?$/.test(id),
),
```

- codex variants: 全部許可
- `gpt-5.x` major / `gpt-5.x-mini`: 許可 (`gpt-5.5` も自動で通る)
- 除外: o-series, gpt-4, `-chat-latest`, `-pro`, `-nano`, 無印 `gpt-5`

## Result (12 models)
`gpt-5-codex`, `gpt-5.1`, `gpt-5.1-codex`, `gpt-5.1-codex-max`, `gpt-5.1-codex-mini`, `gpt-5.2`, `gpt-5.2-codex`, `gpt-5.3-codex`, `gpt-5.3-codex-spark`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.5`

旧 pi-mono リスト (10) + `gpt-5-codex` + `gpt-5.5`。今後 models.dev に `gpt-5.6` 等が来れば自動で含まれる。

## Test plan
- [x] 1164/1164 tests pass
- [x] vp check pass
- [ ] サイドパネル: openai-codex プロバイダーで `o4-mini` がモデル一覧から消えていることを確認
- [ ] サイドパネル: `gpt-5.5` を選択して実際にメッセージが流れることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)