### PR TITLE
chore(release): v0.1.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sitesurf",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "AIと一緒にWebページを操作するChrome拡張機能",
   "license": "MIT",
   "type": "module",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "SiteSurf",
   "description": "AIと一緒にWebページを操作するChrome拡張",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "action": {
     "default_title": "SiteSurfを開く",
     "default_icon": {


### PR DESCRIPTION
v0.1.8 → v0.1.9 のリリース版上げ。

## ハイライト: モデル一覧の刷新と Codex 経由の対応モデル拡張

### 新モデル
- **OpenAI**: `gpt-5.5` を追加 (#181)
- **Kimi**: `kimi-k2.6` を追加 (#181)

### Codex (ChatGPT 経由) の刷新
opencode と同じ思想で、`openai-codex` プロバイダーのモデル一覧を models.dev の openai リストと共通化 (#182)。codex variants (`gpt-5-codex`, `gpt-5.1-codex`, `gpt-5.1-codex-max`, `gpt-5.1-codex-mini`, `gpt-5.2-codex`, `gpt-5.3-codex`, `gpt-5.3-codex-spark`) も自動で含まれるようになった。

ただし Codex API は openai 全モデルを受け付けないため、pi-mono 参考の正規表現で許可リストを構築 (#183):
- 許可: codex variants 全部 + `gpt-5.x` (major) + `gpt-5.x-mini`
- 除外: o-series / gpt-4 系 / `-chat-latest` / `-pro` / `-nano` / 無印 `gpt-5`

結果、Codex で選べるモデルは以下12個 (`gpt-5.5` 含む):
`gpt-5-codex`, `gpt-5.1`, `gpt-5.1-codex`, `gpt-5.1-codex-max`, `gpt-5.1-codex-mini`, `gpt-5.2`, `gpt-5.2-codex`, `gpt-5.3-codex`, `gpt-5.3-codex-spark`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.5`

### スクリプト改善
- `npm run generate-models` の出力後に `vp fmt --write` を実行するように変更し、再生成だけで `vp check` が通る状態に (#182)

## Changes
- #181 chore(models): regenerate models list (add gpt-5.5, kimi-k2.6)
- #182 refactor(constants): share openai model list with openai-codex (opencode-style)
- #183 fix(constants): restrict openai-codex models to Codex API allowlist

🤖 Generated with [Claude Code](https://claude.com/claude-code)